### PR TITLE
Generate transportKey and write it to the notaryProviderContract. Remove transport encryption based on OTEnvelope.

### DIFF
--- a/include/opentxs/client/OTClient.hpp
+++ b/include/opentxs/client/OTClient.hpp
@@ -217,7 +217,8 @@ public:
 public:
     explicit OTClient(OTWallet* theWallet);
 
-    bool connect(const std::string& endpoint);
+    bool connect(const std::string& endpoint,
+                 const unsigned char* transportKey);
 
     inline OTMessageBuffer& GetMessageBuffer()
     {

--- a/include/opentxs/client/OTServerConnection.hpp
+++ b/include/opentxs/client/OTServerConnection.hpp
@@ -135,6 +135,7 @@
 
 #include <memory>
 #include <string>
+#include <opentxs/core/String.hpp>
 
 // forward declare zsock_t
 typedef struct _zsock_t zsock_t;
@@ -174,7 +175,7 @@ public:
               const Message& theMessage);
 
 private:
-    bool send(const OTEnvelope& envelope);
+    bool send(const String&);
     bool receive(std::string& reply);
 
 private:

--- a/include/opentxs/client/OTServerConnection.hpp
+++ b/include/opentxs/client/OTServerConnection.hpp
@@ -152,7 +152,8 @@ class Message;
 class OTServerConnection
 {
 public:
-    OTServerConnection(OTClient* theClient, const std::string& endpoint);
+    OTServerConnection(OTClient* theClient, const std::string& endpoint,
+                       const unsigned char* transportKey);
     ~OTServerConnection();
 
     bool GetNotaryID(Identifier& theID) const;

--- a/include/opentxs/core/OTServerContract.hpp
+++ b/include/opentxs/core/OTServerContract.hpp
@@ -134,6 +134,7 @@
 #define OPENTXS_CORE_OTSERVERCONTRACT_HPP
 
 #include "Contract.hpp"
+#include <czmq.h>
 
 namespace opentxs
 {
@@ -149,6 +150,8 @@ public:
     EXPORT virtual ~OTServerContract();
 
     EXPORT bool GetConnectInfo(String& strHostname, int32_t& nPort) const;
+    EXPORT unsigned char* GetTransportKey() const;
+    static zcert_t* LoadOrCreateTransportKey(const String& nymID);
     EXPORT virtual void CreateContents(); // Only used when first generating an
                                           // asset or server contract. Meant for
                                           // contracts which never change after
@@ -166,6 +169,7 @@ protected:
     String m_strHostname;
     int32_t m_nPort;
     String m_strURL;
+    unsigned char* m_transportKey;
 };
 
 } // namespace opentxs

--- a/include/opentxs/server/MessageProcessor.hpp
+++ b/include/opentxs/server/MessageProcessor.hpp
@@ -135,6 +135,7 @@
 
 #include <string>
 #include <memory>
+#include <czmq.h>
 
 // forward declare czmq types
 typedef struct _zsock_t zsock_t;
@@ -155,7 +156,7 @@ public:
     EXPORT void run();
 
 private:
-    void init(int port);
+    void init(int port, zcert_t* transportKey);
     bool processMessage(const std::string& messageString, std::string& reply);
     void processSocket();
 

--- a/include/opentxs/server/OTServer.hpp
+++ b/include/opentxs/server/OTServer.hpp
@@ -143,6 +143,7 @@
 #include <opentxs/core/OTTransaction.hpp>
 #include <memory>
 #include <cstddef>
+#include <czmq.h>
 
 namespace opentxs
 {
@@ -170,6 +171,7 @@ public:
     bool IsFlaggedForShutdown() const;
 
     bool GetConnectInfo(String& hostname, int32_t& port) const;
+    zcert_t* GetTransportKey() const;
 
     const Nym& GetServerNym() const;
 

--- a/include/opentxs/server/ServerLoader.hpp
+++ b/include/opentxs/server/ServerLoader.hpp
@@ -139,6 +139,8 @@
 #include <opentxs/core/util/OTDataFolder.hpp>
 #include <opentxs/core/Log.hpp>
 
+#include <czmq.h>
+
 #define SERVER_CONFIG_KEY "server"
 
 namespace opentxs
@@ -232,6 +234,11 @@ public:
                       "contract? Have you tried the test password? "
                       "(\"test\")\n");
         return port;
+    }
+
+    zcert_t* getTransportKey() const
+    {
+        return server_->GetTransportKey();
     }
 
 private:

--- a/src/client/OTClient.cpp
+++ b/src/client/OTClient.cpp
@@ -176,9 +176,10 @@ OTClient::OTClient(OTWallet* theWallet)
 {
 }
 
-bool OTClient::connect(const std::string& endpoint)
+bool OTClient::connect(const std::string& endpoint,
+                       const unsigned char* transportKey)
 {
-    m_pConnection.reset(new OTServerConnection(this, endpoint));
+    m_pConnection.reset(new OTServerConnection(this, endpoint, transportKey));
     return true;
 }
 
@@ -220,7 +221,7 @@ void OTClient::ProcessMessageOut(OTServerContract* pServerContract, Nym* pNym,
         String endpoint;
         endpoint.Format("tcp://%s:%d", hostname.Get(), port);
 
-        connect(endpoint.Get());
+        connect(endpoint.Get(), pServerContract->GetTransportKey());
     }
 
     m_pConnection->send(pServerContract, pNym, theMessage);

--- a/src/client/OTServerConnection.cpp
+++ b/src/client/OTServerConnection.cpp
@@ -154,7 +154,8 @@ namespace opentxs
 // but either way the connections need a pointer to the wallet
 // they are associated with, so they can access those accounts.
 OTServerConnection::OTServerConnection(OTClient* theClient,
-                                       const std::string& endpoint)
+                                       const std::string& endpoint,
+                                       const unsigned char* transportKey)
     : socket_zmq(zsock_new_req(NULL))
     , m_pNym(nullptr)
     , m_pServerContract(nullptr)
@@ -165,10 +166,10 @@ OTServerConnection::OTServerConnection(OTClient* theClient,
         OT_FAIL;
     }
     zsock_set_linger(socket_zmq, 1000);
+    // Set new client public and secret key.
     zcert_apply(zcert_new(), socket_zmq);
-    // test key value taken from `man zmq_curve`
-    zsock_set_curve_serverkey(socket_zmq,
-                              "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7");
+    // Set server public key.
+    zsock_set_curve_serverkey_bin(socket_zmq, transportKey);
 
     if (zsock_connect(socket_zmq, "%s", endpoint.c_str())) {
         Log::vError("Failed to connect to %s\n", endpoint.c_str());

--- a/src/client/OTServerConnection.cpp
+++ b/src/client/OTServerConnection.cpp
@@ -222,10 +222,8 @@ void OTServerConnection::send(OTServerContract* pServerContract, Nym* pNym,
     const Nym* pServerNym = pServerContract->GetContractPublicNym();
     OT_ASSERT(nullptr != pServerNym);
 
-    OTEnvelope theEnvelope;
-    String strEnvelopeContents;
-    theMessage.SaveContractRaw(strEnvelopeContents);
-    theEnvelope.Seal(*pServerNym, strEnvelopeContents);
+    String strContents;
+    theMessage.SaveContractRaw(strContents);
 
     otOut << "\n=====>BEGIN Sending " << theMessage.m_strCommand
           << " message via ZMQ... Request number: "
@@ -233,7 +231,7 @@ void OTServerConnection::send(OTServerContract* pServerContract, Nym* pNym,
 
     m_pServerContract = pServerContract;
     m_pNym = pNym;
-    send(theEnvelope);
+    send(strContents);
 
     otWarn << "<=====END Finished sending " << theMessage.m_strCommand
            << " message (and hopefully receiving "
@@ -241,9 +239,9 @@ void OTServerConnection::send(OTServerContract* pServerContract, Nym* pNym,
            << "\n\n";
 }
 
-bool OTServerConnection::send(const OTEnvelope& theEnvelope)
+bool OTServerConnection::send(const String& theString)
 {
-    OTASCIIArmor ascEnvelope(theEnvelope);
+    OTASCIIArmor ascEnvelope(theString);
 
     if (!ascEnvelope.Exists()) {
         return false;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,10 @@
 # Copyright (c) Monetas AG, 2014
 
+include_directories(SYSTEM
+  ${ZEROMQ_INCLUDE_DIRS}
+  ${CZMQ_INCLUDE_DIR}
+)
+
 add_subdirectory(otprotob)
 add_subdirectory(trade)
 add_subdirectory(cron)
@@ -119,7 +124,7 @@ else()
 endif()
 
 target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58)
-target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
+target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring} czmq_local)
 set_lib_property(opentxs-core)
 
 if(WIN32)

--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -1,5 +1,11 @@
 # Copyright (c) Monetas AG, 2014
 
+include_directories(SYSTEM
+  ${ZEROMQ_INCLUDE_DIRS}
+  ${CZMQ_INCLUDE_DIR}
+)
+
+
 set(cxx-sources
   OTPayment.cpp
 )

--- a/src/server/MessageProcessor.cpp
+++ b/src/server/MessageProcessor.cpp
@@ -154,7 +154,7 @@ MessageProcessor::MessageProcessor(ServerLoader& loader)
     , zmqAuth_(zactor_new(zauth, NULL))
     , zmqPoller_(zpoller_new(zmqSocket_, NULL))
 {
-    init(loader.getPort());
+    init(loader.getPort(), loader.getTransportKey());
 }
 
 MessageProcessor::~MessageProcessor()
@@ -165,7 +165,7 @@ MessageProcessor::~MessageProcessor()
     zsock_destroy(&zmqSocket_);
 }
 
-void MessageProcessor::init(int port)
+void MessageProcessor::init(int port, zcert_t* transportKey)
 {
     if (port == 0) {
         OT_FAIL;
@@ -178,11 +178,7 @@ void MessageProcessor::init(int port)
     zsock_wait(zmqAuth_);
     zsock_set_zap_domain(zmqSocket_, "global");
     zsock_set_curve_server(zmqSocket_, 1);
-    // test key values taken from `man zmq_curve`
-    zsock_set_curve_publickey(zmqSocket_,
-                              "rq:rM>}U?@Lns47E1%kR.o@n%FcmmsL/@{H8]yf7");
-    zsock_set_curve_secretkey(zmqSocket_,
-                              "JTKVSB%%)wK0E.X)V>+}o?pNmC{O&4W4b!Ni{Lh6");
+    zcert_apply(transportKey, zmqSocket_);
     zsock_bind(zmqSocket_, "tcp://*:%d", port);
 }
 

--- a/src/server/MessageProcessor.cpp
+++ b/src/server/MessageProcessor.cpp
@@ -250,31 +250,17 @@ bool MessageProcessor::processMessage(const std::string& messageString,
     OTASCIIArmor ascMessage;
     ascMessage.MemSet(messageString.data(), messageString.size());
 
-    OTEnvelope envelope;
-    if (!envelope.SetAsciiArmoredData(ascMessage)) {
-        Log::vError("Error retrieving envelope.\n");
-        return true;
-    }
-
-    // Now the base64 is decoded and the envelope is in binary form again.
-    Log::vOutput(2, "Successfully retrieved envelope from message.\n");
-
-    // Decrypt the Envelope.
-    String envelopeContents;
-    if (!envelope.Open(server_->GetServerNym(), envelopeContents)) {
-        Log::vError("Unable to open envelope.\n");
-        return true;
-    }
-
+    String messageContents;
+    ascMessage.GetString(messageContents);
     // All decrypted--now let's load the results into an OTMessage.
     // No need to call message.ParseRawFile() after, since
     // LoadContractFromString handles it.
     Message message;
-    if (!envelopeContents.Exists() ||
-        !message.LoadContractFromString(envelopeContents)) {
-        Log::vError("Error loading message from envelope "
+    if (!messageContents.Exists() ||
+        !message.LoadContractFromString(messageContents)) {
+        Log::vError("Error loading message from message "
                     "contents:\n\n%s\n\n",
-                    envelopeContents.Get());
+                    messageContents.Get());
         return true;
     }
 

--- a/src/server/OTServer.cpp
+++ b/src/server/OTServer.cpp
@@ -849,4 +849,9 @@ bool OTServer::GetConnectInfo(String& strHostname, int32_t& nPort) const
     return m_pServerContract->GetConnectInfo(strHostname, nPort);
 }
 
+zcert_t* OTServer::GetTransportKey() const
+{
+    return OTServerContract::LoadOrCreateTransportKey(m_strServerNymID);
+}
+
 } // namespace opentxs


### PR DESCRIPTION
This PR puts a `<transportKey>` element into the notaryProviderContract, containing the notary's public transport key. Using [zcert_public_txt](http://czmq.zeromq.org/manual:zcert) returns the [Z85 encoding](http://rfc.zeromq.org/spec:32) of the key. Despite the Z85 RFC explicitly mentioning XML in the reasoning of the encoding, the encoding contains the `<>` characters. This is why I also base64-encode it. @toxeus, @OttoAllmendinger, do you have a better solutions in mind? I did not yet investigate PEM or section markers, I figured @toxeus is the expert on that.

The public and the private key are stored in `server_data/credentials/<serverNymID>/transportKey` (and `_secret`). The notary generates/reads this. The client reads the transport public key from the notary provider contract.