### PR TITLE
Fix android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ endif()
 #-----------------------------------------------------------------------------
 # Build Unit tests
 
-if(BUILD_TESTS)
+if(BUILD_TESTS AND NOT ANDROID)
   set(GTEST_ROOT ${opentxs_SOURCE_DIR}/deps/gtest)
   set(GTEST_FOUND ON)
   set(GTEST_INCLUDE_DIRS ${GTEST_ROOT}/include)
@@ -240,6 +240,7 @@ if(BUILD_TESTS)
   set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY})
 
   enable_testing()
+  add_subdirectory(tests)
 endif()
 
 
@@ -362,7 +363,6 @@ endfunction(set_lib_property)
 
 add_subdirectory(deps)
 add_subdirectory(src)
-add_subdirectory(tests)
 add_subdirectory(wrappers)
 
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -123,8 +123,8 @@ else()
   )
 endif()
 
-target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58)
-target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring} czmq_local)
+target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58 czmq_local)
+target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
 set_lib_property(opentxs-core)
 
 if(WIN32)


### PR DESCRIPTION
Disable opentxs tests for android build. Mips platform has problem with linking testing binary.