### PR TITLE
Dockerfile: add Dockerfile for Android

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM monetas/ot-android-dev
+FROM monetas/base-ot-dev
 
 MAINTAINER Darragh Grealish "darragh@monetas.net"
 

--- a/Dockerfiles/Dockerfile.android
+++ b/Dockerfiles/Dockerfile.android
@@ -1,0 +1,18 @@
+FROM monetas/ot-android-dev
+
+MAINTAINER Filip Gospodinov "filip@monetas.net"
+
+ENV OT_PATH /home/otuser/opentxs-source
+
+ADD CMakeLists.txt .clang-format .gitignore .gitmodules $OT_PATH/
+ADD cmake $OT_PATH/cmake
+ADD deps $OT_PATH/deps
+ADD scripts $OT_PATH/scripts
+ADD tests $OT_PATH/tests
+ADD wrappers $OT_PATH/wrappers
+ADD include $OT_PATH/include
+ADD .git $OT_PATH/.git
+ADD src $OT_PATH/src
+
+WORKDIR /home/otuser/ot-android/
+RUN ./run-build.sh


### PR DESCRIPTION
This PR decouples the Android and the Linux Dockerfiles. This is only possible because Docker learned the `-f` flag in version 1.5. Then, we can use the Android Dockerfile to re-enable Android builds on Jenkins.