### PR TITLE
CMake: link czmq_local as PRIVATE

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -123,8 +123,8 @@ else()
   )
 endif()
 
-target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58)
-target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring} czmq_local)
+target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58 czmq_local)
+target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
 set_lib_property(opentxs-core)
 
 if(WIN32)


### PR DESCRIPTION
Third party software that links to opentxs in general does not use
any czmq symbols at all. Therefore, there is no need for the third
party software to link against it. Hence, make link czmq_local
with opentxs a PRIVATE linking.