### PR TITLE
Dockerfile.android: add CMD for easy lib fetch

### DIFF
--- a/Dockerfiles/Dockerfile.android
+++ b/Dockerfiles/Dockerfile.android
@@ -16,3 +16,4 @@ ADD src $OT_PATH/src
 
 WORKDIR /home/otuser/ot-android/
 RUN ./run-build.sh
+CMD uid=$(ls -ldn /mnt/ | awk '{print $3}') && install -o $uid -g $uid opentxs-*.tar.bz2 /mnt/


### PR DESCRIPTION
Now, the Android libs can easily be built and fetched:

```bash
docker build --pull --rm --force-rm -t android -f Dockerfiles/Dockerfile.android .
LIBS_DIR=$HOME/android_libs
mkdir $LIBS_DIR
docker run --rm -v $LIBS_DIR:/mnt/ android
ls $LIBS_DIR
```

**IMPORTANT**: this *only* works with Docker verion >= 1.5.