### PR TITLE
cmake: fix linking problem with cmake version <3.0

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -151,7 +151,8 @@ else()
   )
 endif()
 
-target_link_libraries(opentxs-client PUBLIC opentxs-ext opentxs-cash opentxs-basket opentxs-core PRIVATE czmq_local)
+target_link_libraries(opentxs-client LINK_PUBLIC opentxs-ext opentxs-cash opentxs-basket opentxs-core)
+target_link_libraries(opentxs-client LINK_PRIVATE czmq_local)
 set_lib_property(opentxs-client)
 
 if(WIN32)

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -42,9 +42,11 @@ else()
 endif()
 
 if(WIN32)
-  target_link_libraries(opentxs-server PUBLIC opentxs-ext opentxs-cash opentxs-basket opentxs-core irrxml PRIVATE czmq_local)
+  target_link_libraries(opentxs-server LINK_PUBLIC opentxs-ext opentxs-cash opentxs-basket opentxs-core irrxml)
+  target_link_libraries(opentxs-server LINK_PRIVATE czmq_local)
 else()
-  target_link_libraries(opentxs-server PUBLIC opentxs-ext opentxs-cash opentxs-basket opentxs-core PRIVATE czmq_local)
+  target_link_libraries(opentxs-server LINK_PUBLIC opentxs-ext opentxs-cash opentxs-basket opentxs-core)
+  target_link_libraries(opentxs-server LINK_PRIVATE czmq_local)
 endif()
 
 set_lib_property(opentxs-server)


### PR DESCRIPTION
Easy backwards compatibility cmake vs <3

http://www.cmake.org/cmake/help/v3.0/command/target_link_libraries.html

With using LINK_PUBLIC and LINK_PRIVATE instead of just PUBLIC/PRIVATE (like we already have it in the core lib) it will still work with cmake versions below 3.
And above 3 aswell.

In general I agree to have it as requirement CMake 3. But since we don't use any features so far from there I think this fix is a good idea.

(I just recognized it because my system replaced my manually installed CMake 3.x with a CMake 2.8.x version with an update)