### PR TITLE
gtest submodule url change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/brofield/simpleini.git
 [submodule "deps/gtest"]
 	path = deps/gtest
-	url = https://github.com/monetas/gtest.git
+	url = https://github.com/Open-Transactions/gtest.git
 [submodule "deps/ChaiScript"]
 	path = deps/ChaiScript
 	url = https://github.com/ChaiScript/ChaiScript.git


### PR DESCRIPTION
This corrects the gtest submodule URL to point to Open-Transactions/gtest 