### PR TITLE
Fix SWIG wrapper for export_cash so that it returns two values.

### DIFF
--- a/wrappers/opentxs.i
+++ b/wrappers/opentxs.i
@@ -103,6 +103,7 @@ namespace std {
 
 
 %rename(OTRecordLessThan) opentxs::OTRecord::operator<(const OTRecord& rhs); 
+%apply std::string &OUTPUT { std::string& STR_RETAINED_COPY };
 
 %feature("director") OTCallback;
 %feature("director") OTNameLookup;


### PR DESCRIPTION
This is @fellowtravler 's suggestion, tests run fine with this fix.