### PR TITLE
Resolve #599 and Update Ubuntu Documentation

### DIFF
--- a/docs/INSTALL-Debian_Ubuntu.txt
+++ b/docs/INSTALL-Debian_Ubuntu.txt
@@ -16,7 +16,7 @@
 $ sudo aptitude install git build-essential cmake pkg-config
 
 # Add PPA that provides libzmq with libsodium support
-sudo add-apt-repository -y ppa:monetas/opentxs && sudo aptitude update
+sudo add-apt-repository -y ppa:opentransactions/opentxs && sudo aptitude update
 # install Open-Transactions library dependencies
 $ sudo aptitude install libssl-dev protobuf-compiler libprotobuf-dev libzmq3-dev
 
@@ -124,7 +124,7 @@ $ make package
 $ ./script/install_sample_data.sh
 
 # also can checkout sample contracts,baskets,
-# server-contracts at https://github.com/monetas/opentxs-sample-data
+# server-contracts at https://github.com/Open-Transactions/opentxs-sample-data
 
 # for python client api support export env variable
 $ export PYTHONPATH=/usr/local/lib:$PYTHONPATH

--- a/src/core/OTServerContract.cpp
+++ b/src/core/OTServerContract.cpp
@@ -74,11 +74,7 @@ OTServerContract::OTServerContract(String& name, String& foldername,
 OTServerContract::~OTServerContract()
 {
     if (nullptr != m_transportKey) {
-        // I'm doing this cast because although m_transportKey is
-        // an unsigned char *, it was originally allocated in a
-        // call to uint8_t * OTCrypto_OpenSSL::Base64Decode.
-        //
-        uint8_t * pKey = static_cast<uint8_t *>(m_transportKey);
+        uint8_t * pKey = m_transportKey;
         delete [] pKey;
         m_transportKey = nullptr;
         m_transportKeyLength = 0;


### PR DESCRIPTION
This resolves the unnecessary cast that was causing issue #599 , and updates the Ubuntu Documentation to point to the new OpenTransactions PPA at https://launchpad.net/~opentransactions/+archive/ubuntu/opentxs 