### PR TITLE
Remove bigint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "deps/gtest"]
 	path = deps/gtest
 	url = https://github.com/monetas/gtest.git
-[submodule "deps/bigint"]
-	path = deps/bigint
-	url = https://github.com/monetas/BigInt.git
 [submodule "deps/ChaiScript"]
 	path = deps/ChaiScript
 	url = https://github.com/ChaiScript/ChaiScript.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ include(CMakePackageConfigHelpers)
 set(CMAKE_CONFIG_DEST "share/cmake/Modules")
 set(OPENTXS_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
 
-export(TARGETS opentxs-core opentxs-client opentxs-ext opentxs-cash opentxs-basket bigint lucre FILE "${CMAKE_BINARY_DIR}/opentxsTargets.cmake")
+export(TARGETS opentxs-core opentxs-client opentxs-ext opentxs-cash opentxs-basket lucre FILE "${CMAKE_BINARY_DIR}/opentxsTargets.cmake")
 
 configure_package_config_file(
        "cmake/opentxsConfig.cmake.in"

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -39,30 +39,6 @@ add_library(bitcoin-base58
 target_link_libraries(bitcoin-base58 ${OPENSSL_LIBRARIES})
 
 
-### Build bigint as library
-set(bigint-sources
-  ${CMAKE_CURRENT_SOURCE_DIR}/bigint/BigInteger.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/bigint/BigIntegerAlgorithms.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/bigint/BigIntegerUtils.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/bigint/BigUnsigned.cc
-  ${CMAKE_CURRENT_SOURCE_DIR}/bigint/BigUnsignedInABase.cc
-)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/bigint/)
-
-if(WIN32)
-  include_directories(${OPENSSL_INCLUDE_DIR})
-  add_library(bigint
-    STATIC
-    ${bigint-sources}
-  )
-else()
-  add_library(bigint
-    ${bigint-sources}
-  )
-endif()
-
-
 ### Build anyoption as library
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -110,7 +86,7 @@ set(CZMQ_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/czmq/include PARENT_SCOPE)
 
 if (NOT WIN32)
   include(GNUInstallDirs)
-  install(TARGETS bigint lucre
+  install(TARGETS lucre
           DESTINATION ${CMAKE_INSTALL_LIBDIR}
           EXPORT opentxsTargets
           COMPONENT main)

--- a/docs/LICENSE-AND-CREDITS.txt
+++ b/docs/LICENSE-AND-CREDITS.txt
@@ -1182,28 +1182,6 @@ With irrXML 1.0, this has now been done.
  */
 
 
-// -------------------------------------------------------------------
-
-/*
-
- C++ Big Integer Library
- 
- http://mattmccutchen.net/bigint/
- 
- Written and maintained by Matt McCutchen <matt@mattmccutchen.net>
- 
- Legal
- -----
- I, Matt McCutchen, the sole author of the original Big Integer Library, 
- waive my copyright to it, placing it in the public domain.  The library 
- comes with absolutely no warranty.
- 
- */
-
-
-
-
-
 // *************************************************************************
 
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -119,7 +119,7 @@ else()
 endif()
 
 target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58)
-target_link_libraries(opentxs-core PUBLIC bigint ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
+target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
 set_lib_property(opentxs-core)
 
 if(WIN32)

--- a/src/core/crypto/OTCryptoOpenSSL.cpp
+++ b/src/core/crypto/OTCryptoOpenSSL.cpp
@@ -147,8 +147,6 @@
 
 #include <bitcoin-base58/base58.h>
 
-#include <bigint/BigIntegerLibrary.hh>
-
 #include <thread>
 
 extern "C" {


### PR DESCRIPTION
The bigint library isn't used anymore since we changed to base58 (removed with PR https://github.com/Open-Transactions/opentxs/pull/348).

Depends on https://github.com/Open-Transactions/opentxs/pull/543 to build on my system (will update my CMake later). I'll rebase if it gets merged (or not).