### PR TITLE
Make OTCallback methods pure virtual

### DIFF
--- a/include/opentxs/core/crypto/OTCallback.hpp
+++ b/include/opentxs/core/crypto/OTCallback.hpp
@@ -350,12 +350,12 @@ public:
 
     // Asks for password once. (For authentication when using nym.)
     EXPORT virtual void runOne(const char* szDisplay,
-                               OTPassword& theOutput) const;
+                               OTPassword& theOutput) const = 0;
 
     // Asks for password twice. (For confirmation when changing password or
     // creating nym.)
     EXPORT virtual void runTwo(const char* szDisplay,
-                               OTPassword& theOutput) const;
+                               OTPassword& theOutput) const = 0;
 };
 
 } // namespace opentxs

--- a/src/core/crypto/OTCallback.cpp
+++ b/src/core/crypto/OTCallback.cpp
@@ -145,23 +145,4 @@ OTCallback::~OTCallback()
     //    std::cout << "OTCallback::~OTCallback()" << std:: endl;
 }
 
-// Asks for password once. (For authentication when using nym.)
-//
-void OTCallback::runOne(const char*,
-                        OTPassword&) const // child class will override.
-{
-    OT_FAIL_MSG("OTCallback::runOne: ASSERT (The child class was supposed to "
-                "override this method.)\n");
-}
-
-// Asks for password twice. (For confirmation when changing password or creating
-// nym.)
-//
-void OTCallback::runTwo(const char*,
-                        OTPassword&) const // child class will override.
-{
-    OT_FAIL_MSG("OTCallback::runTwo: ASSERT (The child class was supposed to "
-                "override this method.)\n");
-}
-
 } // namespace opentxs


### PR DESCRIPTION
This prevent problems like yamamushi/Moneychanger#1 during linking