### PR TITLE
Remove unused const (build error fix)

### DIFF
--- a/src/core/Log.cpp
+++ b/src/core/Log.cpp
@@ -794,7 +794,7 @@ namespace
 #endif
 
 // invoke set_terminate as part of global constant initialization
-static const bool SET_TERMINATE = std::set_terminate(ot_terminate);
+//static const bool SET_TERMINATE = std::set_terminate(ot_terminate);
 
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
This fixes a build issue on Linux (possibly other platforms) where a build error is triggered due to a unused const in Log.cpp - This comments out the line for build purposes, but also allows developers to uncomment it in case it is used later.