### PR TITLE
Fix mem leak in loading nym

### DIFF
--- a/include/opentxs/client/OTWallet.hpp
+++ b/include/opentxs/client/OTWallet.hpp
@@ -211,6 +211,8 @@ public:
     EXPORT void DisplayStatistics(String& strOutput);
 
     EXPORT Nym* GetNymByID(const Identifier& NYM_ID);
+    EXPORT Nym* GetPrivateNymByID(const Identifier& NYM_ID);
+    EXPORT Nym* GetPublicNymByID(const Identifier& NYM_ID);
     EXPORT Nym* GetNymByIDPartialMatch(std::string PARTIAL_ID); // wallet name
                                                                 // for nym also
                                                                 // accepted.
@@ -220,6 +222,8 @@ public:
     EXPORT OTServerContract* GetServerContractPartialMatch(
         std::string PARTIAL_ID); // wallet name for server also accepted.
 
+    EXPORT void AddPrivateNym(const Nym& theNym);
+    EXPORT void AddPublicNym(const Nym& theNym);
     EXPORT void AddNym(const Nym& theNym);
     EXPORT void AddAccount(const Account& theAcct);
 
@@ -305,13 +309,17 @@ public:
     // in addition to removing from wallet. (To delete them on server side.)
     //
     EXPORT bool RemoveAccount(const Identifier& theTargetID);
-    EXPORT bool RemoveNym(const Identifier& theTargetID);
+    EXPORT bool RemovePrivateNym(const Identifier& theTargetID);
+    EXPORT bool RemovePublicNym(const Identifier& theTargetID);
 
 private:
+    void AddNym(const Nym& theNym, mapOfNyms& map);
+    bool RemoveNym(const Identifier& theTargetID, mapOfNyms& map);
     void Release();
 
 private:
-    mapOfNyms m_mapNyms;
+    mapOfNyms m_mapPrivateNyms;
+    mapOfNyms m_mapPublicNyms;
     mapOfContracts m_mapContracts;
     mapOfServers m_mapServers;
     mapOfAccounts m_mapAccounts;

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -550,8 +550,8 @@ public:
         const String* pstrName = nullptr, const char* szFuncName = nullptr,
         const OTPasswordData* pPWData = nullptr,
         const OTPassword* pImportPassword = nullptr);
-    EXPORT bool HasPublicKey();
-    EXPORT bool HasPrivateKey();
+    EXPORT bool HasPublicKey() const;
+    EXPORT bool HasPrivateKey() const;
     EXPORT const OTAsymmetricKey& GetPublicAuthKey() const; // Authentication
     const OTAsymmetricKey& GetPrivateAuthKey() const;
     EXPORT const OTAsymmetricKey& GetPublicEncrKey() const; // Encryption

--- a/include/opentxs/core/crypto/OTKeypair.hpp
+++ b/include/opentxs/core/crypto/OTKeypair.hpp
@@ -201,8 +201,8 @@ public:
     EXPORT bool ReEncrypt(const OTPassword& theExportPassword, bool bImporting,
                           String& strOutput); // Used when importing/exporting
                                               // a Nym to/from the wallet.
-    EXPORT bool HasPublicKey();
-    EXPORT bool HasPrivateKey();
+    EXPORT bool HasPublicKey() const;
+    EXPORT bool HasPrivateKey() const;
     EXPORT const OTAsymmetricKey& GetPublicKey() const;
     EXPORT const OTAsymmetricKey& GetPrivateKey() const;
     EXPORT bool CalculateID(Identifier& theOutput) const;

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -1882,7 +1882,7 @@ bool OTAPI_Exec::Wallet_RemoveNym(const std::string& NYM_ID) const
 
     Identifier theID(NYM_ID);
 
-    if (pWallet->RemoveNym(theID)) {
+    if (pWallet->RemovePrivateNym(theID)) {
         otOut << __FUNCTION__ << ": Success erasing Nym from wallet: " << NYM_ID
               << "\n";
         pWallet->SaveWallet();

--- a/src/client/OpenTransactions.cpp
+++ b/src/client/OpenTransactions.cpp
@@ -2265,7 +2265,7 @@ bool OT_API::Wallet_RemoveNym(const Identifier& NYM_ID) const
         OT_FAIL;
     }
 
-    if (m_pWallet->RemoveNym(NYM_ID)) {
+    if (m_pWallet->RemovePrivateNym(NYM_ID)) {
         otOut << __FUNCTION__
               << ": Success erasing Nym from wallet: " << String(NYM_ID)
               << "\n";

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -5924,14 +5924,14 @@ bool Nym::DoesCertfileExist(const String& strNymID)
                         strCredListFile.Get()); // New-school.
 }
 
-bool Nym::HasPublicKey()
+bool Nym::HasPublicKey() const
 {
     OT_ASSERT(nullptr != m_pkeypair);
 
     return m_pkeypair->HasPublicKey();
 }
 
-bool Nym::HasPrivateKey()
+bool Nym::HasPrivateKey() const
 {
     OT_ASSERT(nullptr != m_pkeypair);
 

--- a/src/core/crypto/OTKeypair.cpp
+++ b/src/core/crypto/OTKeypair.cpp
@@ -210,7 +210,7 @@ void OTKeypair::SetMetadata(const OTSignatureMetadata& theMetadata)
     *(m_pkeyPrivate->m_pMetadata) = theMetadata;
 }
 
-bool OTKeypair::HasPublicKey()
+bool OTKeypair::HasPublicKey() const
 {
     OT_ASSERT(nullptr != m_pkeyPublic);
 
@@ -218,7 +218,7 @@ bool OTKeypair::HasPublicKey()
                                      // in it, or tried to.
 }
 
-bool OTKeypair::HasPrivateKey()
+bool OTKeypair::HasPrivateKey() const
 {
     OT_ASSERT(nullptr != m_pkeyPrivate);
 


### PR DESCRIPTION
GetOrLoadNym returns pointer to Nym but caller should not delete the object. The owner is OTWallet. When loading public nyms the Nym object was not stored and caller did not delete it so the public nym leaked. Now OTWallet has two lists, one with private nyms (that is also stored) and one with with public nym.