### PR TITLE
Export methods for accessing currency properties.

### DIFF
--- a/include/opentxs/client/OTAPI.hpp
+++ b/include/opentxs/client/OTAPI.hpp
@@ -713,6 +713,10 @@ public:
 
     EXPORT static std::string FormatAmountWithoutSymbol(
         const std::string& INSTRUMENT_DEFINITION_ID, const int64_t& THE_AMOUNT);
+    EXPORT static std::string GetCurrencyTLA(
+        const std::string& INSTRUMENT_DEFINITION_ID);
+    EXPORT static std::string GetCurrencySymbol(
+        const std::string& INSTRUMENT_DEFINITION_ID);
 
     /** StringToAmount:
      // Input: currency contract, formatted string. (And locale, internally.)

--- a/include/opentxs/client/OTAPI_Exec.hpp
+++ b/include/opentxs/client/OTAPI_Exec.hpp
@@ -699,6 +699,10 @@ public:
         const std::string& INSTRUMENT_DEFINITION_ID) const;
     int32_t GetCurrencyDecimalPower(
         const std::string& INSTRUMENT_DEFINITION_ID) const;
+    std::string GetCurrencyTLA(
+        const std::string& INSTRUMENT_DEFINITION_ID) const;
+    std::string GetCurrencySymbol(
+        const std::string& INSTRUMENT_DEFINITION_ID) const;
 
     /** FormatAmount:
     // Input: currency contract, amount. (And locale, internally.)

--- a/src/client/OTAPI.cpp
+++ b/src/client/OTAPI.cpp
@@ -493,6 +493,18 @@ int32_t OTAPI_Wrap::GetCurrencyDecimalPower(
     return Exec()->GetCurrencyDecimalPower(INSTRUMENT_DEFINITION_ID);
 }
 
+std::string OTAPI_Wrap::GetCurrencyTLA(
+    const std::string& INSTRUMENT_DEFINITION_ID)
+{
+    return Exec()->GetCurrencyTLA(INSTRUMENT_DEFINITION_ID);
+}
+
+std::string OTAPI_Wrap::GetCurrencySymbol(
+    const std::string& INSTRUMENT_DEFINITION_ID)
+{
+    return Exec()->GetCurrencySymbol(INSTRUMENT_DEFINITION_ID);
+}
+
 int64_t OTAPI_Wrap::StringToAmount(const std::string& INSTRUMENT_DEFINITION_ID,
                                    const std::string& str_input)
 {

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -1344,6 +1344,50 @@ int32_t OTAPI_Exec::GetCurrencyDecimalPower(
     return pContract->GetCurrencyDecimalPower();
 }
 
+std::string OTAPI_Exec::GetCurrencyTLA(
+    const std::string& INSTRUMENT_DEFINITION_ID) const
+{
+    bool bIsInitialized = OTAPI()->IsInitialized();
+    if (!bIsInitialized) {
+        otErr << __FUNCTION__
+              << ": Not initialized; call OT_API::Init first.\n";
+        return "";
+    }
+    if (INSTRUMENT_DEFINITION_ID.empty()) {
+        otErr << __FUNCTION__
+              << ": Empty INSTRUMENT_DEFINITION_ID passed in!\n";
+        return "";
+    }
+    const Identifier theInstrumentDefinitionID(INSTRUMENT_DEFINITION_ID);
+    AssetContract* pContract =
+        OTAPI()->GetAssetType(theInstrumentDefinitionID, __FUNCTION__);
+    if (nullptr == pContract) return "";
+    // By this point, pContract is a good pointer.  (No need to cleanup.)
+    return pContract->GetCurrencyTLA().Get();
+}
+
+std::string OTAPI_Exec::GetCurrencySymbol(
+    const std::string& INSTRUMENT_DEFINITION_ID) const
+{
+    bool bIsInitialized = OTAPI()->IsInitialized();
+    if (!bIsInitialized) {
+        otErr << __FUNCTION__
+              << ": Not initialized; call OT_API::Init first.\n";
+        return "";
+    }
+    if (INSTRUMENT_DEFINITION_ID.empty()) {
+        otErr << __FUNCTION__
+              << ": Empty INSTRUMENT_DEFINITION_ID passed in!\n";
+        return "";
+    }
+    const Identifier theInstrumentDefinitionID(INSTRUMENT_DEFINITION_ID);
+    AssetContract* pContract =
+        OTAPI()->GetAssetType(theInstrumentDefinitionID, __FUNCTION__);
+    if (nullptr == pContract) return "";
+    // By this point, pContract is a good pointer.  (No need to cleanup.)
+    return pContract->GetCurrencySymbol().Get();
+}
+
 // Returns amount from formatted string, based on currency contract and locale.
 //
 int64_t OTAPI_Exec::StringToAmount(const std::string& INSTRUMENT_DEFINITION_ID,


### PR DESCRIPTION
Android NDK does not support locales. So it is better if amount
formating is be done in Java.

Closing monetas/opentxs#40