### PR TITLE
client/server: forward declare zsock_t 

### DIFF
--- a/include/opentxs/client/OTServerConnection.hpp
+++ b/include/opentxs/client/OTServerConnection.hpp
@@ -133,9 +133,11 @@
 #ifndef OPENTXS_CLIENT_OTSERVERCONNECTION_HPP
 #define OPENTXS_CLIENT_OTSERVERCONNECTION_HPP
 
-#include <czmq.h>
 #include <memory>
 #include <string>
+
+// forward declare zsock_t
+typedef struct _zsock_t zsock_t;
 
 namespace opentxs
 {

--- a/include/opentxs/server/MessageProcessor.hpp
+++ b/include/opentxs/server/MessageProcessor.hpp
@@ -133,9 +133,11 @@
 #ifndef OPENTXS_SERVER_MESSAGEPROCESSOR_HPP
 #define OPENTXS_SERVER_MESSAGEPROCESSOR_HPP
 
-#include <czmq.h>
 #include <string>
 #include <memory>
+
+// forward declare zsock_t
+typedef struct _zsock_t zsock_t;
 
 namespace opentxs
 {

--- a/src/client/OTClient.cpp
+++ b/src/client/OTClient.cpp
@@ -129,8 +129,6 @@
  =uSzz
  -----END PGP SIGNATURE-----
  **************************************************************/
-#include <cinttypes>
-
 #include <opentxs/core/stdafx.hpp>
 
 #include <opentxs/client/OTClient.hpp>
@@ -165,6 +163,7 @@
 
 #include <memory>
 #include <cstdio>
+#include <cinttypes>
 
 namespace opentxs
 {

--- a/src/client/OTServerConnection.cpp
+++ b/src/client/OTServerConnection.cpp
@@ -140,6 +140,8 @@
 #include <opentxs/core/Nym.hpp>
 #include <opentxs/core/OTServerContract.hpp>
 
+#include <czmq.h>
+
 namespace opentxs
 {
 

--- a/src/server/MessageProcessor.cpp
+++ b/src/server/MessageProcessor.cpp
@@ -143,6 +143,8 @@
 #include <opentxs/core/crypto/OTEnvelope.hpp>
 #include <opentxs/core/util/Timer.hpp>
 
+#include <czmq.h>
+
 namespace opentxs
 {
 


### PR DESCRIPTION
This way we can encapsulate czmq.h inside the cpp file which minimizes
the conflict introduced by czmq.h including inttypes.h which prohibits
cinttypes from being properly included (PRIxYZ macros are not defined).