### PR TITLE
Implement secp256k1 credentials

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "deps/czmq"]
 	path = deps/czmq
 	url = https://github.com/zeromq/czmq
+[submodule "deps/bitcoin-secp256k1"]
+	path = deps/bitcoin-secp256k1
+	url = https://github.com/bitcoin/secp256k1.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,8 +52,10 @@ option(KEYRING_KWALLET     "Build with KWallet Keyring" OFF)
 option(KEYRING_FLATFILE    "Build with Flatfile Keyring" OFF)
 
 option(OT_CRYPTO_SUPPORTED_KEY_RSA     "Enable RSA key support" ON)
+option(OT_CRYPTO_SUPPORTED_KEY_SECP256K1 "Enable secp256k1 key support" ON)
 
 option(OT_CRYPTO_USING_OPENSSL       "Use OpenSSL crypto implementation" ON)
+option(OT_CRYPTO_USING_LIBSECP256K1  "Use libsecp256k1 crypto implementation" ON)
 
 # SWIG Bindings
 option(JAVA    "Build with Java binding" OFF)
@@ -104,9 +106,11 @@ message(STATUS "Keyring flatfile:       ${KEYRING_FLATFILE}")
 
 message(STATUS "Key algorithms-------------------------------")
 message(STATUS "RSA:                    ${OT_CRYPTO_SUPPORTED_KEY_RSA}")
+message(STATUS "secp256k1               ${OT_CRYPTO_SUPPORTED_KEY_SECP256K1}")
 
 message(STATUS "Crypto library providers---------------------")
 message(STATUS "OpenSSL:                ${OT_CRYPTO_USING_OPENSSL}")
+message(STATUS "libsecp256k1:           ${OT_CRYPTO_USING_LIBSECP256K1}")
 
 message(STATUS "Bindings ------------------------------------")
 message(STATUS "Java binding:           ${JAVA}")
@@ -182,6 +186,8 @@ execute_process(COMMAND git "submodule" "update" "--init" "--recursive" WORKING_
 #-----------------------------------------------------------------------------
 # Third party libraries
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 if(APPLE)
   find_package(OpenSSL REQUIRED)
 else()
@@ -189,6 +195,9 @@ else()
 endif()
 find_package(Protobuf REQUIRED)
 find_package(ZLIB REQUIRED)
+if(OT_CRYPTO_USING_LIBSECP256K1)
+  find_package(GMP REQUIRED)
+endif()
 
 #-----------------------------------------------------------------------------
 # System libraries used for linking.
@@ -307,10 +316,18 @@ if(OT_CRYPTO_SUPPORTED_KEY_RSA)
   add_definitions(-DOT_CRYPTO_SUPPORTED_KEY_RSA)
 endif()
 
+if(OT_CRYPTO_SUPPORTED_KEY_SECP256K1)
+  add_definitions(-DOT_CRYPTO_SUPPORTED_KEY_SECP256K1)
+endif()
+
 #Crypto libraries
 
 if(OT_CRYPTO_USING_OPENSSL)
-add_definitions(-DOT_CRYPTO_USING_OPENSSL)
+  add_definitions(-DOT_CRYPTO_USING_OPENSSL)
+endif()
+
+if(OT_CRYPTO_USING_LIBSECP256K1)
+  add_definitions(-DOT_CRYPTO_USING_LIBSECP256K1)
 endif()
 
 add_definitions(-DOT_CASH_USING_LUCRE)
@@ -381,8 +398,22 @@ function(set_lib_property lib)
 endfunction(set_lib_property)
 
 add_subdirectory(deps)
+
+if (OT_CRYPTO_USING_LIBSECP256K1)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR}/deps/include)
+    link_directories(${CMAKE_CURRENT_BINARY_DIR}/deps/lib)
+endif()
+
 add_subdirectory(src)
 add_subdirectory(wrappers)
+
+if (OT_CRYPTO_USING_LIBSECP256K1)
+    add_dependencies(opentxs libsecp256k1)
+    add_dependencies(opentxs-cron libsecp256k1)
+    add_dependencies(opentxs-recurring libsecp256k1)
+    add_dependencies(opentxs-script libsecp256k1)
+    add_dependencies(opentxs-trade libsecp256k1)
+endif()
 
 if (NOT ANDROID)
   add_subdirectory(tests)

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,0 +1,19 @@
+# Try to find the GMP librairies
+# GMP_FOUND - system has GMP lib
+# GMP_INCLUDE_DIR - the GMP include directory
+# GMP_LIBRARIES - Libraries needed to use GMP
+
+if (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+                # Already in cache, be silent
+                set(GMP_FIND_QUIETLY TRUE)
+endif (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h )
+find_library(GMP_LIBRARIES NAMES gmp libgmp )
+find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx )
+MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARIES} " " ${GMPXX_LIBRARIES} )
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -95,3 +95,31 @@ if (NOT WIN32)
           EXPORT opentxsTargets
           COMPONENT main)
 endif()
+
+if (OT_CRYPTO_USING_LIBSECP256K1)
+    include(ExternalProject)
+    ExternalProject_Add(
+        libsecp256k1
+        EP_BASE ${CMAKE_CURRENT_BINARY_DIR}
+        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bitcoin-secp256k1
+        CONFIGURE_COMMAND CFLAGS=-fpic ${CMAKE_CURRENT_SOURCE_DIR}/bitcoin-secp256k1/configure --prefix ${CMAKE_CURRENT_BINARY_DIR} --enable-shared=no --enable-static=yes --enable-module-ecdh
+        BUILD_COMMAND make
+        BUILD_IN_SOURCE 0
+    )
+
+    ExternalProject_Add_Step(
+        libsecp256k1
+        generate
+        COMMAND autoreconf -if --warnings=all ${CMAKE_CURRENT_SOURCE_DIR}/bitcoin-secp256k1
+        DEPENDERS configure
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/libsecp256k1
+    )
+
+    ExternalProject_Add_Step(
+        libsecp256k1
+        make_build
+        COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/libsecp256k1
+        DEPENDERS generate
+    )
+    set_property(TARGET libsecp256k1 PROPERTY EXCLUDE_FROM_ALL TRUE)
+endif()

--- a/include/opentxs/client/OTAPI.hpp
+++ b/include/opentxs/client/OTAPI.hpp
@@ -417,6 +417,11 @@ public:
         const std::string& ALT_LOCATION); // source and location can be empty.
                                           // (OT will generate a Nym with a
                                           // public key as the source.)
+    EXPORT static std::string CreateNymECDSA(
+        const std::string& NYM_ID_SOURCE,
+        const std::string& ALT_LOCATION); // source and location can be empty.
+                                          // (OT will generate a Nym with a
+                                          // public key as the source.)
 
     EXPORT static std::string GetNym_ActiveCronItemIDs(
         const std::string& NYM_ID, const std::string& NOTARY_ID);

--- a/include/opentxs/client/OTAPI_Exec.hpp
+++ b/include/opentxs/client/OTAPI_Exec.hpp
@@ -419,6 +419,13 @@ public:
         const; // source and location can be empty.
                // (OT will generate a Nym with a
                // public key as the source.)
+    EXPORT std::string CreateNymECDSA(
+                                 const std::string& NYM_ID_SOURCE,
+                                 const std::string& ALT_LOCATION)
+        const; // source and location can be empty.
+               // (OT will generate a Nym with a
+               // public key as the source.)
+
 
     EXPORT std::string GetNym_ActiveCronItemIDs(
         const std::string& NYM_ID, const std::string& NOTARY_ID) const;

--- a/include/opentxs/client/OT_ME.hpp
+++ b/include/opentxs/client/OT_ME.hpp
@@ -109,6 +109,10 @@ public:
                                  const std::string& NYM_ID,
                                  const std::string& TARGET_NYM_ID) const;
 
+    EXPORT std::string create_nym_ecdsa(
+                                  const std::string& NYM_ID_SOURCE,
+                                  const std::string& ALT_LOCATION) const;
+
     EXPORT std::string create_nym_legacy(int32_t nKeybits,
                                   const std::string& NYM_ID_SOURCE,
                                   const std::string& ALT_LOCATION) const;

--- a/include/opentxs/core/Contract.hpp
+++ b/include/opentxs/core/Contract.hpp
@@ -39,6 +39,8 @@
 #ifndef OPENTXS_CORE_CONTRACT_HPP
 #define OPENTXS_CORE_CONTRACT_HPP
 
+#include <opentxs/core/crypto/CryptoHash.hpp>
+
 #include "Identifier.hpp"
 #include "OTStringXML.hpp"
 #include "util/Common.hpp" // TODO: remove this when feasible
@@ -82,7 +84,7 @@ protected:
     OTStringXML m_xmlUnsigned; // The Unsigned Clear Text (XML contents without
                                // signatures.)
     String m_strRawFile;       // The complete raw file including signatures.
-    String m_strSigHashType;   // The Hash algorithm used for the signature
+    CryptoHash::HashType m_strSigHashType;   // The Hash algorithm used for the signature
     String m_strContractType;  // CONTRACT, MESSAGE, TRANSACTION, LEDGER,
                                // TRANSACTION ITEM
 
@@ -151,7 +153,7 @@ public:
     //
     static bool AddBookendsAroundContent(
         String& strOutput, const String& strContents,
-        const String& strContractType, const String& strHashType,
+        const String& strContractType, const CryptoHash::HashType hashType,
         const listOfSignatures& listSignatures);
 
     EXPORT static bool LoadEncodedTextField(irr::io::IrrXMLReader*& xml,
@@ -168,10 +170,6 @@ public:
     static bool SkipToElement(irr::io::IrrXMLReader*& xml);
     static bool SkipToTextField(irr::io::IrrXMLReader*& xml);
     static bool SkipAfterLoadingField(irr::io::IrrXMLReader*& xml);
-    inline const char* GetHashType() const
-    {
-        return m_strSigHashType.Get();
-    }
     inline void SetIdentifier(const Identifier& theID)
     {
         m_ID = theID;
@@ -369,7 +367,7 @@ public:
                                     const OTPasswordData* pPWData = nullptr);
     EXPORT bool SignContract(const OTAsymmetricKey& theKey,
                              OTSignature& theSignature,
-                             const String& strHashType,
+                             const CryptoHash::HashType hashType,
                              const OTPasswordData* pPWData = nullptr);
 
     // Calculates a hash of m_strRawFile (the xml portion of the contract plus
@@ -418,7 +416,7 @@ public:
 
     EXPORT bool VerifySignature(const OTAsymmetricKey& theKey,
                                 const OTSignature& theSignature,
-                                const String& strHashType,
+                                const CryptoHash::HashType hashType,
                                 const OTPasswordData* pPWData = nullptr) const;
 
     EXPORT const Nym* GetContractPublicNym() const;

--- a/include/opentxs/core/Identifier.hpp
+++ b/include/opentxs/core/Identifier.hpp
@@ -39,6 +39,7 @@
 #ifndef OPENTXS_CORE_OTIDENTIFIER_HPP
 #define OPENTXS_CORE_OTIDENTIFIER_HPP
 
+#include <opentxs/core/crypto/CryptoHash.hpp>
 #include "OTData.hpp"
 
 #include <string>
@@ -63,7 +64,7 @@ private:
 public:
     EXPORT friend std::ostream& operator<<(std::ostream& os, const String& obj);
 
-    EXPORT static const String DefaultHashAlgorithm;
+    EXPORT static const CryptoHash::HashType DefaultHashAlgorithm;
     EXPORT Identifier();
 
     EXPORT Identifier(const Identifier& theID);

--- a/include/opentxs/core/Identifier.hpp
+++ b/include/opentxs/core/Identifier.hpp
@@ -58,9 +58,6 @@ class OTSymmetricKey;
 
 class Identifier : public OTData
 {
-private:
-    bool CalculateDigest(const unsigned char* data, size_t len);
-
 public:
     EXPORT friend std::ostream& operator<<(std::ostream& os, const String& obj);
 

--- a/include/opentxs/core/OTData.hpp
+++ b/include/opentxs/core/OTData.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_OTDATA_HPP
 
 #include <cstdint>
+#include <vector>
 
 namespace opentxs
 {
@@ -53,6 +54,7 @@ public:
     EXPORT OTData(const void* data, uint32_t size);
     EXPORT OTData(const OTData& source);
     EXPORT OTData(const OTASCIIArmor& source);
+    EXPORT OTData(const std::vector<unsigned char> sourceVector);
     EXPORT virtual ~OTData();
 
     EXPORT void Release();

--- a/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
+++ b/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
@@ -62,8 +62,6 @@ private:
     AsymmetricKeySecp256k1();
     virtual void ReleaseKeyLowLevel_Hook() const;
     // used by LowLevelKeyGenerator
-    bool SetKey(
-        const OTPassword& key);
     FormattedKey key_;
 
 public:

--- a/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
+++ b/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
@@ -40,6 +40,9 @@
 #define OPENTXS_CORE_CRYPTO_ASYMMETRICKEYSECP256K1_HPP
 
 #include <opentxs/core/crypto/OTAsymmetricKey.hpp>
+#include <opentxs/core/crypto/LowLevelKeyGenerator.hpp>
+
+#include <bitcoin-base58/base58.h>
 
 namespace opentxs
 {
@@ -54,9 +57,13 @@ class AsymmetricKeySecp256k1 : public OTAsymmetricKey
 private:
     typedef OTAsymmetricKey ot_super;
     friend class OTAsymmetricKey; // For the factory.
+    friend class LowLevelKeyGenerator;
 
     AsymmetricKeySecp256k1();
     virtual void ReleaseKeyLowLevel_Hook() const;
+    // used by LowLevelKeyGenerator
+    virtual bool SetKey(
+        const OTPassword& key);
 
 public:
     virtual CryptoAsymmetric& engine() const;

--- a/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
+++ b/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
@@ -79,7 +79,7 @@ public:
         const OTPassword* pImportPassword = nullptr);
     virtual bool GetPrivateKey(
         FormattedKey& strOutput,
-        const OTAsymmetricKey* pPubkey,
+        const OTAsymmetricKey* pPubkey = nullptr,
         const String* pstrReason = nullptr,
         const OTPassword* pImportPassword = nullptr) const;
     virtual bool GetPublicKey(String& strKey) const;

--- a/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
+++ b/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
@@ -39,6 +39,7 @@
 #ifndef OPENTXS_CORE_CRYPTO_ASYMMETRICKEYSECP256K1_HPP
 #define OPENTXS_CORE_CRYPTO_ASYMMETRICKEYSECP256K1_HPP
 
+#include <opentxs/core/FormattedKey.hpp>
 #include <opentxs/core/crypto/OTAsymmetricKey.hpp>
 #include <opentxs/core/crypto/LowLevelKeyGenerator.hpp>
 
@@ -50,7 +51,6 @@ namespace opentxs
 class OTCaller;
 class OTPassword;
 class String;
-class FormattedKey;
 
 class AsymmetricKeySecp256k1 : public OTAsymmetricKey
 {
@@ -62,8 +62,9 @@ private:
     AsymmetricKeySecp256k1();
     virtual void ReleaseKeyLowLevel_Hook() const;
     // used by LowLevelKeyGenerator
-    virtual bool SetKey(
+    bool SetKey(
         const OTPassword& key);
+    FormattedKey key_;
 
 public:
     virtual CryptoAsymmetric& engine() const;

--- a/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
+++ b/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
@@ -36,11 +36,10 @@
  *
  ************************************************************/
 
-#ifndef OPENTXS_CORE_CRYPTO_OTASYMMETRICKEYOPENSSL_HPP
-#define OPENTXS_CORE_CRYPTO_OTASYMMETRICKEYOPENSSL_HPP
+#ifndef OPENTXS_CORE_CRYPTO_ASYMMETRICKEYSECP256K1_HPP
+#define OPENTXS_CORE_CRYPTO_ASYMMETRICKEYSECP256K1_HPP
 
 #include <opentxs/core/crypto/OTAsymmetricKey.hpp>
-#include <opentxs/core/crypto/OTASCIIArmor.hpp>
 
 namespace opentxs
 {
@@ -50,59 +49,18 @@ class OTPassword;
 class String;
 class FormattedKey;
 
-// Todo:
-// 1. Add this value to the config file so it becomes merely a default value
-// here.
-// 2. This timer solution isn't the full solution but only a stopgap measure.
-//    See notes in ReleaseKeyLowLevel for more -- ultimate solution will involve
-//    the callback itself, and some kind of encrypted storage of hashed
-// passwords,
-//    using session keys, as well as an option to use ssh-agent and other
-// standard
-//    APIs for protected memory.
-//
-// UPDATE: Am in the process now of adding the actual Master key. Therefore
-// OT_MASTER_KEY_TIMEOUT
-// was added for the actual mechanism, while OT_KEY_TIMER (a stopgap measure)
-// was set to 0, which
-// makes it of no effect. Probably OT_KEY_TIMER will be removed entirely (we'll
-// see.)
-//
-#ifndef OT_KEY_TIMER
-
-#define OT_KEY_TIMER 30
-
-// TODO: Next release, as users get converted to file format 2.0 (master key)
-// then reduce this timer from 30 to 0. (30 is just to help them convert.)
-
-//#define OT_KEY_TIMER 0
-
-//#define OT_MASTER_KEY_TIMEOUT 300  // This is in OTEnvelope.h
-
-// FYI: 1800 seconds is 30 minutes, 300 seconds is 5 mins.
-#endif // OT_KEY_TIMER
-
-#if defined(OT_CRYPTO_USING_OPENSSL)
-
-class OTAsymmetricKey_OpenSSL : public OTAsymmetricKey
+class AsymmetricKeySecp256k1 : public OTAsymmetricKey
 {
 private:
     typedef OTAsymmetricKey ot_super;
     friend class OTAsymmetricKey; // For the factory.
-    OTASCIIArmor* m_p_ascKey = nullptr; // base64-encoded, string form of key. (Encrypted
-                              // too, for private keys. Should store it in this
-                              // form most of the time.)
+
+    AsymmetricKeySecp256k1();
+    virtual void ReleaseKeyLowLevel_Hook() const;
+
 public:
     virtual CryptoAsymmetric& engine() const;
     virtual bool IsEmpty() const;
-    // m_p_ascKey is the most basic value. m_pKey is derived from it, for
-      // example.
-    // Don't ever call this. It's only here because it's impossible to get rid of
-    // unless and until RSA key support is removed entirely.
-    bool SaveCertToString(
-        String& strOutput, const String* pstrReason = nullptr,
-        const OTPassword* pImportPassword = nullptr) const;
-
     virtual bool SetPrivateKey(
         const FormattedKey& strCert,
         const String* pstrReason = nullptr,
@@ -116,36 +74,18 @@ public:
         const OTAsymmetricKey* pPubkey,
         const String* pstrReason = nullptr,
         const OTPassword* pImportPassword = nullptr) const;
-
     virtual bool GetPublicKey(String& strKey) const;
     virtual bool GetPublicKey(FormattedKey& strKey) const;
     virtual bool SetPublicKey(const String& strKey);
     virtual bool SetPublicKey(const FormattedKey& strKey);
-
     virtual bool ReEncryptPrivateKey(const OTPassword& theExportPassword,
                                      bool bImporting) const;
-
-    class OTAsymmetricKey_OpenSSLPrivdp;
-    OTAsymmetricKey_OpenSSLPrivdp* dp;
-
-protected: // CONSTRUCTOR
-    OTAsymmetricKey_OpenSSL();
-
-public: // DERSTRUCTION
-    virtual ~OTAsymmetricKey_OpenSSL();
+    void Release_AsymmetricKeySecp256k1();
     virtual void Release();
-    void Release_AsymmetricKey_OpenSSL();
+    virtual ~AsymmetricKeySecp256k1();
 
-protected:
-    virtual void ReleaseKeyLowLevel_Hook() const;
 };
-
-#elif defined(OT_CRYPTO_USING_GPG)
-
-#else // NO CRYPTO ENGINE DEFINED?
-
-#endif
 
 } // namespace opentxs
 
-#endif // OPENTXS_CORE_CRYPTO_OTASYMMETRICKEYOPENSSL_HPP
+#endif // OPENTXS_CORE_CRYPTO_ASYMMETRICKEYSECP256K1_HPP

--- a/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
+++ b/include/opentxs/core/crypto/AsymmetricKeySecp256k1.hpp
@@ -43,8 +43,6 @@
 #include <opentxs/core/crypto/OTAsymmetricKey.hpp>
 #include <opentxs/core/crypto/LowLevelKeyGenerator.hpp>
 
-#include <bitcoin-base58/base58.h>
-
 namespace opentxs
 {
 

--- a/include/opentxs/core/crypto/Credential.hpp
+++ b/include/opentxs/core/crypto/Credential.hpp
@@ -87,7 +87,8 @@ public:
     enum CredentialType: int32_t {
         ERROR_TYPE,
         RSA_PUBKEY,
-        URL
+        URL,
+        SECP256K1_PUBKEY
     };
 
     static String CredentialTypeToString(CredentialType credentialType);

--- a/include/opentxs/core/crypto/Credential.hpp
+++ b/include/opentxs/core/crypto/Credential.hpp
@@ -86,9 +86,9 @@ class Credential : public Contract
 public:
     enum CredentialType: int32_t {
         ERROR_TYPE,
-        RSA_PUBKEY,
+        LEGACY,
         URL,
-        SECP256K1_PUBKEY
+        SECP256K1
     };
 
     static String CredentialTypeToString(CredentialType credentialType);

--- a/include/opentxs/core/crypto/Crypto.hpp
+++ b/include/opentxs/core/crypto/Crypto.hpp
@@ -78,18 +78,16 @@ public:
 
 class Crypto
 {
-private:
-    static int32_t s_nCount; // Instance count, should never exceed 1.
 protected:
     Crypto() = default;
 
-    virtual void Init_Override() const;
-    virtual void Cleanup_Override() const;
+    virtual void Init_Override() const=0;
+    virtual void Cleanup_Override() const=0;
 
 public:
     virtual ~Crypto() = default;
-    virtual void Init() const;
-    virtual void Cleanup() const;
+    void Init() const;
+    void Cleanup() const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/CryptoAsymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoAsymmetric.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_CRYPTO_CRYPTOASYMMETRIC_HPP
 
 #include <opentxs/core/String.hpp>
+#include <opentxs/core/crypto/CryptoHash.hpp>
 #include <set>
 
 namespace opentxs
@@ -66,11 +67,13 @@ public:
     virtual bool SignContract(const String& strContractUnsigned,
                               const OTAsymmetricKey& theKey,
                               OTSignature& theSignature, // output
-                              const String& strHashType,
+                              const CryptoHash::HashType hashType,
                               const OTPasswordData* pPWData = nullptr) = 0;
     virtual bool VerifySignature(
-        const String& strContractToVerify, const OTAsymmetricKey& theKey,
-        const OTSignature& theSignature, const String& strHashType,
+        const String& strContractToVerify,
+        const OTAsymmetricKey& theKey,
+        const OTSignature& theSignature,
+        const CryptoHash::HashType hashType,
         const OTPasswordData* pPWData = nullptr) const = 0;
 };
 

--- a/include/opentxs/core/crypto/CryptoAsymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoAsymmetric.hpp
@@ -59,11 +59,6 @@ class CryptoAsymmetric
 
 public:
 
-    virtual bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
-                      OTData& dataOutput) const = 0;
-    virtual bool Open(OTData& dataInput, const Nym& theRecipient,
-                      String& theOutput,
-                      const OTPasswordData* pPWData = nullptr) const = 0;
     virtual bool SignContract(const String& strContractUnsigned,
                               const OTAsymmetricKey& theKey,
                               OTSignature& theSignature, // output

--- a/include/opentxs/core/crypto/CryptoEngine.hpp
+++ b/include/opentxs/core/crypto/CryptoEngine.hpp
@@ -45,8 +45,12 @@
 
 #ifdef OT_CRYPTO_USING_OPENSSL
 #include <opentxs/core/crypto/OpenSSL.hpp>
-#else // Apparently NO crypto engine is defined!
+#else //No SSL library defined
 // Perhaps error out here...
+#endif
+
+#ifdef OT_CRYPTO_USING_LIBSECP256K1
+#include <opentxs/core/crypto/Libsecp256k1.hpp>
 #endif
 
 namespace opentxs
@@ -55,8 +59,12 @@ namespace opentxs
 // Choose your OpenSSL-compatible library here.
 #ifdef OT_CRYPTO_USING_OPENSSL
 typedef OpenSSL SSLImplementation;
-#else // Apparently NO crypto engine is defined!
+#else //No SSL library defined
 // Perhaps error out here...
+#endif
+
+#if defined OT_CRYPTO_USING_LIBSECP256K1
+typedef Libsecp256k1 secp256k1;
 #endif
 
 //Singlton class for providing an interface to external crypto libraries
@@ -69,6 +77,10 @@ private:
     CryptoEngine& operator=(CryptoEngine const&) = delete;
     void Init();
     SSLImplementation* pSSL_ = nullptr;
+#ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
+    secp256k1* psecp256k1_;
+#endif
+
     static CryptoEngine* pInstance_;
 
 public:

--- a/include/opentxs/core/crypto/CryptoEngine.hpp
+++ b/include/opentxs/core/crypto/CryptoEngine.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_CRYPTO_CRYPTOENGINE_HPP
 
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
+#include <opentxs/core/crypto/CryptoHash.hpp>
 #include <opentxs/core/crypto/CryptoSymmetric.hpp>
 #include <opentxs/core/crypto/CryptoUtil.hpp>
 
@@ -86,6 +87,8 @@ private:
 public:
     //Utility class for misc OpenSSL-provided functions
     EXPORT CryptoUtil& Util();
+    //Hash function interface
+    EXPORT CryptoHash& Hash();
     //Asymmetric encryption engines
 #ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
     EXPORT CryptoAsymmetric& RSA();

--- a/include/opentxs/core/crypto/CryptoEngine.hpp
+++ b/include/opentxs/core/crypto/CryptoEngine.hpp
@@ -90,6 +90,9 @@ public:
 #ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
     EXPORT CryptoAsymmetric& RSA();
 #endif
+#ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
+    EXPORT CryptoAsymmetric& SECP256K1();
+#endif
     //Symmetric encryption engines
 #ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
     EXPORT CryptoSymmetric& AES();

--- a/include/opentxs/core/crypto/CryptoEngine.hpp
+++ b/include/opentxs/core/crypto/CryptoEngine.hpp
@@ -78,7 +78,7 @@ private:
     void Init();
     SSLImplementation* pSSL_ = nullptr;
 #ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
-    secp256k1* psecp256k1_;
+    secp256k1* psecp256k1_ = nullptr;
 #endif
 
     static CryptoEngine* pInstance_;

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -54,6 +54,7 @@ public:
     enum HashType {
       ERROR,
       HASH256,
+      HASH160,
       SHA1,
       SHA224,
       SHA256,

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -83,8 +83,8 @@ public:
         const String& inputData,
         OTPassword& outputDigest) const;
 
-    static HashType StringToHashType(String& inputString);
-    static String HashTypeToString(HashType hashType);
+    static HashType StringToHashType(const String& inputString);
+    static String HashTypeToString(const HashType hashType);
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -65,7 +65,7 @@ public:
     virtual bool Hash(
         const HashType hashType,
         const OTData& data,
-        String& digest) const = 0;
+        OTData& digest) const = 0;
 
     static HashType StringToHashType(String& inputString);
     static String HashTypeToString(HashType hashType);

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -67,6 +67,10 @@ public:
         const HashType hashType,
         const OTData& data,
         OTData& digest) const = 0;
+    bool Hash(
+        const HashType hashType,
+        const String& data,
+        OTData& digest);
 
     static HashType StringToHashType(String& inputString);
     static String HashTypeToString(HashType hashType);

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -54,6 +54,7 @@ protected:
 public:
     enum HashType {
       ERROR,
+      NONE,
       HASH256,
       HASH160,
       SHA1,

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -1,0 +1,75 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CRYPTO_CRYPTOHASH_HPP
+#define OPENTXS_CORE_CRYPTO_CRYPTOHASH_HPP
+
+namespace opentxs
+{
+
+class OTData;
+class String;
+
+class CryptoHash
+{
+protected:
+    CryptoHash() = default;
+
+public:
+    enum HashType {
+      ERROR,
+      SHA1,
+      SHA224,
+      SHA256,
+      SHA384,
+      SHA512
+    };
+
+    virtual ~CryptoHash() = default;
+    virtual bool Hash(
+        const HashType hashType,
+        const OTData& data,
+        String& digest) const = 0;
+
+    static HashType StringToHashType(String& inputString);
+    static String HashTypeToString(HashType hashType);
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CRYPTO_CRYPTOHASH_HPP

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -67,8 +67,8 @@ public:
     virtual ~CryptoHash() = default;
     virtual bool Digest(
         const HashType hashType,
-        const OTData& data,
-        OTData& digest) const = 0;
+        const OTPassword& data,
+        OTPassword& digest) const = 0;
     virtual bool HMAC(
         const CryptoHash::HashType hashType,
         const OTPassword& inputKey,
@@ -77,6 +77,10 @@ public:
     bool Digest(
         const HashType hashType,
         const String& data,
+        OTData& digest);
+    bool Digest(
+        const HashType hashType,
+        const OTData& data,
         OTData& digest);
     bool HMAC(
         const CryptoHash::HashType hashType,

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -67,6 +67,26 @@ public:
         const HashType hashType,
         const OTData& data,
         OTData& digest) const = 0;
+    virtual bool HMAC(
+        const CryptoHash::HashType hashType,
+        const OTData& inputKey,
+        const OTData& inputData,
+        OTData& outputDigest) const = 0;
+    bool HMAC(
+        const CryptoHash::HashType hashType,
+        const String& inputKey,
+        const String& inputData,
+        OTData& outputDigest) const;
+    bool HMAC(
+        const CryptoHash::HashType hashType,
+        const OTData& inputKey,
+        const String& inputData,
+        OTData& outputDigest) const;
+    bool HMAC(
+        const CryptoHash::HashType hashType,
+        const String& inputKey,
+        const OTData& inputData,
+        OTData& outputDigest) const;
     bool Digest(
         const HashType hashType,
         const String& data,

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -63,11 +63,11 @@ public:
     };
 
     virtual ~CryptoHash() = default;
-    virtual bool Hash(
+    virtual bool Digest(
         const HashType hashType,
         const OTData& data,
         OTData& digest) const = 0;
-    bool Hash(
+    bool Digest(
         const HashType hashType,
         const String& data,
         OTData& digest);

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -43,6 +43,7 @@ namespace opentxs
 {
 
 class OTData;
+class OTPassword;
 class String;
 
 class CryptoHash
@@ -69,28 +70,18 @@ public:
         OTData& digest) const = 0;
     virtual bool HMAC(
         const CryptoHash::HashType hashType,
-        const OTData& inputKey,
+        const OTPassword& inputKey,
         const OTData& inputData,
-        OTData& outputDigest) const = 0;
-    bool HMAC(
-        const CryptoHash::HashType hashType,
-        const String& inputKey,
-        const String& inputData,
-        OTData& outputDigest) const;
-    bool HMAC(
-        const CryptoHash::HashType hashType,
-        const OTData& inputKey,
-        const String& inputData,
-        OTData& outputDigest) const;
-    bool HMAC(
-        const CryptoHash::HashType hashType,
-        const String& inputKey,
-        const OTData& inputData,
-        OTData& outputDigest) const;
+        OTPassword& outputDigest) const = 0;
     bool Digest(
         const HashType hashType,
         const String& data,
         OTData& digest);
+    bool HMAC(
+        const CryptoHash::HashType hashType,
+        const OTPassword& inputKey,
+        const String& inputData,
+        OTPassword& outputDigest) const;
 
     static HashType StringToHashType(String& inputString);
     static String HashTypeToString(HashType hashType);

--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -53,6 +53,7 @@ protected:
 public:
     enum HashType {
       ERROR,
+      HASH256,
       SHA1,
       SHA224,
       SHA256,

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -42,6 +42,7 @@
 #include <opentxs/core/OTData.hpp>
 #include <opentxs/core/String.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
+#include <opentxs/core/crypto/OTEnvelope.hpp>
 #include <opentxs/core/util/Assert.hpp>
 
 #include <memory>
@@ -55,6 +56,7 @@ class OTPassword;
 class OTPasswordData;
 class OTData;
 
+typedef std::tuple<String, String, String, String, OTEnvelope> symmetricEnvelope;
 typedef std::shared_ptr<OTPassword> BinarySecret;
 // Sometimes I want to decrypt into an OTPassword (for encrypted symmetric
 // keys being decrypted) and sometimes I want to decrypt into an OTData
@@ -105,6 +107,10 @@ public:
 
     static Mode StringToMode(const String& Mode);
 
+    static uint32_t KeySize(const Mode Mode);
+    static uint32_t IVSize(const Mode Mode);
+    static uint32_t TagSize(const Mode Mode);
+
     // InstantiateBinarySecret
     // (To instantiate a text secret, just do this: OTPassword thePass;)
     //
@@ -151,13 +157,26 @@ public:
                              // passed in.)
         OTData& theEncryptedOutput) const = 0; // OUTPUT. (Ciphertext.)
     virtual bool Encrypt(
-        const OTPassword& theRawSymmetricKey,
-        const Mode cipher,
-        const char* szInput,
-        uint32_t lInputLength,
-        OTData& theEncryptedOutput,
-        const OTData* theIV = nullptr,  // For some cipher modes, IV is optional
-        OTData* tag = nullptr) const = 0; // Only used for AEAD
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const char* plaintext,
+        uint32_t plaintextLength,
+        OTData& ciphertext) const = 0;
+    virtual bool Encrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const char* plaintext,
+        uint32_t plaintextLength,
+        OTData& ciphertext) const = 0;
+    virtual bool Encrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const char* plaintext,
+        uint32_t plaintextLength,
+        OTData& ciphertext,
+        OTData& tag) const = 0;
 
     virtual bool Decrypt(const OTPassword& theRawSymmetricKey, // The symmetric
                                                                // key, in clear
@@ -171,13 +190,26 @@ public:
         const = 0; // OUTPUT. (Recovered plaintext.) You can pass OTPassword& OR
                    // OTData& here (either will work.)
     virtual bool Decrypt(
-        const OTPassword& theRawSymmetricKey,
-        const Mode cipher,
-        const char* szInput,
-        uint32_t lInputLength,
-        CryptoSymmetricDecryptOutput theDecryptedOutput,
-        const OTData* theIV = nullptr,  // For some cipher modes, IV is optional
-        const OTData* tag = nullptr) const = 0; // Only used for AEAD
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const char* ciphertext,
+        uint32_t ciphertextLength,
+        CryptoSymmetricDecryptOutput plaintext) const = 0;
+    virtual bool Decrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const char* ciphertext,
+        uint32_t ciphertextLength,
+        CryptoSymmetricDecryptOutput plaintext) const = 0;
+    virtual bool Decrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const OTData& tag,
+        const char* ciphertext,
+        const uint32_t ciphertextLength,
+        CryptoSymmetricDecryptOutput plaintext) const = 0;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -96,6 +96,7 @@ public:
     // (To instantiate a text secret, just do this: OTPassword thePass;)
     //
     virtual OTPassword* InstantiateBinarySecret() const = 0;
+    virtual BinarySecret InstantiateBinarySecretSP() const = 0;
     // KEY DERIVATION
     //
     // DeriveNewKey derives a 128-bit symmetric key from a passphrase.

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_CRYPTO_CRYPTOSYMMETRIC_HPP
 
 #include <opentxs/core/OTData.hpp>
+#include <opentxs/core/String.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
 #include <opentxs/core/util/Assert.hpp>
 
@@ -92,6 +93,18 @@ public:
 class CryptoSymmetric
 {
 public:
+    enum Mode: int32_t {
+        ERROR_MODE,
+        AES_128_CBC,
+        AES_256_ECB,
+        AES_128_GCM,
+        AES_256_GCM
+    };
+
+    static String ModeToString(const Mode Mode);
+
+    static Mode StringToMode(const String& Mode);
+
     // InstantiateBinarySecret
     // (To instantiate a text secret, just do this: OTPassword thePass;)
     //
@@ -137,6 +150,14 @@ public:
         const OTData& theIV, // (We assume this IV is already generated and
                              // passed in.)
         OTData& theEncryptedOutput) const = 0; // OUTPUT. (Ciphertext.)
+    virtual bool Encrypt(
+        const OTPassword& theRawSymmetricKey,
+        const Mode cipher,
+        const char* szInput,
+        uint32_t lInputLength,
+        OTData& theEncryptedOutput,
+        const OTData* theIV = nullptr,  // For some cipher modes, IV is optional
+        OTData* tag = nullptr) const = 0; // Only used for AEAD
 
     virtual bool Decrypt(const OTPassword& theRawSymmetricKey, // The symmetric
                                                                // key, in clear
@@ -149,6 +170,14 @@ public:
                          CryptoSymmetricDecryptOutput theDecryptedOutput)
         const = 0; // OUTPUT. (Recovered plaintext.) You can pass OTPassword& OR
                    // OTData& here (either will work.)
+    virtual bool Decrypt(
+        const OTPassword& theRawSymmetricKey,
+        const Mode cipher,
+        const char* szInput,
+        uint32_t lInputLength,
+        CryptoSymmetricDecryptOutput theDecryptedOutput,
+        const OTData* theIV = nullptr,  // For some cipher modes, IV is optional
+        const OTData* tag = nullptr) const = 0; // Only used for AEAD
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -47,6 +47,7 @@
 
 #include <memory>
 #include <mutex>
+#include <tuple>
 
 namespace opentxs
 {
@@ -56,7 +57,7 @@ class OTPassword;
 class OTPasswordData;
 class OTData;
 
-typedef std::tuple<String, String, String, String, OTEnvelope> symmetricEnvelope;
+typedef std::tuple<String, String, String, String, std::shared_ptr<OTEnvelope> > symmetricEnvelope;
 typedef std::shared_ptr<OTPassword> BinarySecret;
 // Sometimes I want to decrypt into an OTPassword (for encrypted symmetric
 // keys being decrypted) and sometimes I want to decrypt into an OTData

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -40,8 +40,10 @@
 #define OPENTXS_CORE_CRYPTO_CRYPTOSYMMETRIC_HPP
 
 #include <opentxs/core/OTData.hpp>
+#include <opentxs/core/crypto/OTPassword.hpp>
 #include <opentxs/core/util/Assert.hpp>
 
+#include <memory>
 #include <mutex>
 
 namespace opentxs
@@ -52,6 +54,7 @@ class OTPassword;
 class OTPasswordData;
 class OTData;
 
+typedef std::shared_ptr<OTPassword> BinarySecret;
 // Sometimes I want to decrypt into an OTPassword (for encrypted symmetric
 // keys being decrypted) and sometimes I want to decrypt into an OTData
 // (For most other types of data.) This class allows me to do it either way

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -212,7 +212,7 @@ public:
         const uint32_t ciphertextLength,
         CryptoSymmetricDecryptOutput plaintext) const = 0;
 
-    EXPORT static BinarySecret GetMasterKey(const OTPasswordData& passwordData, bool askTwice = false);
+        EXPORT static BinarySecret GetMasterKey(const OTPasswordData& passwordData, const bool askTwice = false);
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -211,6 +211,8 @@ public:
         const char* ciphertext,
         const uint32_t ciphertextLength,
         CryptoSymmetricDecryptOutput plaintext) const = 0;
+
+    EXPORT static BinarySecret GetMasterKey(const OTPasswordData& passwordData, bool askTwice = false);
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/CryptoUtil.hpp
+++ b/include/opentxs/core/crypto/CryptoUtil.hpp
@@ -45,6 +45,7 @@ namespace opentxs
 {
 
 class Identifier;
+class OTData;
 class OTPassword;
 
 class CryptoUtil
@@ -75,6 +76,8 @@ public:
                                bool bLineBreaks) const = 0;
     virtual uint8_t* Base64Decode(const char* input, size_t* out_len,
                                   bool bLineBreaks) const = 0;
+    String Nonce(const uint32_t size) const;
+    String Nonce(const uint32_t size, OTData& rawOutput) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/CryptoUtil.hpp
+++ b/include/opentxs/core/crypto/CryptoUtil.hpp
@@ -78,6 +78,11 @@ public:
                                   bool bLineBreaks) const = 0;
     String Nonce(const uint32_t size) const;
     String Nonce(const uint32_t size, OTData& rawOutput) const;
+
+    static String Base58CheckEncode(const OTPassword& input);
+    static String Base58CheckEncode(const OTData& input);
+    static bool Base58CheckDecode(const String& input, OTData& output);
+    static bool Base58CheckDecode(const String& input, OTPassword& output);
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Letter.hpp
+++ b/include/opentxs/core/crypto/Letter.hpp
@@ -45,7 +45,12 @@
 #include <opentxs/core/crypto/OTEnvelope.hpp>
 
 namespace opentxs
+
 {
+
+class Nym;
+class OTData;
+class OTPasswordData;
 
 typedef std::map<String, OTEnvelope> mapOfSessionKeys;
 
@@ -78,6 +83,16 @@ public:
     void Release_Letter();
     virtual void Release();
     virtual void UpdateContents();
+
+    static bool Seal(
+        const mapOfAsymmetricKeys& RecipPubKeys,
+        const String& theInput,
+        OTData& dataOutput);
+    static bool Open(
+        const OTData& dataInput,
+        const Nym& theRecipient,
+        String& theOutput,
+        const OTPasswordData* pPWData = nullptr);
 
     const String& EphemeralKey() const;
     const String& IV() const;

--- a/include/opentxs/core/crypto/Letter.hpp
+++ b/include/opentxs/core/crypto/Letter.hpp
@@ -42,9 +42,12 @@
 #include <opentxs/core/Contract.hpp>
 #include <opentxs/core/String.hpp>
 #include <opentxs/core/crypto/OTASCIIArmor.hpp>
+#include <opentxs/core/crypto/OTEnvelope.hpp>
 
 namespace opentxs
 {
+
+typedef std::map<String, OTEnvelope> mapOfSessionKeys;
 
 // A letter is a contract that contains the contents of an OTEnvelope
 // along with some necessary metadata.
@@ -55,9 +58,9 @@ private: // Private prevents erroneous use by other classes.
     typedef Contract ot_super;
     String ephemeralKey_;
     String macType_;
-    String nonce_;
-    String sessionKey_;
+    String iv_;
     OTASCIIArmor ciphertext_;
+    mapOfSessionKeys sessionKeys_;
     Letter() = delete;
 
 protected:
@@ -67,9 +70,9 @@ public:
     Letter(
         const String& ephemeralKey,
         const String& macType,
-        const String& nonce,
-        const String& sessionKey,
-        const OTASCIIArmor& ciphertext);
+        const String& iv,
+        const OTASCIIArmor& ciphertext,
+        const mapOfSessionKeys& sessionKeys);
     Letter(const String& input);
     virtual ~Letter();
     void Release_Letter();
@@ -77,9 +80,9 @@ public:
     virtual void UpdateContents();
 
     const String& EphemeralKey() const;
-    const String& Nonce() const;
+    const String& IV() const;
     const String& MACType() const;
-    const String& SessionKey() const;
+    const mapOfSessionKeys& SessionKeys() const;
     const OTASCIIArmor& Ciphertext() const;
 };
 

--- a/include/opentxs/core/crypto/Letter.hpp
+++ b/include/opentxs/core/crypto/Letter.hpp
@@ -71,6 +71,7 @@ private: // Private prevents erroneous use by other classes.
     String ephemeralKey_;
     String iv_;
     String tag_;
+    String plaintextMode_;
     OTASCIIArmor ciphertext_;
     listOfSessionKeys sessionKeys_;
     Letter() = delete;
@@ -83,6 +84,7 @@ public:
         const String& ephemeralKey,
         const String& iv,
         const String& tag,
+        const String& mode,
         const OTASCIIArmor& ciphertext,
         const listOfSessionKeys& sessionKeys);
     Letter(const String& input);
@@ -104,6 +106,7 @@ public:
     const String& EphemeralKey() const;
     const String& IV() const;
     const String& AEADTag() const;
+    CryptoSymmetric::Mode Mode() const;
     const listOfSessionKeys& SessionKeys() const;
     const OTASCIIArmor& Ciphertext() const;
 };

--- a/include/opentxs/core/crypto/Letter.hpp
+++ b/include/opentxs/core/crypto/Letter.hpp
@@ -1,0 +1,86 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CRYPTO_LETTER_HPP
+#define OPENTXS_CORE_CRYPTO_LETTER_HPP
+
+#include <opentxs/core/Contract.hpp>
+#include <opentxs/core/String.hpp>
+#include <opentxs/core/crypto/OTASCIIArmor.hpp>
+
+namespace opentxs
+{
+
+// A letter is a contract that contains the contents of an OTEnvelope
+// along with some necessary metadata.
+// Currently only used for the secp256k1 version of Seal() and Open()
+class Letter : public Contract
+{
+private: // Private prevents erroneous use by other classes.
+    typedef Contract ot_super;
+    String ephemeralKey_;
+    String macType_;
+    String nonce_;
+    String sessionKey_;
+    OTASCIIArmor ciphertext_;
+    Letter() = delete;
+
+protected:
+    virtual int32_t ProcessXMLNode(irr::io::IrrXMLReader*& xml);
+
+public:
+    Letter(
+        const String& ephemeralKey,
+        const String& macType,
+        const String& nonce,
+        const String& sessionKey,
+        const OTASCIIArmor& ciphertext);
+    Letter(const String& input);
+    virtual ~Letter();
+    void Release_Letter();
+    virtual void Release();
+    virtual void UpdateContents();
+
+    const String& Nonce() const;
+    const String& SessionKey() const;
+    const OTASCIIArmor& Ciphertext() const;
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CRYPTO_LETTER_HPP

--- a/include/opentxs/core/crypto/Letter.hpp
+++ b/include/opentxs/core/crypto/Letter.hpp
@@ -76,7 +76,9 @@ public:
     virtual void Release();
     virtual void UpdateContents();
 
+    const String& EphemeralKey() const;
     const String& Nonce() const;
+    const String& MACType() const;
     const String& SessionKey() const;
     const OTASCIIArmor& Ciphertext() const;
 };

--- a/include/opentxs/core/crypto/Letter.hpp
+++ b/include/opentxs/core/crypto/Letter.hpp
@@ -41,8 +41,12 @@
 
 #include <opentxs/core/Contract.hpp>
 #include <opentxs/core/String.hpp>
+#include <opentxs/core/crypto/CryptoSymmetric.hpp>
 #include <opentxs/core/crypto/OTASCIIArmor.hpp>
 #include <opentxs/core/crypto/OTEnvelope.hpp>
+
+#include <list>
+#include <tuple>
 
 namespace opentxs
 
@@ -52,7 +56,7 @@ class Nym;
 class OTData;
 class OTPasswordData;
 
-typedef std::map<String, OTEnvelope> mapOfSessionKeys;
+typedef std::list<symmetricEnvelope> listOfSessionKeys;
 
 // A letter is a contract that contains the contents of an OTEnvelope
 // along with some necessary metadata.
@@ -61,11 +65,14 @@ class Letter : public Contract
 {
 private: // Private prevents erroneous use by other classes.
     typedef Contract ot_super;
+    static const CryptoSymmetric::Mode defaultPlaintextMode_ = CryptoSymmetric::AES_256_GCM;
+    static const CryptoSymmetric::Mode defaultSessionKeyMode_ = CryptoSymmetric::AES_256_GCM;
+    static const CryptoHash::HashType defaultHMAC_ = CryptoHash::SHA256;
     String ephemeralKey_;
-    String macType_;
     String iv_;
+    String tag_;
     OTASCIIArmor ciphertext_;
-    mapOfSessionKeys sessionKeys_;
+    listOfSessionKeys sessionKeys_;
     Letter() = delete;
 
 protected:
@@ -74,10 +81,10 @@ protected:
 public:
     Letter(
         const String& ephemeralKey,
-        const String& macType,
         const String& iv,
+        const String& tag,
         const OTASCIIArmor& ciphertext,
-        const mapOfSessionKeys& sessionKeys);
+        const listOfSessionKeys& sessionKeys);
     Letter(const String& input);
     virtual ~Letter();
     void Release_Letter();
@@ -96,8 +103,8 @@ public:
 
     const String& EphemeralKey() const;
     const String& IV() const;
-    const String& MACType() const;
-    const mapOfSessionKeys& SessionKeys() const;
+    const String& AEADTag() const;
+    const listOfSessionKeys& SessionKeys() const;
     const OTASCIIArmor& Ciphertext() const;
 };
 

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -64,13 +64,15 @@ private:
     Libsecp256k1() = delete;
     secp256k1_context_t* context_ = nullptr;
 
+    CryptoUtil& ssl_;
+
 protected:
     Libsecp256k1(CryptoUtil& ssl);
-    void Init_Override() const;
-    void Cleanup_Override() const;
+    virtual void Init_Override() const;
+    virtual void Cleanup_Override() const;
 
 public:
-    ~Libsecp256k1();
+    virtual ~Libsecp256k1();
     bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
                       OTData& dataOutput) const;
     bool Open(OTData& dataInput, const Nym& theRecipient,

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -98,6 +98,9 @@ public:
     bool secp256k1_pubkey_serialize(
         OTPassword& serializedPubkey,
         const secp256k1_pubkey_t& pubkey) const;
+    bool secp256k1_pubkey_parse(
+        secp256k1_pubkey_t& pubkey,
+        const OTPassword& serializedPubkey) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -79,14 +79,17 @@ public:
     bool Open(OTData& dataInput, const Nym& theRecipient,
                       String& theOutput,
                       const OTPasswordData* pPWData = nullptr) const;
-    bool SignContract(const String& strContractUnsigned,
-                              const OTAsymmetricKey& theKey,
-                              OTSignature& theSignature, // output
-                              const String& strHashType,
-                              const OTPasswordData* pPWData = nullptr);
+    bool SignContract(
+        const String& strContractUnsigned,
+        const OTAsymmetricKey& theKey,
+        OTSignature& theSignature, // output
+        const CryptoHash::HashType hashType,
+        const OTPasswordData* pPWData = nullptr);
     bool VerifySignature(
-        const String& strContractToVerify, const OTAsymmetricKey& theKey,
-        const OTSignature& theSignature, const String& strHashType,
+        const String& strContractToVerify,
+        const OTAsymmetricKey& theKey,
+        const OTSignature& theSignature,
+        const CryptoHash::HashType hashType,
         const OTPasswordData* pPWData = nullptr) const;
 
     bool secp256k1_privkey_tweak_add(

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -136,7 +136,7 @@ public:
     bool ECDH(
         const OTAsymmetricKey& publicKey,
         const OTAsymmetricKey& privateKey,
-        const OTPasswordData passwordData,
+        const OTPasswordData& passwordData,
         OTPassword& secret,
         bool ephemeral = false) const;
     bool EncryptSessionKeyECDH(
@@ -150,7 +150,7 @@ public:
         const symmetricEnvelope& encryptedSessionKey,
         const OTAsymmetricKey& privateKey,
         const OTAsymmetricKey& publicKey,
-        const OTPasswordData passwordData,
+        const OTPasswordData& passwordData,
         OTPassword& sessionKey) const;
 
     bool secp256k1_privkey_tweak_add(

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -66,7 +66,6 @@ private:
     secp256k1_context_t* context_ = nullptr;
 
     CryptoUtil& ssl_;
-
 protected:
     Libsecp256k1(CryptoUtil& ssl);
     virtual void Init_Override() const;
@@ -74,6 +73,8 @@ protected:
 
 public:
     virtual ~Libsecp256k1();
+
+    EXPORT static const int PrivateKeySize = 32;
     bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
                       OTData& dataOutput) const;
     bool Open(OTData& dataInput, const Nym& theRecipient,
@@ -92,14 +93,33 @@ public:
         const CryptoHash::HashType hashType,
         const OTPasswordData* pPWData = nullptr) const;
 
+    bool OTSignatureToECDSASignature(
+        const OTSignature& inSignature,
+        secp256k1_ecdsa_signature_t& outSignature) const;
+    bool ECDSASignatureToOTSignature(
+        const secp256k1_ecdsa_signature_t& inSignature,
+        OTSignature& outSignature) const;
+    bool AsymmetricKeyToECDSAPubkey(
+        const OTAsymmetricKey& asymmetricKey,
+        secp256k1_pubkey_t& pubkey) const;
+    bool ECDSAPubkeyToAsymmetricKey(
+        const secp256k1_pubkey_t& pubkey,
+        OTAsymmetricKey& asymmetricKey) const;
+    bool AsymmetricKeyToECDSAPrivkey(
+        const OTAsymmetricKey& asymmetricKey,
+        OTPassword& privkey) const;
+    bool ECDSAPrivkeyToAsymmetricKey(
+        const OTPassword& privkey,
+        OTAsymmetricKey& asymmetricKey) const;
+
     bool secp256k1_privkey_tweak_add(
-        uint8_t key [32],
-        const uint8_t tweak [32]) const;
+        uint8_t key [PrivateKeySize],
+        const uint8_t tweak [PrivateKeySize]) const;
     bool secp256k1_pubkey_create(
         secp256k1_pubkey_t& pubkey,
         const OTPassword& privkey) const;
     bool secp256k1_pubkey_serialize(
-        OTPassword& serializedPubkey,
+        OTData& serializedPubkey,
         const secp256k1_pubkey_t& pubkey) const;
     bool secp256k1_pubkey_parse(
         secp256k1_pubkey_t& pubkey,

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -36,76 +36,34 @@
  *
  ************************************************************/
 
-#include <opentxs/core/crypto/CryptoEngine.hpp>
+#ifndef OPENTXS_CORE_CRYPTO_LIBSECP256K1_HPP
+#define OPENTXS_CORE_CRYPTO_LIBSECP256K1_HPP
+
+#include <opentxs/core/crypto/Crypto.hpp>
+
+extern "C" {
+#include "secp256k1.h"
+}
 
 namespace opentxs
 {
 
-CryptoEngine* CryptoEngine::pInstance_ = nullptr;
-
-CryptoEngine::CryptoEngine()
-    : pSSL_(new SSLImplementation)
-#ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
-    , psecp256k1_ (new secp256k1)
-#endif
+class Libsecp256k1 : public Crypto
 {
-    Init();
-}
+    friend class CryptoEngine;
 
-void CryptoEngine::Init()
-{
-    pSSL_->Init();
-#if defined OT_CRYPTO_SUPPORTED_KEY_SECP256K1
-    psecp256k1_->Init();
-#endif
+private:
+    secp256k1_context_t* context_ = nullptr;
 
-}
+protected:
+    Libsecp256k1();
+    void Init_Override() const;
+    void Cleanup_Override() const;
 
-CryptoUtil& CryptoEngine::Util()
-{
-    OT_ASSERT(nullptr != pSSL_);
-
-    return *pSSL_;
-}
-
-#ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
-CryptoAsymmetric& CryptoEngine::RSA()
-{
-    OT_ASSERT(nullptr != pSSL_);
-
-    return *pSSL_;
-}
-
-#endif
-#ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
-CryptoSymmetric& CryptoEngine::AES()
-{
-    OT_ASSERT(nullptr != pSSL_);
-
-    return *pSSL_;
-}
-#endif
-CryptoEngine& CryptoEngine::Instance()
-{
-    if (nullptr == pInstance_)
-    {
-        pInstance_ = new CryptoEngine;
-    }
-
-    return *pInstance_;
-}
-
-void CryptoEngine::Cleanup()
-{
-    pSSL_->Cleanup();
-#if defined OT_CRYPTO_SUPPORTED_KEY_SECP256K1
-    psecp256k1_->Cleanup();
-#endif
-}
-
-CryptoEngine::~CryptoEngine()
-{
-    Cleanup();
-}
+public:
+    ~Libsecp256k1();
+};
 
 } // namespace opentxs
+
+#endif // OPENTXS_CORE_CRYPTO_OTCRYPTO_HPP

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -41,6 +41,7 @@
 
 #include <opentxs/core/crypto/Crypto.hpp>
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
+#include <opentxs/core/crypto/OTEnvelope.hpp>
 
 extern "C" {
 #include "secp256k1.h"
@@ -121,6 +122,17 @@ public:
         const OTAsymmetricKey& publicKey,
         const OTAsymmetricKey& privateKey,
              OTPassword& secret) const;
+    bool EncryptSessionKeyECDH(
+        const OTPassword& sessionKey,
+        const OTAsymmetricKey& privateKey,
+        const OTAsymmetricKey& publicKey,
+        std::pair<String, OTEnvelope>& encryptedSessionKey) const;
+    bool DecryptSessionKeyECDH(
+        const std::pair<String, OTEnvelope>& encryptedSessionKey,
+        const CryptoHash::HashType macType,
+        const OTAsymmetricKey& privateKey,
+        const OTAsymmetricKey& publicKey,
+        OTPassword& sessionKey) const;
 
     bool secp256k1_privkey_tweak_add(
         uint8_t key [PrivateKeySize],
@@ -134,7 +146,8 @@ public:
     bool secp256k1_pubkey_parse(
         secp256k1_pubkey_t& pubkey,
         const OTPassword& serializedPubkey) const;
-    String Nonce(uint32_t size) const;
+    String Nonce(const uint32_t size) const;
+    String Nonce(const uint32_t size, OTData& rawOutput) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -119,11 +119,19 @@ public:
         const OTPasswordData& passwordData,
         OTPassword& privkey,
         bool ephemeral = false) const;
+    bool ImportECDSAPrivkey(
+        const FormattedKey& asymmetricKey,
+        const OTPassword& password,
+        OTPassword& privkey) const;
     bool ECDSAPrivkeyToAsymmetricKey(
         const OTPassword& privkey,
         const OTPasswordData& passwordData,
         OTAsymmetricKey& asymmetricKey,
         bool ephemeral = false) const;
+    bool ExportECDSAPrivkey(
+        const OTPassword& privkey,
+        const OTPassword& password,
+        OTAsymmetricKey& asymmetricKey) const;
 
     bool ECDH(
         const OTAsymmetricKey& publicKey,

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -54,16 +54,18 @@ class OTData;
 class OTPasswordData;
 class Nym;
 class OTSignature;
+class CryptoUtil;
 
 class Libsecp256k1 : public Crypto, public CryptoAsymmetric
 {
     friend class CryptoEngine;
 
 private:
+    Libsecp256k1() = delete;
     secp256k1_context_t* context_ = nullptr;
 
 protected:
-    Libsecp256k1();
+    Libsecp256k1(CryptoUtil& ssl);
     void Init_Override() const;
     void Cleanup_Override() const;
 

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -44,6 +44,7 @@
 
 extern "C" {
 #include "secp256k1.h"
+#include "secp256k1_ecdh.h"
 }
 
 namespace opentxs
@@ -112,6 +113,11 @@ public:
     bool ECDSAPrivkeyToAsymmetricKey(
         const OTPassword& privkey,
         OTAsymmetricKey& asymmetricKey) const;
+
+    bool ECDH(
+        const OTAsymmetricKey& publicKey,
+        const OTAsymmetricKey& privateKey,
+             OTPassword& secret) const;
 
     bool secp256k1_privkey_tweak_add(
         uint8_t key [PrivateKeySize],

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -68,7 +68,7 @@ class Libsecp256k1 : public Crypto, public CryptoAsymmetric
 
 private:
     Libsecp256k1() = delete;
-    secp256k1_context_t* context_ = nullptr;
+    secp256k1_context* context_ = nullptr;
 
     CryptoUtil& ssl_;
 
@@ -99,15 +99,15 @@ public:
 
     bool OTSignatureToECDSASignature(
         const OTSignature& inSignature,
-        secp256k1_ecdsa_signature_t& outSignature) const;
+        secp256k1_ecdsa_signature& outSignature) const;
     bool ECDSASignatureToOTSignature(
-        const secp256k1_ecdsa_signature_t& inSignature,
+        const secp256k1_ecdsa_signature& inSignature,
         OTSignature& outSignature) const;
     bool AsymmetricKeyToECDSAPubkey(
         const OTAsymmetricKey& asymmetricKey,
-        secp256k1_pubkey_t& pubkey) const;
+        secp256k1_pubkey& pubkey) const;
     bool ECDSAPubkeyToAsymmetricKey(
-        const secp256k1_pubkey_t& pubkey,
+        const secp256k1_pubkey& pubkey,
         OTAsymmetricKey& asymmetricKey) const;
     bool AsymmetricKeyToECDSAPrivkey(
         const OTAsymmetricKey& asymmetricKey,
@@ -157,13 +157,13 @@ public:
         uint8_t key [PrivateKeySize],
         const uint8_t tweak [PrivateKeySize]) const;
     bool secp256k1_pubkey_create(
-        secp256k1_pubkey_t& pubkey,
+        secp256k1_pubkey& pubkey,
         const OTPassword& privkey) const;
     bool secp256k1_pubkey_serialize(
         OTData& serializedPubkey,
-        const secp256k1_pubkey_t& pubkey) const;
+        const secp256k1_pubkey& pubkey) const;
     bool secp256k1_pubkey_parse(
-        secp256k1_pubkey_t& pubkey,
+        secp256k1_pubkey& pubkey,
         const OTPassword& serializedPubkey) const;
 };
 

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -87,6 +87,10 @@ public:
         const String& strContractToVerify, const OTAsymmetricKey& theKey,
         const OTSignature& theSignature, const String& strHashType,
         const OTPasswordData* pPWData = nullptr) const;
+
+    bool secp256k1_privkey_tweak_add(
+        uint8_t key [32],
+        const uint8_t tweak [32]) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -77,6 +77,9 @@ public:
     virtual ~Libsecp256k1();
 
     EXPORT static const int PrivateKeySize = 32;
+    EXPORT static const CryptoHash::HashType ECDHDefaultHMAC = CryptoHash::SHA256;
+    EXPORT static const int ECDHDefaultHMACSize = 32;
+
     bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
                       OTData& dataOutput) const;
     bool Open(OTData& dataInput, const Nym& theRecipient,

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_CRYPTO_LIBSECP256K1_HPP
 
 #include <opentxs/core/crypto/Crypto.hpp>
+#include <opentxs/core/crypto/CryptoAsymmetric.hpp>
 
 extern "C" {
 #include "secp256k1.h"
@@ -48,7 +49,13 @@ extern "C" {
 namespace opentxs
 {
 
-class Libsecp256k1 : public Crypto
+class OTAsymmetricKey;
+class OTData;
+class OTPasswordData;
+class Nym;
+class OTSignature;
+
+class Libsecp256k1 : public Crypto, public CryptoAsymmetric
 {
     friend class CryptoEngine;
 
@@ -62,6 +69,20 @@ protected:
 
 public:
     ~Libsecp256k1();
+    bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
+                      OTData& dataOutput) const;
+    bool Open(OTData& dataInput, const Nym& theRecipient,
+                      String& theOutput,
+                      const OTPasswordData* pPWData = nullptr) const;
+    bool SignContract(const String& strContractUnsigned,
+                              const OTAsymmetricKey& theKey,
+                              OTSignature& theSignature, // output
+                              const String& strHashType,
+                              const OTPasswordData* pPWData = nullptr);
+    bool VerifySignature(
+        const String& strContractToVerify, const OTAsymmetricKey& theKey,
+        const OTSignature& theSignature, const String& strHashType,
+        const OTPasswordData* pPWData = nullptr) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -51,6 +51,7 @@ namespace opentxs
 
 class OTAsymmetricKey;
 class OTData;
+class OTPassword;
 class OTPasswordData;
 class Nym;
 class OTSignature;
@@ -91,6 +92,12 @@ public:
     bool secp256k1_privkey_tweak_add(
         uint8_t key [32],
         const uint8_t tweak [32]) const;
+    bool secp256k1_pubkey_create(
+        secp256k1_pubkey_t& pubkey,
+        const OTPassword& privkey) const;
+    bool secp256k1_pubkey_serialize(
+        OTPassword& serializedPubkey,
+        const secp256k1_pubkey_t& pubkey) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -84,11 +84,6 @@ public:
     EXPORT static const CryptoHash::HashType ECDHDefaultHMAC = CryptoHash::SHA256;
     EXPORT static const CryptoSymmetric::Mode ECDHDefaultAlgo = CryptoSymmetric::AES_256_ECB;
 
-    bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
-                      OTData& dataOutput) const;
-    bool Open(OTData& dataInput, const Nym& theRecipient,
-                      String& theOutput,
-                      const OTPasswordData* pPWData = nullptr) const;
     bool SignContract(
         const String& strContractUnsigned,
         const OTAsymmetricKey& theKey,

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -41,6 +41,7 @@
 
 #include <opentxs/core/crypto/Crypto.hpp>
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
+#include <opentxs/core/crypto/CryptoSymmetric.hpp>
 #include <opentxs/core/crypto/OTEnvelope.hpp>
 
 extern "C" {
@@ -79,7 +80,7 @@ public:
 
     EXPORT static const int PrivateKeySize = 32;
     EXPORT static const CryptoHash::HashType ECDHDefaultHMAC = CryptoHash::SHA256;
-    EXPORT static const int ECDHDefaultHMACSize = 32;
+    EXPORT static const CryptoSymmetric::Mode ECDHDefaultAlgo = CryptoSymmetric::AES_256_ECB;
 
     bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
                       OTData& dataOutput) const;
@@ -126,10 +127,9 @@ public:
         const OTPassword& sessionKey,
         const OTAsymmetricKey& privateKey,
         const OTAsymmetricKey& publicKey,
-        std::pair<String, OTEnvelope>& encryptedSessionKey) const;
+        symmetricEnvelope& encryptedSessionKey) const;
     bool DecryptSessionKeyECDH(
-        const std::pair<String, OTEnvelope>& encryptedSessionKey,
-        const CryptoHash::HashType macType,
+        const symmetricEnvelope& encryptedSessionKey,
         const OTAsymmetricKey& privateKey,
         const OTAsymmetricKey& publicKey,
         OTPassword& sessionKey) const;

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -146,8 +146,6 @@ public:
     bool secp256k1_pubkey_parse(
         secp256k1_pubkey_t& pubkey,
         const OTPassword& serializedPubkey) const;
-    String Nonce(const uint32_t size) const;
-    String Nonce(const uint32_t size, OTData& rawOutput) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -43,6 +43,7 @@
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
 #include <opentxs/core/crypto/CryptoSymmetric.hpp>
 #include <opentxs/core/crypto/OTEnvelope.hpp>
+#include <opentxs/core/crypto/OTPasswordData.hpp>
 
 extern "C" {
 #include "secp256k1.h"
@@ -115,27 +116,38 @@ public:
         OTAsymmetricKey& asymmetricKey) const;
     bool AsymmetricKeyToECDSAPrivkey(
         const OTAsymmetricKey& asymmetricKey,
-        OTPassword& privkey) const;
+        const OTPasswordData& passwordData,
+        OTPassword& privkey,
+        bool ephemeral = false) const;
     bool AsymmetricKeyToECDSAPrivkey(
         const FormattedKey& asymmetricKey,
-        OTPassword& privkey) const;
+        const OTPasswordData& passwordData,
+        OTPassword& privkey,
+        bool ephemeral = false) const;
     bool ECDSAPrivkeyToAsymmetricKey(
         const OTPassword& privkey,
-        OTAsymmetricKey& asymmetricKey) const;
+        const OTPasswordData& passwordData,
+        OTAsymmetricKey& asymmetricKey,
+        bool ephemeral = false) const;
 
     bool ECDH(
         const OTAsymmetricKey& publicKey,
         const OTAsymmetricKey& privateKey,
-        OTPassword& secret) const;
+        const OTPasswordData passwordData,
+        OTPassword& secret,
+        bool ephemeral = false) const;
     bool EncryptSessionKeyECDH(
         const OTPassword& sessionKey,
         const OTAsymmetricKey& privateKey,
         const OTAsymmetricKey& publicKey,
-        symmetricEnvelope& encryptedSessionKey) const;
+        const OTPasswordData& passwordData,
+        symmetricEnvelope& encryptedSessionKey,
+        bool ephemeral = false) const;
     bool DecryptSessionKeyECDH(
         const symmetricEnvelope& encryptedSessionKey,
         const OTAsymmetricKey& privateKey,
         const OTAsymmetricKey& publicKey,
+        const OTPasswordData passwordData,
         OTPassword& sessionKey) const;
 
     bool secp256k1_privkey_tweak_add(

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -66,6 +66,7 @@ private:
     secp256k1_context_t* context_ = nullptr;
 
     CryptoUtil& ssl_;
+
 protected:
     Libsecp256k1(CryptoUtil& ssl);
     virtual void Init_Override() const;
@@ -124,6 +125,7 @@ public:
     bool secp256k1_pubkey_parse(
         secp256k1_pubkey_t& pubkey,
         const OTPassword& serializedPubkey) const;
+    String Nonce(uint32_t size) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -59,6 +59,7 @@ class OTPasswordData;
 class Nym;
 class OTSignature;
 class CryptoUtil;
+class FormattedKey;
 
 class Libsecp256k1 : public Crypto, public CryptoAsymmetric
 {
@@ -115,6 +116,9 @@ public:
     bool AsymmetricKeyToECDSAPrivkey(
         const OTAsymmetricKey& asymmetricKey,
         OTPassword& privkey) const;
+    bool AsymmetricKeyToECDSAPrivkey(
+        const FormattedKey& asymmetricKey,
+        OTPassword& privkey) const;
     bool ECDSAPrivkeyToAsymmetricKey(
         const OTPassword& privkey,
         OTAsymmetricKey& asymmetricKey) const;
@@ -122,7 +126,7 @@ public:
     bool ECDH(
         const OTAsymmetricKey& publicKey,
         const OTAsymmetricKey& privateKey,
-             OTPassword& secret) const;
+        OTPassword& secret) const;
     bool EncryptSessionKeyECDH(
         const OTPassword& sessionKey,
         const OTAsymmetricKey& privateKey,

--- a/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
+++ b/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
@@ -111,7 +111,7 @@ public:
     bool m_bCleanup = true; // By default, LowLevelKeyGenerator cleans up the members. But
                      // if you set this to false, it will NOT cleanup.
     bool MakeNewKeypair();
-    bool SetOntoKeypair(OTKeypair& theKeypair, OTPasswordData passwordData, bool ephemeral = false);
+    bool SetOntoKeypair(OTKeypair& theKeypair, OTPasswordData& passwordData, bool ephemeral = false);
 
     LowLevelKeyGenerator(const std::shared_ptr<NymParameters>& pkeyData);
     ~LowLevelKeyGenerator();

--- a/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
+++ b/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
@@ -87,38 +87,28 @@ class NymParameters;
 class LowLevelKeyGenerator
 {
 private:
+    class LowLevelKeyGeneratordp;
 
     std::shared_ptr<NymParameters> pkeyData_;
 
-    LowLevelKeyGenerator();
-    LowLevelKeyGenerator(const LowLevelKeyGenerator&);
-    LowLevelKeyGenerator& operator=(const LowLevelKeyGenerator&);
+    LowLevelKeyGenerator() = delete;
+    LowLevelKeyGenerator(const LowLevelKeyGenerator&) = delete;
+    LowLevelKeyGenerator& operator=(const LowLevelKeyGenerator&) = delete;
     void Cleanup();
+    LowLevelKeyGeneratordp* dp = nullptr;
+
+#if defined(OT_CRYPTO_USING_OPENSSL)
+    class LowLevelKeyGeneratorOpenSSLdp;
+#endif
 
 public:
     bool m_bCleanup = true; // By default, LowLevelKeyGenerator cleans up the members. But
                      // if you set this to false, it will NOT cleanup.
     bool MakeNewKeypair();
-//    void Cleanup();
     bool SetOntoKeypair(OTKeypair& theKeypair);
 
     LowLevelKeyGenerator(const std::shared_ptr<NymParameters>& pkeyData);
     ~LowLevelKeyGenerator();
-
-//----------------------------------------
-// CRYPTO LIBRARIES
-//----------------------------------------
-#if defined(OT_CRYPTO_USING_OPENSSL)
-    class LowLevelKeyGeneratorOpenSSLdp;
-    LowLevelKeyGeneratorOpenSSLdp* dp = nullptr;
-#endif
-
-//----------------------------------------
-// CRYPTO ALGORITHMS
-//----------------------------------------
-#if defined(OT_CRYPTO_SUPPORTED_KEY_RSA)
-
-#endif
 
 };
 

--- a/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
+++ b/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
@@ -39,6 +39,8 @@
 #ifndef OPENTXS_CORE_CRYPTO_LOWLEVELKEYGENERATOR_HPP
 #define OPENTXS_CORE_CRYPTO_LOWLEVELKEYGENERATOR_HPP
 
+#include <opentxs/core/crypto/OTPasswordData.hpp>
+
 #include <memory>
 
 namespace opentxs
@@ -109,7 +111,7 @@ public:
     bool m_bCleanup = true; // By default, LowLevelKeyGenerator cleans up the members. But
                      // if you set this to false, it will NOT cleanup.
     bool MakeNewKeypair();
-    bool SetOntoKeypair(OTKeypair& theKeypair);
+    bool SetOntoKeypair(OTKeypair& theKeypair, OTPasswordData passwordData, bool ephemeral = false);
 
     LowLevelKeyGenerator(const std::shared_ptr<NymParameters>& pkeyData);
     ~LowLevelKeyGenerator();

--- a/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
+++ b/include/opentxs/core/crypto/LowLevelKeyGenerator.hpp
@@ -101,6 +101,10 @@ private:
     class LowLevelKeyGeneratorOpenSSLdp;
 #endif
 
+#if defined(OT_CRYPTO_USING_LIBSECP256K1)
+    class LowLevelKeyGeneratorSecp256k1dp;
+#endif
+
 public:
     bool m_bCleanup = true; // By default, LowLevelKeyGenerator cleans up the members. But
                      // if you set this to false, it will NOT cleanup.

--- a/include/opentxs/core/crypto/NymParameters.hpp
+++ b/include/opentxs/core/crypto/NymParameters.hpp
@@ -83,10 +83,10 @@ private:
 
 #if defined(OT_CRYPTO_SUPPORTED_KEY_SECP256K1)
     NymParameterType nymType_ = NymParameterType::SECP256K1;
-    Credential::CredentialType credentialType_ = Credential::RSA_PUBKEY;
+    Credential::CredentialType credentialType_ = Credential::SECP256K1;
 #elif defined(OT_CRYPTO_SUPPORTED_KEY_RSA)
     NymParameterType nymType_ = NymParameterType::LEGACY;
-    Credential::CredentialType credentialType_ = Credential::RSA_PUBKEY;
+    Credential::CredentialType credentialType_ = Credential::LEGACY;
 #else
     NymParameterType nymType_ = NymParameterType::ERROR;
     Credential::CredentialType credentialType_ = Credential::ERROR_TYPE;

--- a/include/opentxs/core/crypto/NymParameters.hpp
+++ b/include/opentxs/core/crypto/NymParameters.hpp
@@ -50,7 +50,8 @@ class NymParameters
 public:
     enum NymParameterType: int32_t {
       ERROR,
-      LEGACY
+      LEGACY,
+      SECP256K1
     };
 
     NymParameterType nymParameterType();

--- a/include/opentxs/core/crypto/NymParameters.hpp
+++ b/include/opentxs/core/crypto/NymParameters.hpp
@@ -71,14 +71,20 @@ public:
     NymParameters(const int32_t keySize);
 #endif
 
-    NymParameters();
-    ~NymParameters();
+    NymParameters(
+        NymParameterType theKeytype,
+        Credential::CredentialType theCredentialtype);
+    NymParameters() = default;
+    ~NymParameters() = default;
 
 private:
-    NymParameters(const NymParameters&);
-    NymParameters& operator=(const NymParameters&);
+    NymParameters(const NymParameters&) = delete;
+    NymParameters& operator=(const NymParameters&) = delete;
 
-#if defined(OT_CRYPTO_SUPPORTED_KEY_RSA)
+#if defined(OT_CRYPTO_SUPPORTED_KEY_SECP256K1)
+    NymParameterType nymType_ = NymParameterType::SECP256K1;
+    Credential::CredentialType credentialType_ = Credential::RSA_PUBKEY;
+#elif defined(OT_CRYPTO_SUPPORTED_KEY_RSA)
     NymParameterType nymType_ = NymParameterType::LEGACY;
     Credential::CredentialType credentialType_ = Credential::RSA_PUBKEY;
 #else

--- a/include/opentxs/core/crypto/OTASCIIArmor.hpp
+++ b/include/opentxs/core/crypto/OTASCIIArmor.hpp
@@ -69,10 +69,31 @@ extern const char* OT_BEGIN_SIGNED_escaped;
 
 // The natural state of OTASCIIArmor is in compressed and base64-encoded, string
 // form.
-// It is derived from OTString. The Get() method returns a base64-encoded
-// string.
-// The Set() method assumes that you are PASSING IN a base64-encoded string.
-// The constructors assume that you are passing in a base64-encoded string.
+//
+// HOW TO USE THIS CLASS
+//
+// Methods that put data into OTASCIIArmor
+//   ...if the input is already encoded:
+//      Constructors that take OTASCIIArmor, OTEnvelope, char*
+//      Assignment operators that take OTASCIIArmor, char*
+//      Load methods
+//
+//   ...if the data is *not* already encoded:
+//      Constructors that take String, OTData
+//      Assignment operators that take String, OTData
+//      Set methods
+//
+// Methods that take data out of OTASCIIArmor
+//   ...in encoded form:
+//      Write methods
+//      Save methods
+//      (inherited) String::Get() method
+//
+//   ...in decoded form:
+//      OTASCIIArmor::GetString() and OTASCIIArmor::GetData() methods
+//
+//      Note: if an OTASCIIArmor is provided to the constructor of String(),
+//      the resulting String will be in *decoded* form.
 class OTASCIIArmor : public String
 {
 public:
@@ -143,14 +164,10 @@ public:
                                                        // right string.
                                  bool bEscaped = false) const;
 
-    // Base64-decode
     EXPORT bool GetData(OTData& theData, bool bLineBreaks = true) const;
-    // Base64-encode
     EXPORT bool SetData(const OTData& theData, bool bLineBreaks = true);
 
-    // Base64-decode and decompress
     EXPORT bool GetString(String& theData, bool bLineBreaks = true) const;
-    // compress and Base64-encode
     EXPORT bool SetString(const String& theData, bool bLineBreaks = true);
 
 private:

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -285,7 +285,7 @@ public: // DESTRUCTION
 
     virtual bool GetPrivateKey(
         FormattedKey& strOutput,
-        const OTAsymmetricKey* pPubkey, //I wish this wasn't necessary
+        const OTAsymmetricKey* pPubkey = nullptr, //I wish this wasn't necessary
         const String* pstrReason = nullptr,
         const OTPassword* pImportPassword = nullptr) const = 0;
     virtual bool SetPrivateKey(

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -117,7 +117,8 @@ public:
     enum KeyType: int32_t {
         ERROR_TYPE,
         NULL_TYPE,
-        RSA
+        RSA,
+        SECP256K1
     };
 
     static String KeyTypeToString(const KeyType keyType);
@@ -126,7 +127,7 @@ public:
 
     KeyType keyType() const;
 
-    virtual CryptoAsymmetric& engine() const;
+    virtual CryptoAsymmetric& engine() const = 0;
 
 protected:
     KeyType m_keyType = ERROR_TYPE;

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -117,7 +117,7 @@ public:
     enum KeyType: int32_t {
         ERROR_TYPE,
         NULL_TYPE,
-        RSA,
+        LEGACY,
         SECP256K1
     };
 

--- a/include/opentxs/core/crypto/OTEnvelope.hpp
+++ b/include/opentxs/core/crypto/OTEnvelope.hpp
@@ -80,7 +80,7 @@ public:
 
     // ASYMMETRIC CRYPTO (RSA / AES)
 
-    EXPORT bool Seal(const setOfNyms recipients,
+    EXPORT bool Seal(const setOfNyms& recipients,
                      const String& theInput); // Put data into this object
                                               // with Seal().
 

--- a/include/opentxs/core/crypto/OTEnvelope.hpp
+++ b/include/opentxs/core/crypto/OTEnvelope.hpp
@@ -55,12 +55,14 @@ class OTPasswordData;
 class Nym;
 class String;
 class OTSymmetricKey;
+class Letter;
 
 typedef std::multimap<std::string, OTAsymmetricKey*> mapOfAsymmetricKeys;
 typedef std::set<Nym*> setOfNyms;
 
 class OTEnvelope
 {
+    friend Letter;
     OTData m_dataContents; // Stores only encrypted contents.
 
 public:

--- a/include/opentxs/core/crypto/OTEnvelope.hpp
+++ b/include/opentxs/core/crypto/OTEnvelope.hpp
@@ -80,15 +80,21 @@ public:
 
     // ASYMMETRIC CRYPTO (RSA / AES)
 
-    // Single recipient:
-    //
+    EXPORT bool Seal(const setOfNyms recipients,
+                     const String& theInput); // Put data into this object
+                                              // with Seal().
+
     EXPORT bool Seal(const Nym& theRecipient,
                      const String& theInput); // Put data into this object
                                               // with Seal().
 
-    EXPORT bool Seal(const OTAsymmetricKey& RecipPubKey,
+    EXPORT bool Seal(const mapOfAsymmetricKeys& recipientKeys,
                      const String& theInput); // Currently supports strings
                                               // only.
+
+    EXPORT bool Seal(const OTAsymmetricKey& RecipPubKey,
+                     const String& theInput); // Currently supports strings
+    // only.
 
     // (Opposite of Seal.)
     //

--- a/include/opentxs/core/crypto/OTKeypair.hpp
+++ b/include/opentxs/core/crypto/OTKeypair.hpp
@@ -97,7 +97,9 @@ private:
     OTAsymmetricKey* m_pkeyPrivate = nullptr; // This nym's private key
 
 public:
-    EXPORT bool MakeNewKeypair(const std::shared_ptr<NymParameters>& pKeyData);
+    EXPORT bool MakeNewKeypair(
+        const std::shared_ptr<NymParameters>& pKeyData,
+        const bool ephemeral = false);
     EXPORT bool ReEncrypt(const OTPassword& theExportPassword, bool bImporting,
                           String& strOutput); // Used when importing/exporting
                                               // a Nym to/from the wallet.

--- a/include/opentxs/core/crypto/OTKeypair.hpp
+++ b/include/opentxs/core/crypto/OTKeypair.hpp
@@ -101,7 +101,7 @@ public:
         const std::shared_ptr<NymParameters>& pKeyData,
         const bool ephemeral = false);
     EXPORT bool ReEncrypt(const OTPassword& theExportPassword, bool bImporting,
-                          String& strOutput); // Used when importing/exporting
+                          FormattedKey& strOutput); // Used when importing/exporting
                                               // a Nym to/from the wallet.
     EXPORT bool CalculateID(Identifier& theOutput) const;
 

--- a/include/opentxs/core/crypto/OTPassword.hpp
+++ b/include/opentxs/core/crypto/OTPassword.hpp
@@ -173,6 +173,11 @@ public:
     EXPORT static void zeroMemory(void* vMemory, uint32_t size);
     EXPORT static void* safe_memcpy(void* dest, uint32_t dsize, const void* src,
                                     uint32_t ssize, bool zeroSource = false);
+    inline void reset()
+    {
+        position_ = 0;
+    }
+    EXPORT uint32_t OTfread(uint8_t* data, uint32_t size);
 
     // OTPassword thePass; will create a text password.
     // But use the below function if you want one that has
@@ -204,6 +209,7 @@ private:
     bool isBinary_;
     bool isPageLocked_;
     const BlockSize blockSize_;
+    uint32_t position_=0;
 
     bool ot_lockPage(void* addr, size_t len);
     bool ot_unlockPage(void* addr, size_t len);

--- a/include/opentxs/core/crypto/OTPassword.hpp
+++ b/include/opentxs/core/crypto/OTPassword.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_CRYPTO_OTPASSWORD_HPP
 
 #include <cstddef>
+#include <string>
 
 namespace opentxs
 {
@@ -140,6 +141,7 @@ public:
     EXPORT uint8_t* getPasswordWritable();
     EXPORT char* getPasswordWritable_char();
     // (FYI, truncates if nInputSize larger than getBlockSize.)
+    EXPORT int32_t setPassword(const std::string& input);
     EXPORT int32_t setPassword(const char* input, int32_t size);
     // (FYI, truncates if nInputSize larger than getBlockSize.)
     EXPORT int32_t setPassword_uint8(const uint8_t* input, uint32_t size);

--- a/include/opentxs/core/crypto/OTPassword.hpp
+++ b/include/opentxs/core/crypto/OTPassword.hpp
@@ -105,9 +105,12 @@ namespace opentxs
 // This is basically just to save me from duplicating work that's already
 // done here in OTPassword.
 //
+class OTData;
+
 class OTPassword
 {
 public:
+
     enum BlockSize {
         // (128 bytes max length for a password.)
         DEFAULT_SIZE = OT_DEFAULT_BLOCKSIZE,
@@ -150,6 +153,7 @@ public:
     EXPORT const uint8_t* getMemory_uint8() const;
     EXPORT void* getMemoryWritable();
     // (FYI, truncates if size larger than getBlockSize.)
+    EXPORT int32_t setMemory(const OTData& data);
     EXPORT int32_t setMemory(const void* input, uint32_t size);
     // (FYI, truncates if size + getPasswordSize() is larger than
     // getBlockSize.)

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -146,9 +146,14 @@ public:
     // Asymmetric (public key) encryption / decryption
     virtual bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
                       OTData& dataOutput) const;
+    virtual bool Seal(mapOfAsymmetricKeys& RecipPubKeys, OTData& theInput,
+                      OTData& dataOutput) const;
 
     virtual bool Open(OTData& dataInput, const Nym& theRecipient,
                       String& theOutput,
+                      const OTPasswordData* pPWData = nullptr) const;
+    virtual bool Open(OTData& dataInput, const Nym& theRecipient,
+                      OTData& plaintext,
                       const OTPasswordData* pPWData = nullptr) const;
     // SIGN / VERIFY
     // Sign or verify using the Asymmetric Key itself.

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -164,7 +164,7 @@ public:
         const CryptoHash::HashType hashType,
         const OTPasswordData* pPWData = nullptr) const;
 
-    virtual bool Hash(
+    virtual bool Digest(
         const CryptoHash::HashType hashType,
         const OTData& data,
         OTData& digest) const;

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -185,19 +185,18 @@ public:
         const uint32_t ciphertextLength,
         CryptoSymmetricDecryptOutput plaintext) const;
 
-    // SEAL / OPEN
+    // Session key operations (used by opentxs::Letter)
     // Asymmetric (public key) encryption / decryption
-    virtual bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,
-                      OTData& dataOutput) const;
-    virtual bool Seal(mapOfAsymmetricKeys& RecipPubKeys, OTData& theInput,
-                      OTData& dataOutput) const;
+    virtual bool EncryptSessionKey(
+        mapOfAsymmetricKeys& RecipPubKeys,
+        OTPassword& plaintext,
+        OTData& dataOutput) const;
+    virtual bool DecryptSessionKey(
+        OTData& dataInput,
+        const Nym& theRecipient,
+        OTPassword& plaintext,
+        const OTPasswordData* pPWData = nullptr) const;
 
-    virtual bool Open(OTData& dataInput, const Nym& theRecipient,
-                      String& theOutput,
-                      const OTPasswordData* pPWData = nullptr) const;
-    virtual bool Open(OTData& dataInput, const Nym& theRecipient,
-                      OTData& plaintext,
-                      const OTPasswordData* pPWData = nullptr) const;
     // SIGN / VERIFY
     // Sign or verify using the Asymmetric Key itself.
     virtual bool SignContract(

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -87,7 +87,7 @@ protected:
     virtual void Cleanup_Override() const;
 
     class OpenSSLdp;
-    OpenSSLdp* dp;
+    OpenSSLdp* dp=nullptr;
 
     virtual bool GetPasswordFromConsole(OTPassword& theOutput,
                                                 const char* szPrompt) const;

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -97,6 +97,7 @@ public:
     static std::mutex* s_arrayMutex;
     // (To instantiate a text secret, just do this: OTPassword thePass;)
     virtual OTPassword* InstantiateBinarySecret() const;
+    virtual BinarySecret InstantiateBinarySecretSP() const;
 
     // RANDOM NUMBERS
     virtual bool RandomizeMemory(uint8_t* szDestination,

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -130,18 +130,34 @@ public:
         const OTData& theIV, // (We assume this IV is already generated and
                              // passed in.)
         OTData& theEncryptedOutput) const; // OUTPUT. (Ciphertext.)
+    virtual bool Encrypt(
+        const OTPassword& theRawSymmetricKey,
+        const CryptoSymmetric::Mode cipher,
+        const char* szInput,
+        uint32_t lInputLength,
+        OTData& theEncryptedOutput,
+        const OTData* theIV = nullptr, // For some cipher modes, IV is optional
+        OTData* tag = nullptr) const; // Only used for AEAD
+    virtual bool Decrypt(
+        const OTPassword& theRawSymmetricKey, // The symmetric key, in clear form.
+        const char* szInput, // This is the Ciphertext.
+        uint32_t lInputLength,
+        const OTData& theIV, // (We assume this IV is
+                            // already generated and passed
+                            // in.)
+        CryptoSymmetricDecryptOutput theDecryptedOutput) const; // OUTPUT. (Recovered
+                                                                // plaintext.) You can pass
+                                                                // OTPassword& OR OTData& here
+                                                                // (either will work.)
+    virtual bool Decrypt(
+        const OTPassword& theRawSymmetricKey,
+        const CryptoSymmetric::Mode cipher,
+        const char* szInput,
+        uint32_t lInputLength,
+        CryptoSymmetricDecryptOutput theDecryptedOutput,
+        const OTData* theIV = nullptr, // For some cipher modes, IV is optional
+        const OTData* tag = nullptr) const; // Only used for AEAD
 
-    virtual bool Decrypt(const OTPassword& theRawSymmetricKey, // The symmetric
-                                                               // key, in clear
-                                                               // form.
-                         const char* szInput, // This is the Ciphertext.
-                         uint32_t lInputLength,
-                         const OTData& theIV, // (We assume this IV is
-                                              // already generated and passed
-                                              // in.)
-                         CryptoSymmetricDecryptOutput theDecryptedOutput)
-        const; // OUTPUT. (Recovered plaintext.) You can pass OTPassword& OR
-               // OTData& here (either will work.)
     // SEAL / OPEN
     // Asymmetric (public key) encryption / decryption
     virtual bool Seal(mapOfAsymmetricKeys& RecipPubKeys, const String& theInput,

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -131,13 +131,27 @@ public:
                              // passed in.)
         OTData& theEncryptedOutput) const; // OUTPUT. (Ciphertext.)
     virtual bool Encrypt(
-        const OTPassword& theRawSymmetricKey,
         const CryptoSymmetric::Mode cipher,
-        const char* szInput,
-        uint32_t lInputLength,
-        OTData& theEncryptedOutput,
-        const OTData* theIV = nullptr, // For some cipher modes, IV is optional
-        OTData* tag = nullptr) const; // Only used for AEAD
+        const OTPassword& key,
+        const char* plaintext,
+        uint32_t plaintextLength,
+        OTData& ciphertext) const;
+    virtual bool Encrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const char* plaintext,
+        uint32_t plaintextLength,
+        OTData& ciphertext) const;
+    virtual bool Encrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const char* plaintext,
+        uint32_t plaintextLength,
+        OTData& ciphertext,
+        OTData& tag) const;
+
     virtual bool Decrypt(
         const OTPassword& theRawSymmetricKey, // The symmetric key, in clear form.
         const char* szInput, // This is the Ciphertext.
@@ -150,13 +164,26 @@ public:
                                                                 // OTPassword& OR OTData& here
                                                                 // (either will work.)
     virtual bool Decrypt(
-        const OTPassword& theRawSymmetricKey,
         const CryptoSymmetric::Mode cipher,
-        const char* szInput,
-        uint32_t lInputLength,
-        CryptoSymmetricDecryptOutput theDecryptedOutput,
-        const OTData* theIV = nullptr, // For some cipher modes, IV is optional
-        const OTData* tag = nullptr) const; // Only used for AEAD
+        const OTPassword& key,
+        const char* ciphertext,
+        uint32_t ciphertextLength,
+        CryptoSymmetricDecryptOutput plaintext) const;
+    virtual bool Decrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const char* ciphertext,
+        uint32_t ciphertextLength,
+        CryptoSymmetricDecryptOutput plaintext) const;
+    virtual bool Decrypt(
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const OTData& tag,
+        const char* ciphertext,
+        const uint32_t ciphertextLength,
+        CryptoSymmetricDecryptOutput plaintext) const;
 
     // SEAL / OPEN
     // Asymmetric (public key) encryption / decryption
@@ -200,6 +227,18 @@ public:
     void thread_cleanup() const;
 
     virtual ~OpenSSL();
+
+private:
+    bool ArgumentCheck(
+        const bool encrypt,
+        const CryptoSymmetric::Mode cipher,
+        const OTPassword& key,
+        const OTData& iv,
+        const OTData& tag,
+        const char* input,
+        const uint32_t inputLength,
+        bool& AEAD,
+        bool& ECB) const;
 };
 
 #else // Apparently NO crypto engine is defined!

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -41,6 +41,7 @@
 
 #include <opentxs/core/crypto/Crypto.hpp>
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
+#include <opentxs/core/crypto/CryptoHash.hpp>
 #include <opentxs/core/crypto/CryptoSymmetric.hpp>
 #include <opentxs/core/crypto/CryptoUtil.hpp>
 #include <opentxs/core/OTData.hpp>
@@ -77,7 +78,7 @@ class OTSignature;
 
 #elif defined(OT_CRYPTO_USING_OPENSSL)
 
-class OpenSSL : public Crypto, public CryptoAsymmetric, public CryptoSymmetric, public CryptoUtil
+class OpenSSL : public Crypto, public CryptoAsymmetric, public CryptoSymmetric, public CryptoUtil, public CryptoHash
 {
     friend class CryptoEngine;
 
@@ -161,6 +162,11 @@ public:
                                  const OTSignature& theSignature,
                                  const String& strHashType,
                                  const OTPasswordData* pPWData = nullptr) const;
+    virtual bool Hash(
+        const CryptoHash::HashType hashType,
+        const OTData& data,
+        String& digest) const;
+
     void thread_setup() const;
     void thread_cleanup() const;
 

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -167,7 +167,7 @@ public:
     virtual bool Hash(
         const CryptoHash::HashType hashType,
         const OTData& data,
-        String& digest) const;
+        OTData& digest) const;
 
     void thread_setup() const;
     void thread_cleanup() const;

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -170,9 +170,9 @@ public:
         OTData& digest) const;
     virtual bool HMAC(
         const CryptoHash::HashType hashType,
-        const OTData& inputKey,
+        const OTPassword& inputKey,
         const OTData& inputData,
-        OTData& outputDigest) const;
+        OTPassword& outputDigest) const;
 
     void thread_setup() const;
     void thread_cleanup() const;

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -151,17 +151,19 @@ public:
                       const OTPasswordData* pPWData = nullptr) const;
     // SIGN / VERIFY
     // Sign or verify using the Asymmetric Key itself.
-    virtual bool SignContract(const String& strContractUnsigned,
-                              const OTAsymmetricKey& theKey,
-                              OTSignature& theSignature, // output
-                              const String& strHashType,
-                              const OTPasswordData* pPWData = nullptr);
+    virtual bool SignContract(
+        const String& strContractUnsigned,
+        const OTAsymmetricKey& theKey,
+        OTSignature& theSignature, // output
+        const CryptoHash::HashType hashType,
+        const OTPasswordData* pPWData = nullptr);
+    virtual bool VerifySignature(
+        const String& strContractToVerify,
+        const OTAsymmetricKey& theKey,
+        const OTSignature& theSignature,
+        const CryptoHash::HashType hashType,
+        const OTPasswordData* pPWData = nullptr) const;
 
-    virtual bool VerifySignature(const String& strContractToVerify,
-                                 const OTAsymmetricKey& theKey,
-                                 const OTSignature& theSignature,
-                                 const String& strHashType,
-                                 const OTPasswordData* pPWData = nullptr) const;
     virtual bool Hash(
         const CryptoHash::HashType hashType,
         const OTData& data,

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -168,6 +168,11 @@ public:
         const CryptoHash::HashType hashType,
         const OTData& data,
         OTData& digest) const;
+    virtual bool HMAC(
+        const CryptoHash::HashType hashType,
+        const OTData& inputKey,
+        const OTData& inputData,
+        OTData& outputDigest) const;
 
     void thread_setup() const;
     void thread_cleanup() const;

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -215,8 +215,8 @@ public:
 
     virtual bool Digest(
         const CryptoHash::HashType hashType,
-        const OTData& data,
-        OTData& digest) const;
+        const OTPassword& data,
+        OTPassword& digest) const;
     virtual bool HMAC(
         const CryptoHash::HashType hashType,
         const OTPassword& inputKey,

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -58,6 +58,7 @@ set(cxx-sources
   commands/CmdNewAsset.cpp
   commands/CmdNewBasket.cpp
   commands/CmdNewKey.cpp
+  commands/CmdNewNymECDSA.cpp
   commands/CmdNewNymLegacy.cpp
   commands/CmdNewOffer.cpp
   commands/CmdNewServer.cpp

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -58,7 +58,7 @@ set(cxx-sources
   commands/CmdNewAsset.cpp
   commands/CmdNewBasket.cpp
   commands/CmdNewKey.cpp
-  commands/CmdNewNym.cpp
+  commands/CmdNewNymLegacy.cpp
   commands/CmdNewOffer.cpp
   commands/CmdNewServer.cpp
   commands/CmdOutbox.cpp

--- a/src/client/OTAPI.cpp
+++ b/src/client/OTAPI.cpp
@@ -274,6 +274,13 @@ std::string OTAPI_Wrap::CreateNymLegacy(const int32_t& nKeySize,
     return Exec()->CreateNymLegacy(nKeySize, NYM_ID_SOURCE, ALT_LOCATION);
 }
 
+std::string OTAPI_Wrap::CreateNymECDSA(
+                                  const std::string& NYM_ID_SOURCE,
+                                  const std::string& ALT_LOCATION)
+{
+    return Exec()->CreateNymECDSA(NYM_ID_SOURCE, ALT_LOCATION);
+}
+
 std::string OTAPI_Wrap::GetNym_ActiveCronItemIDs(const std::string& NYM_ID,
                                                  const std::string& NOTARY_ID)
 {

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -511,6 +511,28 @@ std::string OTAPI_Exec::CreateNymLegacy(
     return "";
 }
 
+std::string OTAPI_Exec::CreateNymECDSA(
+    const std::string& NYM_ID_SOURCE,      // Can be empty.
+    const std::string& ALT_LOCATION) const // Can be empty.
+{
+    std::shared_ptr<NymParameters> pKeyData;
+    pKeyData = std::make_shared<NymParameters>(
+        NymParameters::SECP256K1,
+        Credential::SECP256K1_PUBKEY);
+
+    Nym* pNym = OTAPI()->CreateNym(pKeyData, NYM_ID_SOURCE, ALT_LOCATION);
+    if (nullptr == pNym) // Creation failed.
+    {
+        otOut << __FUNCTION__ << ": Failed trying to create Nym.\n";
+        return "";
+    }
+    // -----------------------------------------------------}
+    String strOutput;
+    pNym->GetIdentifier(strOutput); // We're returning the new Nym ID.
+    if (strOutput.Exists()) return strOutput.Get();
+    return "";
+}
+
 std::string OTAPI_Exec::GetNym_ActiveCronItemIDs(
     const std::string& NYM_ID, const std::string& NOTARY_ID) const
 {

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -518,7 +518,7 @@ std::string OTAPI_Exec::CreateNymECDSA(
     std::shared_ptr<NymParameters> pKeyData;
     pKeyData = std::make_shared<NymParameters>(
         NymParameters::SECP256K1,
-        Credential::SECP256K1_PUBKEY);
+        Credential::SECP256K1);
 
     Nym* pNym = OTAPI()->CreateNym(pKeyData, NYM_ID_SOURCE, ALT_LOCATION);
     if (nullptr == pNym) // Creation failed.

--- a/src/client/OT_ME.cpp
+++ b/src/client/OT_ME.cpp
@@ -308,6 +308,24 @@ std::string OT_ME::check_nym(const std::string& NOTARY_ID,
 // CREATE NYM
 // returns new Nym ID
 //
+std::string OT_ME::create_nym_ecdsa(
+                              const std::string& strNymIDSource,
+                              const std::string& strAltLocation) const
+{
+    std::string strNymID =
+        OTAPI_Wrap::CreateNymECDSA(strNymIDSource, strAltLocation);
+
+    if (!VerifyStringVal(strNymID)) {
+        otOut << "OT_ME_create_nym_ecdsa: Failed in "
+              << "OT_API_CreateNymECDSA\n";
+    }
+
+    return strNymID;
+}
+
+// CREATE NYM
+// returns new Nym ID
+//
 std::string OT_ME::create_nym_legacy(int32_t nKeybits,
                               const std::string& strNymIDSource,
                               const std::string& strAltLocation) const

--- a/src/client/commands/CmdNewNymECDSA.cpp
+++ b/src/client/commands/CmdNewNymECDSA.cpp
@@ -1,0 +1,106 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "CmdNewNymECDSA.hpp"
+
+#include <opentxs/client/OTAPI.hpp>
+#include <opentxs/client/OT_ME.hpp>
+#include <opentxs/core/Log.hpp>
+
+using namespace opentxs;
+using namespace std;
+
+CmdNewNymECDSA::CmdNewNymECDSA()
+{
+    command = "newnymecdsa";
+    args[0] = "--label <label>";
+    args[2] = "[--source <source>]";
+    args[3] = "[--location <location>]";
+    category = catNyms;
+    help = "create a new secp256k1 nym.";
+}
+
+CmdNewNymECDSA::~CmdNewNymECDSA()
+{
+}
+
+int32_t CmdNewNymECDSA::runWithOptions()
+{
+    return run(getOption("label"), getOption("source"),
+               getOption("location"));
+}
+
+// FYI, a source can be a URL, a Bitcoin address, a Namecoin address,
+// a public key, or the unique DN info from a traditionally-issued cert.
+// Hashing the source should produce the NymID. Also, the source should
+// always (somehow) validate the credential IDs, if they are to be trusted
+// for their purported Nym. Another optional parameter is 'altlocation'
+// which, in the case of DN info as a source, would be the download location
+// where a Cert should be found with that DN info, or a PKI where the Cert
+// can be found.
+//
+// NOTE: If you leave the source BLANK, then OT will just generate a public
+// key to serve as the source. The public key will be hashed to form the
+// NymID, and all credentials for that Nym will need to be signed by the
+// corresponding private key. That's the only way they can be 'verified by
+// their source.'
+
+int32_t CmdNewNymECDSA::run(
+    string label,
+    string source,
+    string location)
+{
+    if (!checkMandatory("label", label)) {
+        return -1;
+    }
+
+    OT_ME ot_me;
+    string mynym = ot_me.create_nym_ecdsa(source, location);
+    if ("" == mynym) {
+        otOut << "Error: cannot create new nym.\n";
+        return -1;
+    }
+
+    cout << "New nym: " << mynym << "\n";
+
+    if (!OTAPI_Wrap::SetNym_Name(mynym, mynym, label)) {
+        otOut << "Error: cannot set new nym name.\n";
+        return -1;
+    }
+    return 1;
+}

--- a/src/client/commands/CmdNewNymECDSA.hpp
+++ b/src/client/commands/CmdNewNymECDSA.hpp
@@ -1,0 +1,156 @@
+/************************************************************
+ *
+ *  CmdNewNymECDSA.hpp
+ *
+ */
+
+/************************************************************
+ -----BEGIN PGP SIGNED MESSAGE-----
+ Hash: SHA1
+
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  Copyright (C) 2010-2013 by "Fellow Traveler" (A pseudonym)
+ *
+ *  EMAIL:
+ *  FellowTraveler@rayservers.net
+ *
+ *  BITCOIN:  1NtTPVVjDsUfDWybS4BwvHpG2pdS9RnYyQ
+ *
+ *  KEY FINGERPRINT (PGP Key in license file):
+ *  9DD5 90EB 9292 4B48 0484  7910 0308 00ED F951 BB8E
+ *
+ *  OFFICIAL PROJECT WIKI(s):
+ *  https://github.com/FellowTraveler/Moneychanger
+ *  https://github.com/FellowTraveler/Open-Transactions/wiki
+ *
+ *  WEBSITE:
+ *  http://www.OpenTransactions.org/
+ *
+ *  Components and licensing:
+ *   -- Moneychanger..A Java client GUI.....LICENSE:.....GPLv3
+ *   -- otlib.........A class library.......LICENSE:...LAGPLv3
+ *   -- otapi.........A client API..........LICENSE:...LAGPLv3
+ *   -- opentxs/ot....Command-line client...LICENSE:...LAGPLv3
+ *   -- otserver......Server Application....LICENSE:....AGPLv3
+ *  Github.com/FellowTraveler/Open-Transactions/wiki/Components
+ *
+ *  All of the above OT components were designed and written by
+ *  Fellow Traveler, with the exception of Moneychanger, which
+ *  was contracted out to Vicky C (bitcointrader4@gmail.com).
+ *  The open-source community has since actively contributed.
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This program is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU Affero
+ *   General Public License as published by the Free Software
+ *   Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   ADDITIONAL PERMISSION under the GNU Affero GPL version 3
+ *   section 7: (This paragraph applies only to the LAGPLv3
+ *   components listed above.) If you modify this Program, or
+ *   any covered work, by linking or combining it with other
+ *   code, such other code is not for that reason alone subject
+ *   to any of the requirements of the GNU Affero GPL version 3.
+ *   (==> This means if you are only using the OT API, then you
+ *   don't have to open-source your code--only your changes to
+ *   Open-Transactions itself must be open source. Similar to
+ *   LGPLv3, except it applies to software-as-a-service, not
+ *   just to distributing binaries.)
+ *
+ *   Extra WAIVER for OpenSSL, Lucre, and all other libraries
+ *   used by Open Transactions: This program is released under
+ *   the AGPL with the additional exemption that compiling,
+ *   linking, and/or using OpenSSL is allowed. The same is true
+ *   for any other open source libraries included in this
+ *   project: complete waiver from the AGPL is hereby granted to
+ *   compile, link, and/or use them with Open-Transactions,
+ *   according to their own terms, as long as the rest of the
+ *   Open-Transactions terms remain respected, with regard to
+ *   the Open-Transactions code itself.
+ *
+ *   Lucre License:
+ *   This code is also "dual-license", meaning that Ben Lau-
+ *   rie's license must also be included and respected, since
+ *   the code for Lucre is also included with Open Transactions.
+ *   See Open-Transactions/src/otlib/lucre/LUCRE_LICENSE.txt
+ *   The Laurie requirements are light, but if there is any
+ *   problem with his license, simply remove the Lucre code.
+ *   Although there are no other blind token algorithms in Open
+ *   Transactions (yet. credlib is coming), the other functions
+ *   will continue to operate.
+ *   See Lucre on Github:  https://github.com/benlaurie/lucre
+ *   -----------------------------------------------------
+ *   You should have received a copy of the GNU Affero General
+ *   Public License along with this program.  If not, see:
+ *   http://www.gnu.org/licenses/
+ *
+ *   If you would like to use this software outside of the free
+ *   software license, please contact FellowTraveler.
+ *   (Unfortunately many will run anonymously and untraceably,
+ *   so who could really stop them?)
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE.  See the GNU Affero General Public License for
+ *   more details.
+
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.9 (Darwin)
+
+ iQIcBAEBAgAGBQJRSsfJAAoJEAMIAO35UbuOQT8P/RJbka8etf7wbxdHQNAY+2cC
+ vDf8J3X8VI+pwMqv6wgTVy17venMZJa4I4ikXD/MRyWV1XbTG0mBXk/7AZk7Rexk
+ KTvL/U1kWiez6+8XXLye+k2JNM6v7eej8xMrqEcO0ZArh/DsLoIn1y8p8qjBI7+m
+ aE7lhstDiD0z8mwRRLKFLN2IH5rAFaZZUvj5ERJaoYUKdn4c+RcQVei2YOl4T0FU
+ LWND3YLoH8naqJXkaOKEN4UfJINCwxhe5Ke9wyfLWLUO7NamRkWD2T7CJ0xocnD1
+ sjAzlVGNgaFDRflfIF4QhBx1Ddl6wwhJfw+d08bjqblSq8aXDkmFA7HeunSFKkdn
+ oIEOEgyj+veuOMRJC5pnBJ9vV+7qRdDKQWaCKotynt4sWJDGQ9kWGWm74SsNaduN
+ TPMyr9kNmGsfR69Q2Zq/FLcLX/j8ESxU+HYUB4vaARw2xEOu2xwDDv6jt0j3Vqsg
+ x7rWv4S/Eh18FDNDkVRChiNoOIilLYLL6c38uMf1pnItBuxP3uhgY6COm59kVaRh
+ nyGTYCDYD2TK+fI9o89F1297uDCwEJ62U0Q7iTDp5QuXCoxkPfv8/kX6lS6T3y9G
+ M9mqIoLbIQ1EDntFv7/t6fUTS2+46uCrdZWbQ5RjYXdrzjij02nDmJAm2BngnZvd
+ kamH0Y/n11lCvo1oQxM+
+ =uSzz
+ -----END PGP SIGNATURE-----
+ **************************************************************/
+
+#ifndef OPENTXS_CLIENT_CMDNEWNYMECDSA_HPP
+#define OPENTXS_CLIENT_CMDNEWNYMECDSA_HPP
+
+#include "CmdBase.hpp"
+
+namespace opentxs
+{
+
+class CmdNewNymECDSA : public CmdBase
+{
+public:
+    EXPORT CmdNewNymECDSA();
+    virtual ~CmdNewNymECDSA();
+
+    EXPORT int32_t run(std::string label,
+                       std::string source, std::string location);
+
+protected:
+    virtual int32_t runWithOptions();
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CLIENT_CMDNEWNYMECDSA_HPP

--- a/src/client/commands/CmdNewNymLegacy.cpp
+++ b/src/client/commands/CmdNewNymLegacy.cpp
@@ -36,7 +36,7 @@
  *
  ************************************************************/
 
-#include "CmdNewNym.hpp"
+#include "CmdNewNymLegacy.hpp"
 
 #include <opentxs/client/OTAPI.hpp>
 #include <opentxs/client/OT_ME.hpp>
@@ -45,22 +45,22 @@
 using namespace opentxs;
 using namespace std;
 
-CmdNewNym::CmdNewNym()
+CmdNewNymLegacy::CmdNewNymLegacy()
 {
-    command = "newnym";
+    command = "newnymlegacy";
     args[0] = "--label <label>";
     args[1] = "[--keybits <1024|2048|4096|8192>]";
     args[2] = "[--source <source>]";
     args[3] = "[--location <location>]";
     category = catNyms;
-    help = "create a new nym.";
+    help = "create a new OpenSSL-based RSA nym.";
 }
 
-CmdNewNym::~CmdNewNym()
+CmdNewNymLegacy::~CmdNewNymLegacy()
 {
 }
 
-int32_t CmdNewNym::runWithOptions()
+int32_t CmdNewNymLegacy::runWithOptions()
 {
     return run(getOption("keybits"), getOption("label"), getOption("source"),
                getOption("location"));
@@ -81,7 +81,7 @@ int32_t CmdNewNym::runWithOptions()
 // corresponding private key. That's the only way they can be 'verified by
 // their source.'
 
-int32_t CmdNewNym::run(string keybits, string label, string source,
+int32_t CmdNewNymLegacy::run(string keybits, string label, string source,
                        string location)
 {
     if (!checkMandatory("label", label)) {

--- a/src/client/commands/CmdNewNymLegacy.hpp
+++ b/src/client/commands/CmdNewNymLegacy.hpp
@@ -1,6 +1,6 @@
 /************************************************************
  *
- *  CmdNewNym.hpp
+ *  CmdNewNymLegacy.hpp
  *
  */
 
@@ -130,19 +130,19 @@
  -----END PGP SIGNATURE-----
  **************************************************************/
 
-#ifndef OPENTXS_CLIENT_CMDNEWNYM_HPP
-#define OPENTXS_CLIENT_CMDNEWNYM_HPP
+#ifndef OPENTXS_CLIENT_CMDNEWNYMLEGACY_HPP
+#define OPENTXS_CLIENT_CMDNEWNYMLEGACY_HPP
 
 #include "CmdBase.hpp"
 
 namespace opentxs
 {
 
-class CmdNewNym : public CmdBase
+class CmdNewNymLegacy : public CmdBase
 {
 public:
-    EXPORT CmdNewNym();
-    virtual ~CmdNewNym();
+    EXPORT CmdNewNymLegacy();
+    virtual ~CmdNewNymLegacy();
 
     EXPORT int32_t run(std::string keybits, std::string label,
                        std::string source, std::string location);
@@ -153,4 +153,4 @@ protected:
 
 } // namespace opentxs
 
-#endif // OPENTXS_CLIENT_CMDNEWNYM_HPP
+#endif // OPENTXS_CLIENT_CMDNEWNYMLEGACY_HPP

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -45,6 +45,7 @@ set(cxx-sources
   Contract.cpp
   crypto/CredentialSet.cpp
   crypto/Crypto.cpp
+  crypto/CryptoHash.cpp
   crypto/CryptoUtil.cpp
   crypto/CryptoSymmetric.cpp
   crypto/OpenSSL.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -5,6 +5,12 @@ include_directories(SYSTEM
   ${CZMQ_INCLUDE_DIR}
 )
 
+if(OT_CRYPTO_USING_LIBSECP256K1)
+  set(LIBSECP256K1 "crypto/Libsecp256k1.cpp")
+else()
+  set(LIBSECP256K1 "")
+endif()
+
 add_subdirectory(otprotob)
 add_subdirectory(trade)
 add_subdirectory(cron)
@@ -39,6 +45,7 @@ set(cxx-sources
   crypto/CryptoUtil.cpp
   crypto/CryptoSymmetric.cpp
   crypto/OpenSSL.cpp
+  ${LIBSECP256K1}
   crypto/CryptoEngine.cpp
   OTData.cpp
   crypto/OTEnvelope.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -52,6 +52,7 @@ set(cxx-sources
   ${LIBSECP256K1}
   crypto/CryptoEngine.cpp
   OTData.cpp
+  crypto/Letter.cpp
   crypto/OTEnvelope.cpp
   Identifier.cpp
   Instrument.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,8 +7,10 @@ include_directories(SYSTEM
 
 if(OT_CRYPTO_USING_LIBSECP256K1)
   set(LIBSECP256K1 "crypto/Libsecp256k1.cpp")
+  set(KEYSECP256K1 "crypto/AsymmetricKeySecp256k1.cpp")
 else()
   set(LIBSECP256K1 "")
+  set(KEYSECP256K1 "")
 endif()
 
 add_subdirectory(otprotob)
@@ -35,6 +37,7 @@ set(cxx-sources
   crypto/OTAsymmetricKey.cpp
   crypto/OTAsymmetricKeyOpenSSL.cpp
   crypto/OTAsymmetricKeyOpenSSLPrivdp.cpp
+  ${KEYSECP256K1}
   crypto/OTCachedKey.cpp
   crypto/OTCallback.cpp
   crypto/OTCaller.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -131,6 +131,14 @@ endif()
 
 target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58 czmq_local)
 target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
+
+if (OT_CRYPTO_USING_LIBSECP256K1)
+    add_library(staticlibsecp256k1 STATIC IMPORTED)
+    set_property(TARGET staticlibsecp256k1 PROPERTY IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/deps/lib/libsecp256k1.a)
+    target_link_libraries(opentxs-core PRIVATE staticlibsecp256k1)
+    target_link_libraries(opentxs-core PUBLIC ${GMP_LIBRARIES})
+endif()
+
 set_lib_property(opentxs-core)
 
 if(WIN32)

--- a/src/core/Identifier.cpp
+++ b/src/core/Identifier.cpp
@@ -173,10 +173,10 @@ const CryptoHash::HashType Identifier::DefaultHashAlgorithm = CryptoHash::SHA256
 
 bool Identifier::CalculateDigest(const String& strInput)
 {
-    OTData input(strInput.Get(), strInput.GetLength());
-
-    return CalculateDigest(input);
-}
+    return CryptoEngine::Instance().Hash().Hash(
+        CryptoHash::HASH160,
+        strInput,
+        *this);}
 
 bool Identifier::CalculateDigest(const OTData& dataInput)
 {

--- a/src/core/Identifier.cpp
+++ b/src/core/Identifier.cpp
@@ -169,7 +169,7 @@ Identifier::~Identifier()
 // which resort to low level calls to accomplish non standard message digests.
 // Otherwise, it will use whatever OpenSSL provides by that name (see
 // GetOpenSSLDigestByName).
-const CryptoHash::HashType Identifier::DefaultHashAlgorithm = CryptoHash::HASH256;
+const CryptoHash::HashType Identifier::DefaultHashAlgorithm = CryptoHash::SHA256;
 
 // This method implements the (ripemd160 . sha256) hash,
 // so the result is 20 bytes long.

--- a/src/core/Identifier.cpp
+++ b/src/core/Identifier.cpp
@@ -169,7 +169,7 @@ Identifier::~Identifier()
 // which resort to low level calls to accomplish non standard message digests.
 // Otherwise, it will use whatever OpenSSL provides by that name (see
 // GetOpenSSLDigestByName).
-const String Identifier::DefaultHashAlgorithm("HASH256");
+const CryptoHash::HashType Identifier::DefaultHashAlgorithm = CryptoHash::HASH256;
 
 // This method implements the (ripemd160 . sha256) hash,
 // so the result is 20 bytes long.

--- a/src/core/Identifier.cpp
+++ b/src/core/Identifier.cpp
@@ -173,14 +173,14 @@ const CryptoHash::HashType Identifier::DefaultHashAlgorithm = CryptoHash::SHA256
 
 bool Identifier::CalculateDigest(const String& strInput)
 {
-    return CryptoEngine::Instance().Hash().Hash(
+    return CryptoEngine::Instance().Hash().Digest(
         CryptoHash::HASH160,
         strInput,
         *this);}
 
 bool Identifier::CalculateDigest(const OTData& dataInput)
 {
-    return CryptoEngine::Instance().Hash().Hash(
+    return CryptoEngine::Instance().Hash().Digest(
         CryptoHash::HASH160,
         dataInput,
         *this);

--- a/src/core/Identifier.cpp
+++ b/src/core/Identifier.cpp
@@ -171,29 +171,19 @@ Identifier::~Identifier()
 // GetOpenSSLDigestByName).
 const CryptoHash::HashType Identifier::DefaultHashAlgorithm = CryptoHash::SHA256;
 
-// This method implements the (ripemd160 . sha256) hash,
-// so the result is 20 bytes long.
-bool Identifier::CalculateDigest(const unsigned char* data, size_t len)
-{
-    // The Hash160 function comes from the Bitcoin reference client, where
-    // it is implemented as RIPEMD160 ( SHA256 ( x ) ) => 20 byte hash
-    auto hash160 = Hash160(data, data + len);
-    SetSize(20);
-    memcpy(const_cast<void*>(GetPointer()), hash160, 20);
-    return true;
-}
-
 bool Identifier::CalculateDigest(const String& strInput)
 {
-    return CalculateDigest(
-        reinterpret_cast<const unsigned char*>(strInput.Get()),
-        static_cast<size_t>(strInput.GetLength()));
+    OTData input(strInput.Get(), strInput.GetLength());
+
+    return CalculateDigest(input);
 }
 
 bool Identifier::CalculateDigest(const OTData& dataInput)
 {
-    auto dataPtr = static_cast<const unsigned char*>(dataInput.GetPointer());
-    return CalculateDigest(dataPtr, dataInput.GetSize());
+    return CryptoEngine::Instance().Hash().Hash(
+        CryptoHash::HASH160,
+        dataInput,
+        *this);
 }
 
 // SET (binary id) FROM ENCODED STRING

--- a/src/core/OTData.cpp
+++ b/src/core/OTData.cpp
@@ -68,9 +68,7 @@ OTData::OTData(const void* data, uint32_t size)
 
 OTData::OTData(const std::vector<unsigned char> sourceVector)
 {
-    for (auto i: sourceVector) {
-        Concatenate(&i, sizeof(i));
-    }
+    Assign(sourceVector.data(), sourceVector.size());
 }
 
 OTData::~OTData()

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -60,20 +60,6 @@ void AsymmetricKeySecp256k1::ReleaseKeyLowLevel_Hook() const
 {
 }
 
-bool AsymmetricKeySecp256k1::SetKey(const OTPassword& key)
-{
-    ReleaseKeyLowLevel(); // In case the key is already loaded, we release it
-                          // here. (Since it's being replaced, it's now the
-                          // wrong key anyway.)
-
-    const uint8_t* keyStart = static_cast<const uint8_t*>(key.getMemory());
-    const uint8_t* keyEnd = keyStart + key.getMemorySize();
-
-    key_ = EncodeBase58Check(keyStart, keyEnd);
-
-    return true;
-}
-
 CryptoAsymmetric& AsymmetricKeySecp256k1::engine() const
 
 {
@@ -129,12 +115,7 @@ bool AsymmetricKeySecp256k1::SetPublicKeyFromPrivateKey(
         bool validPubkey = engine.secp256k1_pubkey_create(pubKey, privKey);
 
         if (validPubkey) {
-            OTPassword publicKey;
-
-            __attribute__((unused)) bool serializedKey =
-                engine.secp256k1_pubkey_serialize(publicKey, pubKey);
-
-            return SetKey(publicKey);
+            return engine.ECDSAPubkeyToAsymmetricKey(pubKey, *this);
         }
     }
 

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -91,7 +91,7 @@ bool AsymmetricKeySecp256k1::SetPrivateKey(
 
 bool AsymmetricKeySecp256k1::SetPublicKeyFromPrivateKey(
     const FormattedKey& strCert,
-    __attribute__((unused)) const String* pstrReason,
+    const String* pstrReason,
     __attribute__((unused)) const OTPassword* pImportPassword)
 {
     ReleaseKeyLowLevel(); // In case the key is already loaded, we release it
@@ -101,10 +101,16 @@ bool AsymmetricKeySecp256k1::SetPublicKeyFromPrivateKey(
     m_bIsPrivateKey = false;
 
     Libsecp256k1& engine = static_cast<Libsecp256k1&>(this->engine());
-
+    bool havePrivkey = false;
     OTPassword privKey;
 
-    bool havePrivkey = engine.AsymmetricKeyToECDSAPrivkey(strCert, privKey);
+    if (nullptr != pstrReason) {
+        OTPasswordData passwordData(*pstrReason);
+        havePrivkey = engine.AsymmetricKeyToECDSAPrivkey(strCert, passwordData, privKey);
+    } else {
+        OTPasswordData passwordData("Unlock the nym's private credential.");
+        havePrivkey = engine.AsymmetricKeyToECDSAPrivkey(strCert, passwordData, privKey);
+    }
 
     if (havePrivkey) {
         secp256k1_pubkey_t pubKey;

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -103,14 +103,12 @@ bool AsymmetricKeySecp256k1::SetPublicKeyFromPrivateKey(
 
     Libsecp256k1& engine = static_cast<Libsecp256k1&>(this->engine());
 
-    std::vector<unsigned char> decodedPrivateKey;
-    bool privkeydecoded = DecodeBase58Check(strCert.Get(), decodedPrivateKey);
+    OTPassword privKey;
 
-    if (privkeydecoded) {
+    bool havePrivkey = engine.AsymmetricKeyToECDSAPrivkey(strCert, privKey);
+
+    if (havePrivkey) {
         secp256k1_pubkey_t pubKey;
-
-        OTPassword privKey;
-        privKey.setMemory(&decodedPrivateKey.front(), decodedPrivateKey.size());
 
         bool validPubkey = engine.secp256k1_pubkey_create(pubKey, privKey);
 

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -56,6 +56,15 @@ void AsymmetricKeySecp256k1::ReleaseKeyLowLevel_Hook() const
 {
 }
 
+bool AsymmetricKeySecp256k1::SetKey(const OTPassword& key)
+{
+    const uint8_t* keyStart = static_cast<const uint8_t*>(key.getMemory());
+    const uint8_t* keyEnd = keyStart + key.getMemorySize();
+
+    String base58Key = EncodeBase58Check(keyStart, keyEnd);
+    return false;
+}
+
 CryptoAsymmetric& AsymmetricKeySecp256k1::engine() const
 
 {

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -40,9 +40,12 @@
 
 #include <opentxs/core/FormattedKey.hpp>
 #include <opentxs/core/String.hpp>
+#include <opentxs/core/crypto/BitcoinCrypto.hpp>
 #include <opentxs/core/crypto/CryptoEngine.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
 #include <opentxs/core/crypto/Libsecp256k1.hpp>
+
+#include <vector>
 
 namespace opentxs
 {
@@ -115,7 +118,7 @@ bool AsymmetricKeySecp256k1::SetPublicKeyFromPrivateKey(
     Libsecp256k1& engine = static_cast<Libsecp256k1&>(this->engine());
 
     std::vector<unsigned char> decodedPrivateKey;
-    bool privkeydecoded = DecodeBase58(strCert.Get(), decodedPrivateKey);
+    bool privkeydecoded = DecodeBase58Check(strCert.Get(), decodedPrivateKey);
 
     if (privkeydecoded) {
         secp256k1_pubkey_t pubKey;

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -40,7 +40,6 @@
 
 #include <opentxs/core/FormattedKey.hpp>
 #include <opentxs/core/String.hpp>
-#include <opentxs/core/crypto/BitcoinCrypto.hpp>
 #include <opentxs/core/crypto/CryptoEngine.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
 #include <opentxs/core/crypto/Libsecp256k1.hpp>

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -114,7 +114,7 @@ bool AsymmetricKeySecp256k1::SetPublicKeyFromPrivateKey(
     }
 
     if (havePrivkey) {
-        secp256k1_pubkey_t pubKey;
+        secp256k1_pubkey pubKey;
 
         bool validPubkey = engine.secp256k1_pubkey_create(pubKey, privKey);
 

--- a/src/core/crypto/AsymmetricKeySecp256k1.cpp
+++ b/src/core/crypto/AsymmetricKeySecp256k1.cpp
@@ -1,0 +1,172 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include <opentxs/core/crypto/AsymmetricKeySecp256k1.hpp>
+
+#include <opentxs/core/FormattedKey.hpp>
+#include <opentxs/core/String.hpp>
+#include <opentxs/core/crypto/CryptoEngine.hpp>
+#include <opentxs/core/crypto/OTPassword.hpp>
+
+namespace opentxs
+{
+
+AsymmetricKeySecp256k1::AsymmetricKeySecp256k1()
+    : OTAsymmetricKey()
+{
+    m_keyType = OTAsymmetricKey::SECP256K1;
+}
+
+void AsymmetricKeySecp256k1::ReleaseKeyLowLevel_Hook() const
+{
+}
+
+CryptoAsymmetric& AsymmetricKeySecp256k1::engine() const
+
+{
+    return CryptoEngine::Instance().SECP256K1();
+}
+
+bool AsymmetricKeySecp256k1::IsEmpty() const
+{
+    return true;
+}
+
+bool AsymmetricKeySecp256k1::SetPrivateKey(
+    __attribute__((unused)) const FormattedKey& strCert,
+    __attribute__((unused)) const String* pstrReason, // This reason is what displays on the
+                              // passphrase dialog.
+    __attribute__((unused)) const OTPassword* pImportPassword) // Used when importing an exported
+                                       // Nym into a wallet.
+{
+    ReleaseKeyLowLevel(); // In case the key is already loaded, we release it
+                          // here. (Since it's being replaced, it's now the
+                          // wrong key anyway.)
+    m_bIsPublicKey = false;
+    m_bIsPrivateKey = true;
+
+    return false;
+}
+
+bool AsymmetricKeySecp256k1::SetPublicKeyFromPrivateKey(
+    __attribute__((unused)) const FormattedKey& strCert,
+    __attribute__((unused)) const String* pstrReason,
+    __attribute__((unused)) const OTPassword* pImportPassword)
+{
+    ReleaseKeyLowLevel(); // In case the key is already loaded, we release it
+                          // here. (Since it's being replaced, it's now the
+                          // wrong key anyway.)
+    m_bIsPublicKey = false;
+    m_bIsPrivateKey = true;
+
+    return false;
+}
+
+bool AsymmetricKeySecp256k1::GetPrivateKey(
+    __attribute__((unused)) FormattedKey& strOutput,
+    __attribute__((unused)) const OTAsymmetricKey* pPubkey,
+    __attribute__((unused)) const String* pstrReason,
+    __attribute__((unused)) const OTPassword* pImportPassword) const
+{
+    return false;
+}
+
+bool AsymmetricKeySecp256k1::GetPublicKey(
+    __attribute__((unused)) String& strKey) const
+{
+    return false;
+}
+
+bool AsymmetricKeySecp256k1::GetPublicKey(
+    __attribute__((unused)) FormattedKey& strKey) const
+{
+    return false;
+}
+
+bool AsymmetricKeySecp256k1::SetPublicKey(
+    __attribute__((unused)) const String& strKey)
+{
+    ReleaseKeyLowLevel(); // In case the key is already loaded, we release it
+                          // here. (Since it's being replaced, it's now the
+                          // wrong key anyway.)
+    m_bIsPublicKey = true;
+    m_bIsPrivateKey = false;
+
+    return false;
+}
+
+bool AsymmetricKeySecp256k1::SetPublicKey(
+    __attribute__((unused)) const FormattedKey& strKey)
+{
+    ReleaseKeyLowLevel(); // In case the key is already loaded, we release it
+                          // here. (Since it's being replaced, it's now the
+                          // wrong key anyway.)
+    m_bIsPublicKey = true;
+    m_bIsPrivateKey = false;
+
+    return false;
+}
+
+bool AsymmetricKeySecp256k1::ReEncryptPrivateKey(
+    __attribute__((unused)) const OTPassword& theExportPassword,
+    __attribute__((unused)) bool bImporting) const
+{
+    return false;
+}
+
+void AsymmetricKeySecp256k1::Release_AsymmetricKeySecp256k1()
+{
+}
+
+void AsymmetricKeySecp256k1::Release()
+{
+    Release_AsymmetricKeySecp256k1(); // My own cleanup is performed here.
+
+    // Next give the base class a chance to do the same...
+    ot_super::Release(); // since I've overridden the base class, I call it
+                         // now...
+}
+
+AsymmetricKeySecp256k1::~AsymmetricKeySecp256k1()
+{
+    Release_AsymmetricKeySecp256k1();
+
+    ReleaseKeyLowLevel_Hook();
+}
+
+} // namespace opentxs

--- a/src/core/crypto/ChildKeyCredential.cpp
+++ b/src/core/crypto/ChildKeyCredential.cpp
@@ -123,7 +123,7 @@ int32_t ChildKeyCredential::ProcessXMLNode(irr::io::IrrXMLReader*& xml)
         if (KeyCredentialType.Exists()) {
             actualCredentialType = StringToCredentialType(KeyCredentialType.Get());
         } else {
-            actualCredentialType = Credential::RSA_PUBKEY; //backward compatibility
+            actualCredentialType = Credential::LEGACY; //backward compatibility
         }
 
         OT_ASSERT(!m_AuthentKey);
@@ -172,7 +172,7 @@ void ChildKeyCredential::UpdateContents()
     if (KeyCredentialType.Exists()) {
         tag.add_attribute("type", KeyCredentialType.Get());
     } else {
-        tag.add_attribute("type", CredentialTypeToString(Credential::RSA_PUBKEY).Get()); //backward compatibility
+        tag.add_attribute("type", CredentialTypeToString(Credential::LEGACY).Get()); //backward compatibility
     }
 
     if (GetNymIDSource().Exists()) {

--- a/src/core/crypto/Credential.cpp
+++ b/src/core/crypto/Credential.cpp
@@ -690,10 +690,10 @@ String Credential::CredentialTypeToString(Credential::CredentialType credentialT
     String credentialString;
 
     switch (credentialType) {
-        case Credential::RSA_PUBKEY :
-            credentialString="rsa";
+        case Credential::LEGACY :
+            credentialString="legacy";
             break;
-        case Credential::SECP256K1_PUBKEY :
+        case Credential::SECP256K1 :
             credentialString="secp256k1";
             break;
         case Credential::URL :
@@ -708,10 +708,10 @@ String Credential::CredentialTypeToString(Credential::CredentialType credentialT
 Credential::CredentialType Credential::StringToCredentialType(const String & credentialType)
 
 {
-    if (credentialType.Compare("rsa"))
-        return Credential::RSA_PUBKEY;
+    if (credentialType.Compare("legacy"))
+        return Credential::LEGACY;
     else if (credentialType.Compare("secp256k1"))
-        return Credential::SECP256K1_PUBKEY;
+        return Credential::SECP256K1;
     else if (credentialType.Compare("url"))
         return Credential::URL;
     return Credential::ERROR_TYPE;
@@ -723,10 +723,10 @@ OTAsymmetricKey::KeyType Credential::CredentialTypeToKeyType(Credential::Credent
     OTAsymmetricKey::KeyType newKeyType;
 
     switch (credentialType) {
-        case Credential::RSA_PUBKEY :
-            newKeyType = OTAsymmetricKey::RSA;
+        case Credential::LEGACY :
+            newKeyType = OTAsymmetricKey::LEGACY;
             break;
-        case Credential::SECP256K1_PUBKEY :
+        case Credential::SECP256K1 :
             newKeyType = OTAsymmetricKey::SECP256K1;
             break;
         case Credential::URL :

--- a/src/core/crypto/Credential.cpp
+++ b/src/core/crypto/Credential.cpp
@@ -687,11 +687,22 @@ const String& Credential::GetPubCredential() const // More intelligent
 String Credential::CredentialTypeToString(Credential::CredentialType credentialType)
 
 {
-    if (credentialType == Credential::RSA_PUBKEY)
-        return "rsa";
-    else if (credentialType == Credential::URL)
-        return "url";
-    return "error";
+    String credentialString;
+
+    switch (credentialType) {
+        case Credential::RSA_PUBKEY :
+            credentialString="rsa";
+            break;
+        case Credential::SECP256K1_PUBKEY :
+            credentialString="secp256k1";
+            break;
+        case Credential::URL :
+            credentialString="url";
+            break;
+        default :
+            credentialString="error";
+    }
+    return credentialString;
 }
 
 Credential::CredentialType Credential::StringToCredentialType(const String & credentialType)
@@ -699,6 +710,8 @@ Credential::CredentialType Credential::StringToCredentialType(const String & cre
 {
     if (credentialType.Compare("rsa"))
         return Credential::RSA_PUBKEY;
+    else if (credentialType.Compare("secp256k1"))
+        return Credential::SECP256K1_PUBKEY;
     else if (credentialType.Compare("url"))
         return Credential::URL;
     return Credential::ERROR_TYPE;
@@ -712,6 +725,9 @@ OTAsymmetricKey::KeyType Credential::CredentialTypeToKeyType(Credential::Credent
     switch (credentialType) {
         case Credential::RSA_PUBKEY :
             newKeyType = OTAsymmetricKey::RSA;
+            break;
+        case Credential::SECP256K1_PUBKEY :
+            newKeyType = OTAsymmetricKey::SECP256K1;
             break;
         case Credential::URL :
             newKeyType = OTAsymmetricKey::NULL_TYPE;

--- a/src/core/crypto/Crypto.cpp
+++ b/src/core/crypto/Crypto.cpp
@@ -42,13 +42,6 @@
 #include <opentxs/core/Log.hpp>
 #include <opentxs/core/util/OTPaths.hpp>
 
-extern "C" {
-#ifdef _WIN32
-#else
-#include <sys/resource.h>
-#endif
-}
-
 #ifdef __APPLE__
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
@@ -203,60 +196,18 @@ uint32_t CryptoConfig::PublicKeysizeMax()
     return GetValue(sp_nPublicKeysizeMax);
 }
 
-// static
-int32_t Crypto::s_nCount =
-    0; // Instance count, should never exceed 1. (At this point, anyway.)
-
-// Currently called by OTLog::OT_Init();
-
 void Crypto::Init() const
 {
-    // This is only supposed to happen once per run.
-    //
-    if (0 == Crypto::s_nCount) {
-        ++(Crypto::s_nCount);
-
-        otWarn << "OT_Init: Setting up rlimits, and crypto library...\n";
-
-// Here is a security measure intended to make it more difficult to capture a
-// core
-// dump. (Not used in debug mode, obviously.)
-//
-#if !defined(PREDEF_MODE_DEBUG) && defined(PREDEF_PLATFORM_UNIX)
-        struct rlimit rlim;
-        getrlimit(RLIMIT_CORE, &rlim);
-        rlim.rlim_max = rlim.rlim_cur = 0;
-        if (setrlimit(RLIMIT_CORE, &rlim)) {
-            OT_FAIL_MSG("Crypto::Init: ASSERT: setrlimit failed. (Used for "
-                        "preventing core dumps.)\n");
-        }
-#endif
-
-        Init_Override();
-    }
-    else
-        otErr << "Crypto::Init: ERROR: Somehow this erroneously got called "
-                 "more than once! (Doing nothing.)\n";
+    Init_Override();
 }
 
-// Currently called by OTLog::OT_Cleanup();
 
 void Crypto::Cleanup() const
 {
-    // This is only supposed to happen once per run.
+    // Any crypto-related cleanup code NOT specific to OpenSSL (which is
+    // handled in OpenSSL, a subclass) would go here.
     //
-    if (1 == Crypto::s_nCount) {
-        --(Crypto::s_nCount);
-
-        // Any crypto-related cleanup code NOT specific to OpenSSL (which is
-        // handled in OpenSSL, a subclass) would go here.
-        //
-
-        Cleanup_Override();
-    }
-    else
-        otErr << "Crypto::Cleanup: ERROR: Somehow this erroneously got "
-                 "called more than once! (Doing nothing.)\n";
+    Cleanup_Override();
 }
 
 // virtual (Should never get called.)

--- a/src/core/crypto/CryptoEngine.cpp
+++ b/src/core/crypto/CryptoEngine.cpp
@@ -45,10 +45,10 @@ CryptoEngine* CryptoEngine::pInstance_ = nullptr;
 
 CryptoEngine::CryptoEngine()
     : pSSL_(new SSLImplementation)
-#ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
-    , psecp256k1_ (new secp256k1)
-#endif
 {
+#ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
+    psecp256k1_ = new Libsecp256k1(*pSSL_);
+#endif
     Init();
 }
 
@@ -89,7 +89,7 @@ CryptoSymmetric& CryptoEngine::AES()
 {
     OT_ASSERT(nullptr != pSSL_);
 
-    return *pSSL_);
+    return *pSSL_;
 }
 #endif
 CryptoEngine& CryptoEngine::Instance()

--- a/src/core/crypto/CryptoEngine.cpp
+++ b/src/core/crypto/CryptoEngine.cpp
@@ -96,6 +96,13 @@ CryptoUtil& CryptoEngine::Util()
     return *pSSL_;
 }
 
+CryptoHash& CryptoEngine::Hash()
+{
+    OT_ASSERT(nullptr != pSSL_);
+
+    return *pSSL_;
+}
+
 #ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
 CryptoAsymmetric& CryptoEngine::RSA()
 {

--- a/src/core/crypto/CryptoEngine.cpp
+++ b/src/core/crypto/CryptoEngine.cpp
@@ -75,14 +75,21 @@ CryptoAsymmetric& CryptoEngine::RSA()
 
     return *pSSL_;
 }
+#endif
+#ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
+CryptoAsymmetric& CryptoEngine::SECP256K1()
+{
+    OT_ASSERT(nullptr != psecp256k1_);
 
+    return *psecp256k1_;
+}
 #endif
 #ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
 CryptoSymmetric& CryptoEngine::AES()
 {
     OT_ASSERT(nullptr != pSSL_);
 
-    return *pSSL_;
+    return *pSSL_);
 }
 #endif
 CryptoEngine& CryptoEngine::Instance()

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -50,9 +50,29 @@ bool CryptoHash::Digest(
     const String& data,
     OTData& digest)
 {
-    OTData plaintext(data.Get(), data.GetLength());
+    OTData plaintext(data.Get(), data.GetLength() + 1); // +1 for null terminator
 
     return Digest(hashType, plaintext, digest);
+}
+
+bool CryptoHash::Digest(
+    const HashType hashType,
+    const OTData& data,
+    OTData& digest)
+{
+    OTPassword plaintext, result;
+    plaintext.setMemory(data);
+
+    bool success =  Digest(hashType, plaintext, result);
+
+    if (success) {
+        digest.Assign(result.getMemory(), result.getMemorySize());
+
+        return true;
+    } else {
+
+        return false;
+    }
 }
 
 bool CryptoHash::HMAC(

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -68,7 +68,9 @@ bool CryptoHash::HMAC(
 
 CryptoHash::HashType CryptoHash::StringToHashType(const String& inputString)
 {
-    if (inputString.Compare("HASH256"))
+    if (inputString.Compare("null"))
+        return CryptoHash::NONE;
+    else if (inputString.Compare("HASH256"))
         return CryptoHash::HASH256;
     else if (inputString.Compare("HASH160"))
         return CryptoHash::HASH160;
@@ -91,6 +93,9 @@ String CryptoHash::HashTypeToString(const CryptoHash::HashType hashType)
     String hashTypeString;
 
     switch (hashType) {
+        case CryptoHash::NONE :
+            hashTypeString = "null";
+            break;
         case CryptoHash::HASH256 :
             hashTypeString = "HASH256";
             break;

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -43,14 +43,14 @@
 namespace opentxs
 {
 
-bool CryptoHash::Hash(
+bool CryptoHash::Digest(
     const HashType hashType,
     const String& data,
     OTData& digest)
 {
     OTData plaintext(data.Get(), data.GetLength());
 
-    return Hash(hashType, plaintext, digest);
+    return Digest(hashType, plaintext, digest);
 }
 
 CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -43,6 +43,40 @@
 namespace opentxs
 {
 
+bool CryptoHash::HMAC(
+        const CryptoHash::HashType hashType,
+        const String& inputKey,
+        const String& inputData,
+        OTData& outputDigest) const
+{
+    OTData convertedKey(inputKey.Get(), inputKey.GetLength());
+    OTData convertedData(inputData.Get(), inputData.GetLength());
+
+    return HMAC(hashType, convertedKey, convertedData, outputDigest);
+}
+
+bool CryptoHash::HMAC(
+        const CryptoHash::HashType hashType,
+        const String& inputKey,
+        const OTData& inputData,
+        OTData& outputDigest) const
+{
+    OTData convertedKey(inputKey.Get(), inputKey.GetLength());
+
+    return HMAC(hashType, convertedKey, inputData, outputDigest);
+}
+
+bool CryptoHash::HMAC(
+        const CryptoHash::HashType hashType,
+        const OTData& inputKey,
+        const String& inputData,
+        OTData& outputDigest) const
+{
+    OTData convertedData(inputData.Get(), inputData.GetLength());
+
+    return HMAC(hashType, inputKey, convertedData, outputDigest);
+}
+
 bool CryptoHash::Digest(
     const HashType hashType,
     const String& data,

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -47,6 +47,8 @@ CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)
 {
     if (inputString.Compare("HASH256"))
         return CryptoHash::HASH256;
+    else if (inputString.Compare("HASH160"))
+        return CryptoHash::HASH160;
     else if (inputString.Compare("SHA1"))
         return CryptoHash::SHA1;
     else if (inputString.Compare("SHA224"))
@@ -68,6 +70,9 @@ String CryptoHash::HashTypeToString(CryptoHash::HashType hashType)
     switch (hashType) {
         case CryptoHash::HASH256 :
             hashTypeString = "HASH256";
+            break;
+        case CryptoHash::HASH160 :
+            hashTypeString = "HASH160";
             break;
         case CryptoHash::SHA1 :
             hashTypeString = "SHA1";

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -66,7 +66,7 @@ bool CryptoHash::HMAC(
     return HMAC(hashType, inputKey, convertedData, outputDigest);
 }
 
-CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)
+CryptoHash::HashType CryptoHash::StringToHashType(const String& inputString)
 {
     if (inputString.Compare("HASH256"))
         return CryptoHash::HASH256;
@@ -85,7 +85,7 @@ CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)
     return CryptoHash::ERROR;
 }
 
-String CryptoHash::HashTypeToString(CryptoHash::HashType hashType)
+String CryptoHash::HashTypeToString(const CryptoHash::HashType hashType)
 
 {
     String hashTypeString;

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -1,0 +1,88 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include <opentxs/core/crypto/CryptoHash.hpp>
+#include <opentxs/core/OTData.hpp>
+#include <opentxs/core/String.hpp>
+
+namespace opentxs
+{
+
+CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)
+{
+    if (inputString.Compare("SHA1"))
+        return CryptoHash::SHA1;
+    else if (inputString.Compare("SHA224"))
+        return CryptoHash::SHA224;
+    else if (inputString.Compare("SHA256"))
+        return CryptoHash::SHA256;
+    else if (inputString.Compare("SHA384"))
+        return CryptoHash::SHA384;
+    else if (inputString.Compare("SHA512"))
+        return CryptoHash::SHA512;
+    return CryptoHash::ERROR;
+}
+
+String CryptoHash::HashTypeToString(CryptoHash::HashType hashType)
+
+{
+    String hashTypeString;
+
+    switch (hashType) {
+        case CryptoHash::SHA1 :
+            hashTypeString = "SHA1";
+            break;
+        case CryptoHash::SHA224 :
+            hashTypeString = "SHA224";
+            break;
+        case CryptoHash::SHA256 :
+            hashTypeString = "SHA256";
+            break;
+        case CryptoHash::SHA384 :
+            hashTypeString = "SHA384";
+            break;
+        case CryptoHash::SHA512 :
+            hashTypeString = "SHA512";
+            break;
+        default :
+            hashTypeString = "ERROR";
+    }
+    return hashTypeString;
+}
+
+} // namespace opentxs

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -37,45 +37,13 @@
  ************************************************************/
 
 #include <opentxs/core/crypto/CryptoHash.hpp>
+
 #include <opentxs/core/OTData.hpp>
 #include <opentxs/core/String.hpp>
+#include <opentxs/core/crypto/OTPassword.hpp>
 
 namespace opentxs
 {
-
-bool CryptoHash::HMAC(
-        const CryptoHash::HashType hashType,
-        const String& inputKey,
-        const String& inputData,
-        OTData& outputDigest) const
-{
-    OTData convertedKey(inputKey.Get(), inputKey.GetLength());
-    OTData convertedData(inputData.Get(), inputData.GetLength());
-
-    return HMAC(hashType, convertedKey, convertedData, outputDigest);
-}
-
-bool CryptoHash::HMAC(
-        const CryptoHash::HashType hashType,
-        const String& inputKey,
-        const OTData& inputData,
-        OTData& outputDigest) const
-{
-    OTData convertedKey(inputKey.Get(), inputKey.GetLength());
-
-    return HMAC(hashType, convertedKey, inputData, outputDigest);
-}
-
-bool CryptoHash::HMAC(
-        const CryptoHash::HashType hashType,
-        const OTData& inputKey,
-        const String& inputData,
-        OTData& outputDigest) const
-{
-    OTData convertedData(inputData.Get(), inputData.GetLength());
-
-    return HMAC(hashType, inputKey, convertedData, outputDigest);
-}
 
 bool CryptoHash::Digest(
     const HashType hashType,
@@ -85,6 +53,17 @@ bool CryptoHash::Digest(
     OTData plaintext(data.Get(), data.GetLength());
 
     return Digest(hashType, plaintext, digest);
+}
+
+bool CryptoHash::HMAC(
+        const CryptoHash::HashType hashType,
+        const OTPassword& inputKey,
+        const String& inputData,
+        OTPassword& outputDigest) const
+{
+    OTData convertedData(inputData.Get(), inputData.GetLength());
+
+    return HMAC(hashType, inputKey, convertedData, outputDigest);
 }
 
 CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -43,6 +43,16 @@
 namespace opentxs
 {
 
+bool CryptoHash::Hash(
+    const HashType hashType,
+    const String& data,
+    OTData& digest)
+{
+    OTData plaintext(data.Get(), data.GetLength());
+
+    return Hash(hashType, plaintext, digest);
+}
+
 CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)
 {
     if (inputString.Compare("HASH256"))

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -45,7 +45,9 @@ namespace opentxs
 
 CryptoHash::HashType CryptoHash::StringToHashType(String& inputString)
 {
-    if (inputString.Compare("SHA1"))
+    if (inputString.Compare("HASH256"))
+        return CryptoHash::HASH256;
+    else if (inputString.Compare("SHA1"))
         return CryptoHash::SHA1;
     else if (inputString.Compare("SHA224"))
         return CryptoHash::SHA224;
@@ -64,6 +66,9 @@ String CryptoHash::HashTypeToString(CryptoHash::HashType hashType)
     String hashTypeString;
 
     switch (hashType) {
+        case CryptoHash::HASH256 :
+            hashTypeString = "HASH256";
+            break;
         case CryptoHash::SHA1 :
             hashTypeString = "SHA1";
             break;

--- a/src/core/crypto/CryptoSymmetric.cpp
+++ b/src/core/crypto/CryptoSymmetric.cpp
@@ -236,18 +236,20 @@ uint32_t CryptoSymmetric::TagSize(const Mode Mode)
     return tagSize;
 }
 
-BinarySecret CryptoSymmetric::GetMasterKey(const OTPasswordData& passwordData, bool askTwice)
+BinarySecret CryptoSymmetric::GetMasterKey(const OTPasswordData& passwordData, const bool askTwice)
 
 {
     BinarySecret masterPassword(std::make_shared<OTPassword>());
 
     OTPassword* masterPasswordInitial = CryptoEngine::Instance().AES().InstantiateBinarySecret();
 
+    OTPasswordData tempData(passwordData.GetDisplayString());
+
     int32_t length_aes_key =
     souped_up_pass_cb(static_cast<char*>(const_cast<void*>(masterPasswordInitial->getMemory())),
                       OTPassword::DEFAULT_SIZE,
                       askTwice,
-                      reinterpret_cast<void*>(const_cast<OTPasswordData*>(&passwordData)));
+                      reinterpret_cast<void*>(&tempData));
 
     masterPassword->setMemory(masterPasswordInitial->getMemory(), length_aes_key);
 

--- a/src/core/crypto/CryptoSymmetric.cpp
+++ b/src/core/crypto/CryptoSymmetric.cpp
@@ -175,6 +175,7 @@ String CryptoSymmetric::ModeToString(const Mode Mode)
     }
     return modeString;
 }
+
 CryptoSymmetric::Mode CryptoSymmetric::StringToMode(const String& Mode)
 {
     if (Mode.Compare("aes-128-cbc"))
@@ -186,6 +187,51 @@ CryptoSymmetric::Mode CryptoSymmetric::StringToMode(const String& Mode)
     if (Mode.Compare("aes-256-gcm"))
         return CryptoSymmetric::AES_256_GCM ;
     return CryptoSymmetric::ERROR_MODE ;
+}
+
+uint32_t CryptoSymmetric::KeySize(const Mode Mode)
+{
+    uint32_t keySize;
+
+    switch (Mode) {
+        case CryptoSymmetric::AES_128_CBC :
+            keySize= 16;
+            break;
+        case CryptoSymmetric::AES_256_ECB  :
+            keySize= 32;
+            break;
+        case CryptoSymmetric::AES_128_GCM  :
+            keySize= 16;
+            break;
+        case CryptoSymmetric::AES_256_GCM  :
+            keySize= 32;
+            break;
+        default :
+            keySize= 0;
+    }
+    return keySize;
+}
+
+uint32_t CryptoSymmetric::IVSize(const Mode Mode)
+{
+    return KeySize(Mode);
+}
+
+uint32_t CryptoSymmetric::TagSize(const Mode Mode)
+{
+    uint32_t tagSize;
+
+    switch (Mode) {
+        case CryptoSymmetric::AES_128_GCM  :
+            tagSize= 16;
+            break;
+        case CryptoSymmetric::AES_256_GCM  :
+            tagSize= 16;
+            break;
+        default :
+            tagSize= 0;
+    }
+    return tagSize;
 }
 
 } // namespace opentxs

--- a/src/core/crypto/CryptoSymmetric.cpp
+++ b/src/core/crypto/CryptoSymmetric.cpp
@@ -40,6 +40,8 @@
 
 #include <opentxs/core/OTData.hpp>
 #include <opentxs/core/crypto/Crypto.hpp>
+#include <opentxs/core/crypto/CryptoEngine.hpp>
+#include <opentxs/core/crypto/OTAsymmetricKey.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
 #include <opentxs/core/crypto/OTPasswordData.hpp>
 
@@ -232,6 +234,27 @@ uint32_t CryptoSymmetric::TagSize(const Mode Mode)
             tagSize= 0;
     }
     return tagSize;
+}
+
+BinarySecret CryptoSymmetric::GetMasterKey(const OTPasswordData& passwordData, bool askTwice)
+
+{
+    BinarySecret masterPassword(std::make_shared<OTPassword>());
+
+    OTPassword* masterPasswordInitial = CryptoEngine::Instance().AES().InstantiateBinarySecret();
+
+    int32_t length_aes_key =
+    souped_up_pass_cb(static_cast<char*>(const_cast<void*>(masterPasswordInitial->getMemory())),
+                      OTPassword::DEFAULT_SIZE,
+                      askTwice,
+                      reinterpret_cast<void*>(const_cast<OTPasswordData*>(&passwordData)));
+
+    masterPassword->setMemory(masterPasswordInitial->getMemory(), length_aes_key);
+
+    delete masterPasswordInitial;
+    masterPasswordInitial = nullptr;
+
+    return masterPassword;
 }
 
 } // namespace opentxs

--- a/src/core/crypto/CryptoSymmetric.cpp
+++ b/src/core/crypto/CryptoSymmetric.cpp
@@ -153,4 +153,39 @@ bool CryptoSymmetricDecryptOutput::Concatenate(const void* pAppendData,
     return false;
 }
 
+String CryptoSymmetric::ModeToString(const Mode Mode)
+{
+    String modeString;
+
+    switch (Mode) {
+        case CryptoSymmetric::AES_128_CBC :
+            modeString="aes-128-cbc";
+            break;
+        case CryptoSymmetric::AES_256_ECB  :
+            modeString="aes-256-ecb";
+            break;
+        case CryptoSymmetric::AES_128_GCM  :
+            modeString="aes-128-gcm";
+            break;
+        case CryptoSymmetric::AES_256_GCM  :
+            modeString="aes-256-gcm";
+            break;
+        default :
+            modeString="error";
+    }
+    return modeString;
+}
+CryptoSymmetric::Mode CryptoSymmetric::StringToMode(const String& Mode)
+{
+    if (Mode.Compare("aes-128-cbc"))
+        return CryptoSymmetric::AES_128_CBC ;
+    if (Mode.Compare("aes-256-ecb"))
+        return CryptoSymmetric::AES_256_ECB ;
+    if (Mode.Compare("aes-128-gcm"))
+        return CryptoSymmetric::AES_128_GCM ;
+    if (Mode.Compare("aes-256-gcm"))
+        return CryptoSymmetric::AES_256_GCM ;
+    return CryptoSymmetric::ERROR_MODE ;
+}
+
 } // namespace opentxs

--- a/src/core/crypto/CryptoUtil.cpp
+++ b/src/core/crypto/CryptoUtil.cpp
@@ -42,6 +42,8 @@
 
 #include <iostream>
 #include <opentxs/core/Log.hpp>
+#include <opentxs/core/OTData.hpp>
+#include <opentxs/core/crypto/BitcoinCrypto.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
 
 namespace opentxs
@@ -93,6 +95,29 @@ bool CryptoUtil::IsBase62(const std::string& str) const
 {
     return str.find_first_not_of("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHI"
                                  "JKLMNOPQRSTUVWXYZ") == std::string::npos;
+}
+
+String CryptoUtil::Nonce(const uint32_t size) const
+{
+    OTData unusedOutput;
+    return Nonce(size, unusedOutput);
+}
+
+String CryptoUtil::Nonce(const uint32_t size, OTData& rawOutput) const
+{
+    rawOutput.zeroMemory();
+    rawOutput.SetSize(size);
+
+    OTPassword source;
+    source.randomizeMemory(size);
+
+    const uint8_t* nonceStart = static_cast<const uint8_t*>(source.getMemory());
+    const uint8_t* nonceEnd = nonceStart + source.getMemorySize();
+
+    String nonce(EncodeBase58Check(nonceStart, nonceEnd));
+
+    rawOutput.Assign(source.getMemory(), source.getMemorySize());
+    return nonce;
 }
 
 } // namespace opentxs

--- a/src/core/crypto/CryptoUtil.cpp
+++ b/src/core/crypto/CryptoUtil.cpp
@@ -120,4 +120,53 @@ String CryptoUtil::Nonce(const uint32_t size, OTData& rawOutput) const
     return nonce;
 }
 
+String CryptoUtil::Base58CheckEncode(const OTData& input)
+{
+    OTPassword transformedInput;
+    transformedInput.setMemory(input);
+
+    return Base58CheckEncode(transformedInput);
+}
+
+String CryptoUtil::Base58CheckEncode(const OTPassword& input)
+{
+    const uint8_t* inputStart = static_cast<const uint8_t*>(input.getMemory());
+    const uint8_t* inputEnd = inputStart + input.getMemorySize();
+
+    String encodedInput = ::EncodeBase58Check(inputStart, inputEnd);
+    return encodedInput;
+}
+
+bool CryptoUtil::Base58CheckDecode(const String& input, OTPassword& output)
+{
+    OTData decodedOutput;
+    bool decoded = Base58CheckDecode(input, decodedOutput);
+
+    if (decoded) {
+        output.setMemory(decodedOutput);
+
+        return true;
+    } else {
+
+        return false;
+    }
+}
+
+bool CryptoUtil::Base58CheckDecode(const String& input, OTData& output)
+{
+    std::vector<unsigned char> decodedInput;
+    bool decoded = DecodeBase58Check(input.Get(), decodedInput);
+
+    if (decoded) {
+        OTData dataOutput(decodedInput);
+        output = dataOutput;
+
+        return true;
+    } else {
+
+        return false;
+    }
+}
+
+
 } // namespace opentxs

--- a/src/core/crypto/CryptoUtil.cpp
+++ b/src/core/crypto/CryptoUtil.cpp
@@ -111,10 +111,7 @@ String CryptoUtil::Nonce(const uint32_t size, OTData& rawOutput) const
     OTPassword source;
     source.randomizeMemory(size);
 
-    const uint8_t* nonceStart = static_cast<const uint8_t*>(source.getMemory());
-    const uint8_t* nonceEnd = nonceStart + source.getMemorySize();
-
-    String nonce(EncodeBase58Check(nonceStart, nonceEnd));
+    String nonce(Base58CheckEncode(source));
 
     rawOutput.Assign(source.getMemory(), source.getMemorySize());
     return nonce;

--- a/src/core/crypto/KeyCredential.cpp
+++ b/src/core/crypto/KeyCredential.cpp
@@ -592,7 +592,7 @@ bool KeyCredential::Sign(Contract& theContract, const OTPasswordData* pPWData)
 bool KeyCredential::ReEncryptKeys(const OTPassword& theExportPassword,
                                     bool bImporting)
 {
-    String strSign, strAuth, strEncr;
+    FormattedKey strSign, strAuth, strEncr;
 
     OT_ASSERT(m_AuthentKey);
     OT_ASSERT(m_EncryptKey);

--- a/src/core/crypto/Letter.cpp
+++ b/src/core/crypto/Letter.cpp
@@ -248,7 +248,7 @@ bool Letter::Seal(
             pKeyData = std::make_shared<NymParameters>(
                 NymParameters::SECP256K1,
                 Credential::SECP256K1_PUBKEY);
-            ephemeralKeypair.MakeNewKeypair(pKeyData);
+            ephemeralKeypair.MakeNewKeypair(pKeyData, true);
             ephemeralKeypair.GetPublicKey(ephemeralPubkey);
 
             const OTAsymmetricKey& ephemeralPrivkey = ephemeralKeypair.GetPrivateKey();
@@ -263,11 +263,14 @@ bool Letter::Seal(
                     "",
                     nullptr);
 
+                OTPasswordData passwordData("ephemeral");
                 bool haveSessionKey = engine.EncryptSessionKeyECDH(
                                         *masterSessionKey,
                                         ephemeralPrivkey,
                                         *(it.second),
-                                        encryptedSessionKey);
+                                        passwordData,
+                                        encryptedSessionKey,
+                                        true);
                 if (haveSessionKey) {
                     sessionKeys.push_back(encryptedSessionKey);
 
@@ -345,6 +348,8 @@ bool Letter::Open(
     String& theOutput,
     const OTPasswordData* pPWData)
 {
+    OT_ASSERT(nullptr != pPWData);
+
     OTASCIIArmor armoredInput(dataInput);
     String decodedInput;
     OTData decodedCiphertext;
@@ -395,8 +400,8 @@ bool Letter::Open(
                                                             it,
                                                             privateKey,
                                                             *publicKey,
-                                                            *sessionKey
-                                                        );
+                                                            *pPWData,
+                                                            *sessionKey);
                                     if (haveSessionKey) {
                                         break;
                                     }

--- a/src/core/crypto/Letter.cpp
+++ b/src/core/crypto/Letter.cpp
@@ -198,7 +198,7 @@ bool Letter::Seal(
                 haveRecipientsECDSA = true;
                 secp256k1Recipients.insert(std::pair<std::string, OTAsymmetricKey*>(it.first, it.second));
                 break;
-            case OTAsymmetricKey::RSA :
+            case OTAsymmetricKey::LEGACY :
                 haveRecipientsRSA = true;
                 RSARecipients.insert(std::pair<std::string, OTAsymmetricKey*>(it.first, it.second));
                 break;
@@ -249,7 +249,7 @@ bool Letter::Seal(
             std::shared_ptr<NymParameters> pKeyData;
             pKeyData = std::make_shared<NymParameters>(
                 NymParameters::SECP256K1,
-                Credential::SECP256K1_PUBKEY);
+                Credential::SECP256K1);
             ephemeralKeypair.MakeNewKeypair(pKeyData, true);
             ephemeralKeypair.GetPublicKey(ephemeralPubkey);
 
@@ -458,7 +458,7 @@ bool Letter::Open(
         }
     }
 
-    if (privateKey.keyType() == OTAsymmetricKey::RSA) {
+    if (privateKey.keyType() == OTAsymmetricKey::LEGACY) {
 
         // Get all the session keys
         listOfSessionKeys sessionKeys(contents.SessionKeys());

--- a/src/core/crypto/Letter.cpp
+++ b/src/core/crypto/Letter.cpp
@@ -135,9 +135,19 @@ void Letter::Release()
     m_strContractType.Set("LETTER");
 }
 
+const String& Letter::EphemeralKey() const
+{
+    return ephemeralKey_;
+}
+
 const String& Letter::Nonce() const
 {
     return nonce_;
+}
+
+const String& Letter::MACType() const
+{
+    return macType_;
 }
 
 const String& Letter::SessionKey() const

--- a/src/core/crypto/Letter.cpp
+++ b/src/core/crypto/Letter.cpp
@@ -1,0 +1,153 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include <opentxs/core/crypto/Letter.hpp>
+
+#include <opentxs/core/Log.hpp>
+#include <opentxs/core/util/Tag.hpp>
+
+#include <cstring>
+#include <irrxml/irrXML.hpp>
+
+namespace opentxs
+{
+
+void Letter::UpdateContents()
+{
+    // I release this because I'm about to repopulate it.
+    m_xmlUnsigned.Release();
+
+    Tag rootNode("letter");
+
+    rootNode.add_attribute("ephemeralkey", ephemeralKey_.Get());
+    rootNode.add_attribute("mac", macType_.Get());
+    rootNode.add_attribute("nonce", nonce_.Get());
+    rootNode.add_attribute("sessionkey", sessionKey_.Get());
+    rootNode.add_tag("ciphertext", ciphertext_.Get());
+
+    std::string str_result;
+    rootNode.output(str_result);
+
+    m_xmlUnsigned.Concatenate("%s", str_result.c_str());
+}
+
+int32_t Letter::ProcessXMLNode(irr::io::IrrXMLReader*& xml)
+{
+    int32_t nReturnVal = 0;
+
+    const String strNodeName(xml->getNodeName());
+
+    if (strNodeName.Compare("letter")) {
+        ephemeralKey_ = xml->getAttributeValue("ephemeralkey");
+        macType_ = xml->getAttributeValue("mac");
+        nonce_ = xml->getAttributeValue("nonce");
+        sessionKey_ = xml->getAttributeValue("sessionkey");
+        nReturnVal = 1;
+    }
+    else if (strNodeName.Compare("ciphertext")) {
+        if (false ==
+            Contract::LoadEncodedTextField(xml, ciphertext_)) {
+            otErr << "Error in Letter::ProcessXMLNode: no ciphertext.\n";
+            return (-1); // error condition
+        }
+        return 1;
+    }
+
+    return nReturnVal;
+}
+
+Letter::Letter(
+        const String& ephemeralKey,
+        const String& macType,
+        const String& nonce,
+        const String& sessionKey,
+        const OTASCIIArmor& ciphertext)
+    : Contract()
+    , ephemeralKey_(ephemeralKey)
+    , macType_(macType)
+    , nonce_(nonce)
+    , sessionKey_(sessionKey)
+    , ciphertext_(ciphertext)
+
+{
+    m_strContractType.Set("LETTER");
+}
+
+Letter::Letter(
+        const String& input)
+    : Contract()
+{
+    m_strContractType.Set("LETTER");
+    m_xmlUnsigned = input;
+    LoadContractXML();
+}
+
+Letter::~Letter()
+{
+    Release_Letter();
+}
+
+void Letter::Release_Letter()
+{
+}
+
+void Letter::Release()
+{
+    Release_Letter();
+
+    ot_super::Release();
+
+    m_strContractType.Set("LETTER");
+}
+
+const String& Letter::Nonce() const
+{
+    return nonce_;
+}
+
+const String& Letter::SessionKey() const
+{
+    return sessionKey_;
+}
+
+const OTASCIIArmor& Letter::Ciphertext() const
+{
+   return ciphertext_;
+}
+
+} // namespace opentxs

--- a/src/core/crypto/Letter.cpp
+++ b/src/core/crypto/Letter.cpp
@@ -70,21 +70,19 @@ void Letter::UpdateContents()
     rootNode.add_attribute("iv", iv_.Get());
     rootNode.add_attribute("tag", tag_.Get());
 
-    if (!sessionKeys_.empty()) {
-        for (auto& it : sessionKeys_) {
-            TagPtr sessionKeyNode = std::make_shared<Tag>("sessionkey");
-            OTASCIIArmor sessionKey;
+    for (auto& it : sessionKeys_) {
+        TagPtr sessionKeyNode = std::make_shared<Tag>("sessionkey");
+        OTASCIIArmor sessionKey;
 
-            std::get<4>(it)->GetAsciiArmoredData(sessionKey);
+        std::get<4>(it)->GetAsciiArmoredData(sessionKey);
 
-            sessionKeyNode->add_attribute("algo", std::get<0>(it).Get());
-            sessionKeyNode->add_attribute("hmac", std::get<1>(it).Get());
-            sessionKeyNode->add_attribute("nonce", std::get<2>(it).Get());
-            sessionKeyNode->add_attribute("tag", std::get<3>(it).Get());
-            sessionKeyNode->set_text(sessionKey.Get());
+        sessionKeyNode->add_attribute("algo", std::get<0>(it).Get());
+        sessionKeyNode->add_attribute("hmac", std::get<1>(it).Get());
+        sessionKeyNode->add_attribute("nonce", std::get<2>(it).Get());
+        sessionKeyNode->add_attribute("tag", std::get<3>(it).Get());
+        sessionKeyNode->set_text(sessionKey.Get());
 
-            rootNode.add_tag(sessionKeyNode);
-        }
+        rootNode.add_tag(sessionKeyNode);
     }
 
     rootNode.add_tag("ciphertext", ciphertext_.Get());
@@ -190,7 +188,7 @@ bool Letter::Seal(
     mapOfAsymmetricKeys secp256k1Recipients;
     mapOfAsymmetricKeys RSARecipients;
 
-    for (auto it : RecipPubKeys) {
+    for (auto& it : RecipPubKeys) {
         switch (it.second->keyType()) {
             case OTAsymmetricKey::SECP256K1 :
                 haveRecipientsECDSA = true;
@@ -281,8 +279,8 @@ bool Letter::Seal(
             }
             #else
 
-            otErr << "Letter::" << __FUNCTION__ << ": Attempting to Seal to OpenSSL recipients"
-                <<" without OpenSSL support.\n";
+            otErr << "Letter::" << __FUNCTION__ << ": Attempting to Seal to secp256k1 recipients"
+                <<" without Libsecp256k1 support.\n";
             return false;
             #endif
         }
@@ -395,7 +393,7 @@ bool Letter::Open(
                                 Libsecp256k1& engine = static_cast<Libsecp256k1&>(privateKey.engine());
 
                                 // The only way to know which session key (might) belong to us to try them all
-                                for (auto it : sessionKeys) {
+                                for (auto& it : sessionKeys) {
                                     haveSessionKey = engine.DecryptSessionKeyECDH(
                                                             it,
                                                             privateKey,
@@ -425,7 +423,7 @@ bool Letter::Open(
                             OpenSSL& engine = static_cast<OpenSSL&>(CryptoEngine::Instance().RSA());
 
                             // The only way to know which session key (might) belong to us to try them all
-                            for (auto it : sessionKeys) {
+                            for (auto& it : sessionKeys) {
                                 OTData plaintextSessionKey;
 
                                 haveSessionKey = engine.Open(std::get<4>(it)->m_dataContents, theRecipient, plaintextSessionKey, pPWData);

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -57,6 +57,47 @@ Libsecp256k1::Libsecp256k1()
         reinterpret_cast<const unsigned char*>(randomSeedArmored.Get()));
 }
 
+bool Libsecp256k1::Seal(
+    __attribute__((unused)) mapOfAsymmetricKeys& RecipPubKeys,
+    __attribute__((unused)) const String& theInput,
+    __attribute__((unused)) OTData& dataOutput
+    ) const
+{
+    return false;
+}
+
+bool Libsecp256k1::Open(
+    __attribute__((unused)) OTData& dataInput,
+    __attribute__((unused)) const Nym& theRecipient,
+    __attribute__((unused)) String& theOutput,
+    __attribute__((unused)) const OTPasswordData* pPWData
+    ) const
+{
+    return false;
+}
+
+bool Libsecp256k1::SignContract(
+    __attribute__((unused)) const String& strContractUnsigned,
+    __attribute__((unused)) const OTAsymmetricKey& theKey,
+    __attribute__((unused)) OTSignature& theSignature, // output
+    __attribute__((unused)) const String& strHashType,
+    __attribute__((unused)) const OTPasswordData* pPWData
+    )
+{
+    return false;
+}
+
+bool Libsecp256k1::VerifySignature(
+    __attribute__((unused)) const String& strContractToVerify,
+    __attribute__((unused)) const OTAsymmetricKey& theKey,
+    __attribute__((unused)) const OTSignature& theSignature,
+    __attribute__((unused)) const String& strHashType,
+    __attribute__((unused)) const OTPasswordData* pPWData
+    ) const
+{
+    return false;
+}
+
 Libsecp256k1::~Libsecp256k1()
 {
 }

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -83,7 +83,14 @@ bool Libsecp256k1::SignContract(
 
     if (haveDigest) {
         OTPassword privKey;
-        bool havePrivateKey = AsymmetricKeyToECDSAPrivkey(theKey, *pPWData, privKey);
+        bool havePrivateKey;
+
+        if (nullptr == pPWData) {
+            OTPasswordData passwordData("Libsecp256k1::SignContract(): Please enter your password to sign this document.");
+            havePrivateKey = AsymmetricKeyToECDSAPrivkey(theKey, passwordData, privKey);
+        } else {
+            havePrivateKey = AsymmetricKeyToECDSAPrivkey(theKey, *pPWData, privKey);
+        }
 
         if (havePrivateKey) {
             secp256k1_ecdsa_signature_t ecdsaSignature;
@@ -267,7 +274,7 @@ bool Libsecp256k1::AsymmetricKeyToECDSAPrivkey(
     if (ephemeral) {
         masterPassword->setPassword("test");
     } else {
-        masterPassword = CryptoSymmetric::GetMasterKey(passwordData, true);
+        masterPassword = CryptoSymmetric::GetMasterKey(passwordData);
     }
 
     OTPassword keyPassword;

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -92,7 +92,7 @@ bool Libsecp256k1::Seal(
     String nonce = Nonce(ECDHDefaultHMACSize);
     ephemeralKeypair.GetPublicKey(ephemeralPubkey);
 
-    std::unique_ptr<OTPassword> ECDHSecret(CryptoEngine::Instance().AES().InstantiateBinarySecret());
+    BinarySecret ECDHSecret(CryptoEngine::Instance().AES().InstantiateBinarySecretSP());
     bool haveECDH = ECDH(*recipient, ephemeralPrivkey, *ECDHSecret);
 
     if (haveECDH) {
@@ -185,7 +185,7 @@ bool Libsecp256k1::Open(
                     OTAsymmetricKey* publicKey = OTAsymmetricKey::KeyFactory(OTAsymmetricKey::SECP256K1);
                     publicKey->SetPublicKey(ephemeralPubkey);
 
-                    std::unique_ptr<OTPassword> ECDHSecret(CryptoEngine::Instance().AES().InstantiateBinarySecret());
+                    BinarySecret ECDHSecret(CryptoEngine::Instance().AES().InstantiateBinarySecretSP());
                     ECDH(*publicKey, privateKey, *ECDHSecret);
 
                     OTPassword sharedSecret;

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -86,12 +86,12 @@ bool Libsecp256k1::Seal(
 
     String examplePassword("this is an example password");
     OTData passwordHash;
-    CryptoEngine::Instance().Hash().Hash(CryptoHash::SHA512, examplePassword, passwordHash);
+    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA512, examplePassword, passwordHash);
     OTPassword sessionKey;
     sessionKey.setMemory(passwordHash);
 
     OTData nonceHash;
-    CryptoEngine::Instance().Hash().Hash(CryptoHash::SHA512, nonce, nonceHash);
+    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA512, nonce, nonceHash);
 
     OTPassword truncatedSessionKey(sessionKey.getMemory(), CryptoConfig::SymmetricKeySize());
     OTData truncatedNonceHash(nonceHash.GetPointer(), CryptoConfig::SymmetricIvSize());
@@ -161,9 +161,9 @@ bool Libsecp256k1::Open(
                 bool haveDecodedCiphertext = ciphertext.GetData(decodedCiphertext);
 
                 if (haveDecodedCiphertext) {
-                    CryptoEngine::Instance().Hash().Hash(CryptoHash::SHA512, examplePassword, passwordHash);
+                    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA512, examplePassword, passwordHash);
                     sessionKey.setMemory(passwordHash);
-                    CryptoEngine::Instance().Hash().Hash(CryptoHash::SHA512, nonce, nonceHash);
+                    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA512, nonce, nonceHash);
 
                     OTPassword truncatedSessionKey(sessionKey.getMemory(), CryptoConfig::SymmetricKeySize());
                     OTData truncatedNonceHash(nonceHash.GetPointer(), CryptoConfig::SymmetricIvSize());
@@ -209,7 +209,7 @@ bool Libsecp256k1::SignContract(
     __attribute__((unused)) const OTPasswordData* pPWData)
 {
     OTData hash;
-    bool haveDigest = CryptoEngine::Instance().Hash().Hash(hashType, strContractUnsigned, hash);
+    bool haveDigest = CryptoEngine::Instance().Hash().Digest(hashType, strContractUnsigned, hash);
 
     if (haveDigest) {
         OTPassword privKey;
@@ -258,7 +258,7 @@ bool Libsecp256k1::VerifySignature(
     ) const
 {
     OTData hash;
-    bool haveDigest = CryptoEngine::Instance().Hash().Hash(hashType, strContractToVerify, hash);
+    bool haveDigest = CryptoEngine::Instance().Hash().Digest(hashType, strContractToVerify, hash);
 
     if (haveDigest) {
         secp256k1_pubkey_t ecdsaPubkey;

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -277,8 +277,16 @@ bool Libsecp256k1::AsymmetricKeyToECDSAPrivkey(
         masterPassword = CryptoSymmetric::GetMasterKey(passwordData);
     }
 
+    return ImportECDSAPrivkey(asymmetricKey, *masterPassword, privkey);
+}
+
+bool Libsecp256k1::ImportECDSAPrivkey(
+    const FormattedKey& asymmetricKey,
+    const OTPassword& password,
+    OTPassword& privkey) const
+{
     OTPassword keyPassword;
-    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA256, *masterPassword, keyPassword);
+    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA256, password, keyPassword);
 
     OTData encryptedPrivkey;
     bool privkeydecoded = CryptoUtil::Base58CheckDecode(asymmetricKey.Get(), encryptedPrivkey);
@@ -314,8 +322,16 @@ bool Libsecp256k1::ECDSAPrivkeyToAsymmetricKey(
         masterPassword = CryptoSymmetric::GetMasterKey(passwordData, true);
     }
 
+    return ExportECDSAPrivkey(privkey, *masterPassword, asymmetricKey);
+}
+
+bool Libsecp256k1::ExportECDSAPrivkey(
+    const OTPassword& privkey,
+    const OTPassword& password,
+    OTAsymmetricKey& asymmetricKey) const
+{
     OTPassword keyPassword;
-    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA256, *masterPassword, keyPassword);
+    CryptoEngine::Instance().Hash().Digest(CryptoHash::SHA256, password, keyPassword);
 
     OTData encryptedKey;
     CryptoEngine::Instance().AES().Encrypt(

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -76,7 +76,7 @@ bool Libsecp256k1::SignContract(
     __attribute__((unused)) const String& strContractUnsigned,
     __attribute__((unused)) const OTAsymmetricKey& theKey,
     __attribute__((unused)) OTSignature& theSignature, // output
-    __attribute__((unused)) const String& strHashType,
+    __attribute__((unused)) const CryptoHash::HashType hashType,
     __attribute__((unused)) const OTPasswordData* pPWData
     )
 {
@@ -87,7 +87,7 @@ bool Libsecp256k1::VerifySignature(
     __attribute__((unused)) const String& strContractToVerify,
     __attribute__((unused)) const OTAsymmetricKey& theKey,
     __attribute__((unused)) const OTSignature& theSignature,
-    __attribute__((unused)) const String& strHashType,
+    __attribute__((unused)) const CryptoHash::HashType hashType,
     __attribute__((unused)) const OTPasswordData* pPWData
     ) const
 {

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -71,25 +71,6 @@ Libsecp256k1::Libsecp256k1(CryptoUtil& ssl)
 }
 
 
-bool Libsecp256k1::Seal(
-    __attribute__((unused)) mapOfAsymmetricKeys& RecipPubKeys,
-    __attribute__((unused)) const String& theInput,
-    __attribute__((unused)) OTData& dataOutput
-    ) const
-{
-    return false;
-}
-
-bool Libsecp256k1::Open(
-    __attribute__((unused)) OTData& dataInput,
-    __attribute__((unused)) const Nym& theRecipient,
-    __attribute__((unused)) String& theOutput,
-    __attribute__((unused)) const OTPasswordData* pPWData
-    ) const
-{
-    return false;
-}
-
 bool Libsecp256k1::SignContract(
     const String& strContractUnsigned,
     const OTAsymmetricKey& theKey,

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -38,23 +38,23 @@
 
 #include <opentxs/core/crypto/Libsecp256k1.hpp>
 
-#include <opentxs/core/OTData.hpp>
-#include <opentxs/core/crypto/OTASCIIArmor.hpp>
+#include <opentxs/core/crypto/CryptoEngine.hpp>
+#include <opentxs/core/crypto/CryptoUtil.hpp>
 
 namespace opentxs
 {
 
-Libsecp256k1::Libsecp256k1()
+Libsecp256k1::Libsecp256k1(CryptoUtil& ssl)
     : Crypto(),
-    context_(secp256k1_context_create(SECP256K1_CONTEXT_SIGN & SECP256K1_CONTEXT_VERIFY))
+    context_(secp256k1_context_create(SECP256K1_CONTEXT_SIGN))
 {
-    OTData randomSeed;
-    randomSeed.Randomize(32);
-    OTASCIIArmor randomSeedArmored(randomSeed);
+    uint8_t randomSeed [32] = {0};
+
+    ssl.RandomizeMemory(&randomSeed[0], 32);
 
     int __attribute__((unused)) randomize = secp256k1_context_randomize(
         context_,
-        reinterpret_cast<const unsigned char*>(randomSeedArmored.Get()));
+        randomSeed);
 }
 
 bool Libsecp256k1::Seal(

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -88,8 +88,7 @@ bool Libsecp256k1::SignContract(
     __attribute__((unused)) const OTPasswordData* pPWData)
 {
     OTData hash;
-    OTData plaintext(strContractUnsigned.Get(), strContractUnsigned.GetLength());
-    bool haveDigest = CryptoEngine::Instance().Hash().Hash(hashType, plaintext, hash);
+    bool haveDigest = CryptoEngine::Instance().Hash().Hash(hashType, strContractUnsigned, hash);
 
     if (haveDigest) {
         OTPassword privKey;
@@ -138,8 +137,7 @@ bool Libsecp256k1::VerifySignature(
     ) const
 {
     OTData hash;
-    OTData plaintext(strContractToVerify.Get(), strContractToVerify.GetLength());
-    bool haveDigest = CryptoEngine::Instance().Hash().Hash(hashType, plaintext, hash);
+    bool haveDigest = CryptoEngine::Instance().Hash().Hash(hashType, strContractToVerify, hash);
 
     if (haveDigest) {
         secp256k1_pubkey_t ecdsaPubkey;

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -40,6 +40,7 @@
 
 #include <opentxs/core/crypto/CryptoEngine.hpp>
 #include <opentxs/core/crypto/CryptoUtil.hpp>
+#include <opentxs/core/crypto/OTPassword.hpp>
 
 namespace opentxs
 {
@@ -95,13 +96,44 @@ bool Libsecp256k1::VerifySignature(
 
 bool Libsecp256k1::secp256k1_privkey_tweak_add(
     uint8_t key [32],
-        const uint8_t tweak [32]) const
+    const uint8_t tweak [32]) const
 {
     if (nullptr != context_) {
         return secp256k1_ec_privkey_tweak_add(context_, key, tweak);
     } else {
         return false;
     }
+}
+
+bool Libsecp256k1::secp256k1_pubkey_create(
+    secp256k1_pubkey_t& pubkey,
+    const OTPassword& privkey) const
+{
+    if (nullptr != context_) {
+        return secp256k1_ec_pubkey_create(context_, &pubkey, static_cast<const unsigned char*>(privkey.getMemory()));
+    }
+
+    return false;
+}
+
+bool Libsecp256k1::secp256k1_pubkey_serialize(
+        OTPassword& serializedPubkey,
+        const secp256k1_pubkey_t& pubkey) const
+{
+    if (nullptr != context_) {
+        uint8_t serializedOutput [65] {};
+        int serializedSize = 0;
+
+        bool serialized = secp256k1_ec_pubkey_serialize(context_, serializedOutput, &serializedSize, &pubkey, false);
+
+        if (serialized) {
+            serializedPubkey.setMemory(serializedOutput, serializedSize);
+            return serialized;
+        }
+
+    }
+
+    return false;
 }
 
 Libsecp256k1::~Libsecp256k1()

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -136,6 +136,22 @@ bool Libsecp256k1::secp256k1_pubkey_serialize(
     return false;
 }
 
+bool Libsecp256k1::secp256k1_pubkey_parse(
+        secp256k1_pubkey_t& pubkey,
+        const OTPassword& serializedPubkey) const
+{
+    if (nullptr != context_) {
+
+        const uint8_t* inputStart = static_cast<const uint8_t*>(serializedPubkey.getMemory());
+
+        bool parsed = secp256k1_ec_pubkey_parse(context_, &pubkey, inputStart, serializedPubkey.getMemorySize());
+
+        return parsed;
+    }
+
+    return false;
+}
+
 Libsecp256k1::~Libsecp256k1()
 {
     OT_ASSERT_MSG(nullptr != context_, "Libsecp256k1::~Libsecp256k1: context_ should never be nullptr, yet it was.")

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -349,7 +349,7 @@ bool Libsecp256k1::ExportECDSAPrivkey(
 bool Libsecp256k1::ECDH(
     const OTAsymmetricKey& publicKey,
     const OTAsymmetricKey& privateKey,
-    const OTPasswordData passwordData,
+    const OTPasswordData& passwordData,
     OTPassword& secret,
     bool ephemeral) const
 {
@@ -460,7 +460,7 @@ bool Libsecp256k1::DecryptSessionKeyECDH(
     const symmetricEnvelope& encryptedSessionKey,
     const OTAsymmetricKey& privateKey,
     const OTAsymmetricKey& publicKey,
-    const OTPasswordData passwordData,
+    const OTPasswordData& passwordData,
     OTPassword& sessionKey) const
 {
     CryptoSymmetric::Mode algo = CryptoSymmetric::StringToMode(std::get<0>(encryptedSessionKey));

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -380,13 +380,11 @@ bool Libsecp256k1::EncryptSessionKeyECDH(
 
                     if (encrypted) {
                         OTASCIIArmor encodedCiphertext(ciphertext);
-                        OTEnvelope sessionKeyEnvelope(encodedCiphertext);
-
                         String tagReadable(CryptoUtil::Base58CheckEncode(tag));
 
                         std::get<2>(encryptedSessionKey) = nonceReadable;
                         std::get<3>(encryptedSessionKey) = tagReadable;
-                        std::get<4>(encryptedSessionKey) = sessionKeyEnvelope;
+                        std::get<4>(encryptedSessionKey) = std::make_shared<OTEnvelope>(encodedCiphertext);
 
                         return true;
                     } else {
@@ -455,7 +453,7 @@ bool Libsecp256k1::DecryptSessionKeyECDH(
                     // Extract and decode the ciphertext from the envelope
                     OTData ciphertext;
                     OTASCIIArmor encodedCiphertext;
-                    std::get<4>(encryptedSessionKey).GetAsciiArmoredData(encodedCiphertext);
+                    std::get<4>(encryptedSessionKey)->GetAsciiArmoredData(encodedCiphertext);
                     encodedCiphertext.GetData(ciphertext);
 
                     return CryptoEngine::Instance().AES().Decrypt(

--- a/src/core/crypto/Libsecp256k1.cpp
+++ b/src/core/crypto/Libsecp256k1.cpp
@@ -93,6 +93,17 @@ bool Libsecp256k1::VerifySignature(
     return false;
 }
 
+bool Libsecp256k1::secp256k1_privkey_tweak_add(
+    uint8_t key [32],
+        const uint8_t tweak [32]) const
+{
+    if (nullptr != context_) {
+        return secp256k1_ec_privkey_tweak_add(context_, key, tweak);
+    } else {
+        return false;
+    }
+}
+
 Libsecp256k1::~Libsecp256k1()
 {
     OT_ASSERT_MSG(nullptr != context_, "Libsecp256k1::~Libsecp256k1: context_ should never be nullptr, yet it was.")

--- a/src/core/crypto/LowLevelKeyGenerator.cpp
+++ b/src/core/crypto/LowLevelKeyGenerator.cpp
@@ -45,6 +45,19 @@
 #include <opentxs/core/crypto/OTKeypair.hpp>
 #include <opentxs/core/Log.hpp>
 
+namespace opentxs
+{
+
+class LowLevelKeyGenerator::LowLevelKeyGeneratordp
+{
+public:
+    LowLevelKeyGeneratordp() = default;
+    virtual ~LowLevelKeyGeneratordp() = default;
+    virtual void Cleanup() = 0;
+};
+
+} // namespace opentxs
+
 #if defined(OT_CRYPTO_USING_OPENSSL)
 
 #include <opentxs/core/crypto/OTAsymmetricKey_OpenSSLPrivdp.hpp>
@@ -56,9 +69,11 @@
 namespace opentxs
 {
 
-class LowLevelKeyGenerator::LowLevelKeyGeneratorOpenSSLdp
+class LowLevelKeyGenerator::LowLevelKeyGeneratorOpenSSLdp : public LowLevelKeyGeneratordp
 {
 public:
+    virtual void Cleanup();
+
     X509* m_pX509 = nullptr;
     EVP_PKEY* m_pKey = nullptr; // Instantiated form of key. (For private keys especially,
                       // we don't want it instantiated for any longer than
@@ -74,23 +89,37 @@ namespace opentxs
 
 LowLevelKeyGenerator::~LowLevelKeyGenerator()
 {
-    if (m_bCleanup) Cleanup();
-    if (nullptr != dp) delete (dp);
+    if (m_bCleanup) {
+        Cleanup();
+    }
+    if (nullptr != dp) {
+        if (pkeyData_->nymParameterType() == NymParameters::LEGACY) {
+            #if defined(OT_CRYPTO_USING_OPENSSL)
+                delete dp;
+            #endif
+            //-------------------------
+            #if defined(OT_CRYPTO_USING_GPG)
+            #endif
+        } else if (pkeyData_->nymParameterType() == NymParameters::SECP256K1) {
+            #if defined(OT_CRYPTO_USING_LIBSECP256K1)
+            #endif
+        }
+    }
 }
 
 LowLevelKeyGenerator::LowLevelKeyGenerator(const std::shared_ptr<NymParameters>& pkeyData)
     : pkeyData_(pkeyData), m_bCleanup(true)
 {
 
-#if defined(OT_CRYPTO_USING_OPENSSL)
+    #if defined(OT_CRYPTO_USING_OPENSSL)
+    if (pkeyData_->nymParameterType() == NymParameters::LEGACY) {
+        dp = new LowLevelKeyGeneratorOpenSSLdp;
+    }
+    #endif
+    //-------------------------
+    #if defined(OT_CRYPTO_USING_GPG)
 
-    dp = new LowLevelKeyGeneratorOpenSSLdp;
-
-#endif
-//-------------------------
-#if defined(OT_CRYPTO_USING_GPG)
-
-#endif
+    #endif
 
 }
 
@@ -101,173 +130,179 @@ LowLevelKeyGenerator::LowLevelKeyGenerator(const std::shared_ptr<NymParameters>&
 void LowLevelKeyGenerator::Cleanup()
 {
 
-#if defined(OT_CRYPTO_USING_OPENSSL)
+    if (nullptr != dp) {
+        dp->Cleanup();
+    }
+}
 
-    if (nullptr != dp->m_pKey) EVP_PKEY_free(dp->m_pKey);
-    dp->m_pKey = nullptr;
-    if (nullptr != dp->m_pX509) X509_free(dp->m_pX509);
-    dp->m_pX509 = nullptr;
+void LowLevelKeyGenerator::LowLevelKeyGeneratorOpenSSLdp::Cleanup()
+{
 
-#endif
-//-------------------------
-#if defined(OT_CRYPTO_USING_GPG)
-
-#endif
-
+    #if defined(OT_CRYPTO_USING_OPENSSL)
+    if (nullptr != m_pKey) {
+        EVP_PKEY_free(m_pKey);
+        m_pKey = nullptr;
+    }
+    if (nullptr != m_pX509) {
+        X509_free(m_pX509);
+        m_pX509 = nullptr;
+    }
+    #endif
+    //-------------------------
+    #if defined(OT_CRYPTO_USING_GPG)
+    #endif
 }
 
 bool LowLevelKeyGenerator::MakeNewKeypair()
 {
 
-// pkeyData can not be null if LowLevelkeyGenerator has been constructed
-if (pkeyData_->nymParameterType() == NymParameters::LEGACY) {
-#if defined(OT_CRYPTO_USING_OPENSSL)
+    // pkeyData can not be null if LowLevelkeyGenerator has been constructed
+    if (pkeyData_->nymParameterType() == NymParameters::LEGACY) {
+        #if defined(OT_CRYPTO_USING_OPENSSL)
 
-//  OpenSSL_BIO bio_err = nullptr;
-    X509* x509          = nullptr;
-    EVP_PKEY* pNewKey   = nullptr;
+        //  OpenSSL_BIO bio_err = nullptr;
+        X509* x509          = nullptr;
+        EVP_PKEY* pNewKey   = nullptr;
 
-//  CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON); // memory leak detection.
-    // Leaving this for now.
-//  bio_err    =    BIO_new_fp(stderr, BIO_NOCLOSE);
+        //  CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON); // memory leak detection.
+            // Leaving this for now.
+        //  bio_err    =    BIO_new_fp(stderr, BIO_NOCLOSE);
 
-    // actually generate the things. // TODO THESE PARAMETERS...(mkcert)
-    mkcert(&x509, &pNewKey, pkeyData_->keySize(), 0, 3650); // 3650=10 years. Todo hardcoded.
-    // Note: 512 bit key CRASHES
-    // 1024 is apparently a minimum requirement, if not an only requirement.
-    // Will need to go over just what sorts of keys are involved here... todo.
+        // actually generate the things. // TODO THESE PARAMETERS...(mkcert)
+        mkcert(&x509, &pNewKey, pkeyData_->keySize(), 0, 3650); // 3650=10 years. Todo hardcoded.
+        // Note: 512 bit key CRASHES
+        // 1024 is apparently a minimum requirement, if not an only requirement.
+        // Will need to go over just what sorts of keys are involved here... todo.
 
-    if (nullptr == x509) {
-        otErr << __FUNCTION__
-              << ": Failed attempting to generate new x509 cert.\n";
+        if (nullptr == x509) {
+            otErr << __FUNCTION__
+                << ": Failed attempting to generate new x509 cert.\n";
 
-        if (nullptr != pNewKey) EVP_PKEY_free(pNewKey);
-        pNewKey = nullptr;
+            if (nullptr != pNewKey) EVP_PKEY_free(pNewKey);
+            pNewKey = nullptr;
 
+            return false;
+        }
+
+        if (nullptr == pNewKey) {
+            otErr << __FUNCTION__
+                << ": Failed attempting to generate new private key.\n";
+
+            if (nullptr != x509) X509_free(x509);
+            x509 = nullptr;
+
+            return false;
+        }
+
+        // Below this point, x509 and pNewKey will need to be cleaned up properly.
+
+        if (m_bCleanup) Cleanup();
+
+        m_bCleanup = true;
+
+        LowLevelKeyGenerator::LowLevelKeyGeneratorOpenSSLdp* ldp =
+            static_cast<LowLevelKeyGenerator::LowLevelKeyGeneratorOpenSSLdp*>(dp);
+
+        ldp->m_pKey = pNewKey;
+        ldp->m_pX509 = x509;
+
+        return true;
+        #elif defined(OT_CRYPTO_USING_GPG)
+
+        #endif
+    } else if (pkeyData_->nymParameterType() == NymParameters::SECP256K1) {
+        #if defined(OT_CRYPTO_USING_LIBSECP256K1)
         return false;
+        #endif
     }
-
-    if (nullptr == pNewKey) {
-        otErr << __FUNCTION__
-              << ": Failed attempting to generate new private key.\n";
-
-        if (nullptr != x509) X509_free(x509);
-        x509 = nullptr;
-
-        return false;
-    }
-
-    // Below this point, x509 and pNewKey will need to be cleaned up properly.
-
-    if (m_bCleanup) Cleanup();
-
-    m_bCleanup = true;
-    dp->m_pKey = pNewKey;
-    dp->m_pX509 = x509;
-
-    // --------COMMENT THIS OUT FOR PRODUCTION --------  TODO security
-    //                  (Debug only.)
-    //    RSA_print_fp(stdout, pNewKey->pkey.rsa, 0); // human readable
-    //    X509_print_fp(stdout, x509); // human readable
-
-    // --------COMMENT THIS OUT FOR PRODUCTION --------  TODO security
-    //                  (Debug only.)
-    // write the private key, then the x509, to stdout.
-
-    //    OTPasswordData thePWData2("OTPseudonym::GenerateNym is calling
-    // PEM_write_PrivateKey...");
-    //
-    //    PEM_write_PrivateKey(stdout, pNewKey, EVP_des_ede3_cbc(), nullptr, 0,
-    // OTAsymmetricKey::GetPasswordCallback(), &thePWData2);
-    //    PEM_write_X509(stdout, x509);
-
-    return true;
-#endif
-}
-//-------------------------
-#if defined(OT_CRYPTO_USING_GPG)
-
-#endif
 //-------------------------
     return false; //unsupported keyType
 }
 
 bool LowLevelKeyGenerator::SetOntoKeypair(OTKeypair& theKeypair)
 {
-#if defined(OT_CRYPTO_USING_OPENSSL)
+    // pkeyData can not be null if LowLevelkeyGenerator has been constructed
+    if (pkeyData_->nymParameterType() == NymParameters::LEGACY) {
+        #if defined(OT_CRYPTO_USING_OPENSSL)
 
-    OT_ASSERT(nullptr != dp->m_pKey);
-    OT_ASSERT(nullptr != dp->m_pX509);
+        LowLevelKeyGenerator::LowLevelKeyGeneratorOpenSSLdp* ldp =
+            static_cast<LowLevelKeyGenerator::LowLevelKeyGeneratorOpenSSLdp*>(dp);
 
-    OT_ASSERT(nullptr != theKeypair.m_pkeyPublic);
-    OT_ASSERT(nullptr != theKeypair.m_pkeyPrivate);
+        OT_ASSERT(nullptr != ldp->m_pKey);
+        OT_ASSERT(nullptr != ldp->m_pX509);
 
-    // Since we are in OpenSSL-specific code, we have to make sure these are
-    // OpenSSL-specific keys.
-    //
-    OTAsymmetricKey_OpenSSL* pPublicKey =
-        dynamic_cast<OTAsymmetricKey_OpenSSL*>(theKeypair.m_pkeyPublic);
-    OTAsymmetricKey_OpenSSL* pPrivateKey =
-        dynamic_cast<OTAsymmetricKey_OpenSSL*>(theKeypair.m_pkeyPrivate);
+        OT_ASSERT(nullptr != theKeypair.m_pkeyPublic);
+        OT_ASSERT(nullptr != theKeypair.m_pkeyPrivate);
 
-    if (nullptr == pPublicKey) {
-        otErr << __FUNCTION__ << ": dynamic_cast to OTAsymmetricKey_OpenSSL "
-                                 "failed. (theKeypair.m_pkeyPublic)\n";
+        // Since we are in OpenSSL-specific code, we have to make sure these are
+        // OpenSSL-specific keys.
+        //
+        OTAsymmetricKey_OpenSSL* pPublicKey =
+            dynamic_cast<OTAsymmetricKey_OpenSSL*>(theKeypair.m_pkeyPublic);
+        OTAsymmetricKey_OpenSSL* pPrivateKey =
+            dynamic_cast<OTAsymmetricKey_OpenSSL*>(theKeypair.m_pkeyPrivate);
+
+        if (nullptr == pPublicKey) {
+            otErr << __FUNCTION__ << ": dynamic_cast to OTAsymmetricKey_OpenSSL "
+                                        "failed. (theKeypair.m_pkeyPublic)\n";
+            return false;
+        }
+        if (nullptr == pPrivateKey) {
+            otErr << __FUNCTION__ << ": dynamic_cast to OTAsymmetricKey_OpenSSL "
+                                        "failed. (theKeypair.m_pkeyPrivate)\n";
+            return false;
+        }
+
+        // Now we can call OpenSSL-specific methods on these keys...
+        //
+        pPublicKey->SetAsPublic();
+        //  EVP_PKEY * pEVP_PubKey = X509_get_pubkey(m_pX509);
+        //  OT_ASSERT(nullptr != pEVP_PubKey);
+        //  pPublicKey-> SetKeyAsCopyOf(*pEVP_PubKey); // bool bIsPrivateKey=false
+        // by default.
+        pPublicKey->dp->SetKeyAsCopyOf(
+            *ldp->m_pKey); // bool bIsPrivateKey=false by default.
+                            //  EVP_PKEY_free(pEVP_PubKey);
+                            //  pEVP_PubKey = nullptr;
+
+        pPublicKey->dp->SetX509(ldp->m_pX509); // m_pX509 is now owned by pPublicKey.
+                                                // (No need to free it in our own
+                                                // destructor anymore.)
+        ldp->m_pX509 =
+            nullptr; // pPublicKey took ownership, so we don't want to ALSO
+                        // clean it up, since pPublicKey already will do so.
+
+        pPrivateKey->SetAsPrivate();
+        pPrivateKey->dp->SetKeyAsCopyOf(
+            *ldp->m_pKey, true); // bool bIsPrivateKey=true; (Default is false)
+        // Since pPrivateKey only takes a COPY of m_pKey, we are still responsible
+        // to clean up m_pKey in our own destructor.
+        // (Assuming m_bCleanup is set to true, which is the default.) That's why
+        // I'm NOT setting it to nullptr, as I did above
+        // with m_pX509.
+
+        EVP_PKEY_free(ldp->m_pKey);
+        ldp->m_pKey = nullptr;
+
+        // Success! At this point, theKeypair's public and private keys have been
+        // set.
+        // Keep in mind though, they still won't be "quite right" until saved and
+        // loaded
+        // again, at least according to existing logic. That saving/reloading is
+        // currently
+        // performed in OTPseudonym::GenerateNym().
+        //
+        return true;
+        #elif defined(OT_CRYPTO_USING_GPG)
+
+        #endif
+    } else if (pkeyData_->nymParameterType() == NymParameters::SECP256K1) {
+        #if defined(OT_CRYPTO_USING_LIBSECP256K1)
         return false;
+        #endif
     }
-    if (nullptr == pPrivateKey) {
-        otErr << __FUNCTION__ << ": dynamic_cast to OTAsymmetricKey_OpenSSL "
-                                 "failed. (theKeypair.m_pkeyPrivate)\n";
-        return false;
-    }
-
-    // Now we can call OpenSSL-specific methods on these keys...
-    //
-    pPublicKey->SetAsPublic();
-    //  EVP_PKEY * pEVP_PubKey = X509_get_pubkey(m_pX509);
-    //  OT_ASSERT(nullptr != pEVP_PubKey);
-    //  pPublicKey-> SetKeyAsCopyOf(*pEVP_PubKey); // bool bIsPrivateKey=false
-    // by default.
-    pPublicKey->dp->SetKeyAsCopyOf(
-        *dp->m_pKey); // bool bIsPrivateKey=false by default.
-                      //  EVP_PKEY_free(pEVP_PubKey);
-                      //  pEVP_PubKey = nullptr;
-
-    pPublicKey->dp->SetX509(dp->m_pX509); // m_pX509 is now owned by pPublicKey.
-                                          // (No need to free it in our own
-                                          // destructor anymore.)
-    dp->m_pX509 =
-        nullptr; // pPublicKey took ownership, so we don't want to ALSO
-                 // clean it up, since pPublicKey already will do so.
-
-    pPrivateKey->SetAsPrivate();
-    pPrivateKey->dp->SetKeyAsCopyOf(
-        *dp->m_pKey, true); // bool bIsPrivateKey=true; (Default is false)
-    // Since pPrivateKey only takes a COPY of m_pKey, we are still responsible
-    // to clean up m_pKey in our own destructor.
-    // (Assuming m_bCleanup is set to true, which is the default.) That's why
-    // I'm NOT setting it to nullptr, as I did above
-    // with m_pX509.
-
-    EVP_PKEY_free(dp->m_pKey);
-    dp->m_pKey = nullptr;
-
-    // Success! At this point, theKeypair's public and private keys have been
-    // set.
-    // Keep in mind though, they still won't be "quite right" until saved and
-    // loaded
-    // again, at least according to existing logic. That saving/reloading is
-    // currently
-    // performed in OTPseudonym::GenerateNym().
-    //
-    return true;
-
-#endif
 //-------------------------
-#if defined(OT_CRYPTO_USING_GPG)
-
-#endif
-
+    return false; //unsupported keyType
 }
 
 } // namespace opentxs

--- a/src/core/crypto/LowLevelKeyGenerator.cpp
+++ b/src/core/crypto/LowLevelKeyGenerator.cpp
@@ -265,7 +265,7 @@ bool LowLevelKeyGenerator::MakeNewKeypair()
     return false; //unsupported keyType
 }
 
-bool LowLevelKeyGenerator::SetOntoKeypair(OTKeypair& theKeypair)
+bool LowLevelKeyGenerator::SetOntoKeypair(OTKeypair& theKeypair, OTPasswordData passwordData, bool ephemeral)
 {
     // pkeyData can not be null if LowLevelkeyGenerator has been constructed
     if (pkeyData_->nymParameterType() == NymParameters::LEGACY) {
@@ -369,7 +369,7 @@ bool LowLevelKeyGenerator::SetOntoKeypair(OTKeypair& theKeypair)
         pPrivateKey->SetAsPrivate();
 
         bool pubkeySet = engine.ECDSAPubkeyToAsymmetricKey(ldp->publicKey_, *pPublicKey);
-        bool privkeySet = engine.ECDSAPrivkeyToAsymmetricKey(ldp->privateKey_, *pPrivateKey);
+        bool privkeySet = engine.ECDSAPrivkeyToAsymmetricKey(ldp->privateKey_, passwordData, *pPrivateKey, ephemeral);
 
         return (pubkeySet && privkeySet);
         #endif

--- a/src/core/crypto/LowLevelKeyGenerator.cpp
+++ b/src/core/crypto/LowLevelKeyGenerator.cpp
@@ -99,7 +99,7 @@ class LowLevelKeyGenerator::LowLevelKeyGeneratorSecp256k1dp : public LowLevelKey
 public:
     virtual void Cleanup();
     OTPassword privateKey_;
-    secp256k1_pubkey_t publicKey_;
+    secp256k1_pubkey publicKey_;
 };
 
 } // namespace opentxs

--- a/src/core/crypto/LowLevelKeyGenerator.cpp
+++ b/src/core/crypto/LowLevelKeyGenerator.cpp
@@ -265,7 +265,7 @@ bool LowLevelKeyGenerator::MakeNewKeypair()
     return false; //unsupported keyType
 }
 
-bool LowLevelKeyGenerator::SetOntoKeypair(OTKeypair& theKeypair, OTPasswordData passwordData, bool ephemeral)
+bool LowLevelKeyGenerator::SetOntoKeypair(OTKeypair& theKeypair, OTPasswordData& passwordData, bool ephemeral)
 {
     // pkeyData can not be null if LowLevelkeyGenerator has been constructed
     if (pkeyData_->nymParameterType() == NymParameters::LEGACY) {

--- a/src/core/crypto/MasterCredential.cpp
+++ b/src/core/crypto/MasterCredential.cpp
@@ -107,7 +107,7 @@ int32_t MasterCredential::ProcessXMLNode(irr::io::IrrXMLReader*& xml)
         if (masterType.Exists()) {
             actualCredentialType = StringToCredentialType(masterType.Get());
         } else {
-            actualCredentialType = Credential::RSA_PUBKEY; //backward compatibility
+            actualCredentialType = Credential::LEGACY; //backward compatibility
         }
 
         OT_ASSERT(!m_AuthentKey);
@@ -149,7 +149,7 @@ void MasterCredential::UpdateContents()
     if (masterType.Exists()) {
         tag.add_attribute("type", masterType.Get());
     } else {
-        tag.add_attribute("type", CredentialTypeToString(Credential::RSA_PUBKEY).Get()); //backward compatibility
+        tag.add_attribute("type", CredentialTypeToString(Credential::LEGACY).Get()); //backward compatibility
     }
 
     if (GetNymIDSource().Exists()) {

--- a/src/core/crypto/NymParameters.cpp
+++ b/src/core/crypto/NymParameters.cpp
@@ -79,7 +79,7 @@ void NymParameters::setCredentialType(Credential::CredentialType theCredentialty
 #if defined(OT_CRYPTO_SUPPORTED_KEY_RSA)
 NymParameters::NymParameters(const int32_t keySize)
     : nymType_(NymParameters::LEGACY),
-    credentialType_(Credential::RSA_PUBKEY),
+    credentialType_(Credential::LEGACY),
     nBits_(keySize)
 {
 }

--- a/src/core/crypto/NymParameters.cpp
+++ b/src/core/crypto/NymParameters.cpp
@@ -47,27 +47,21 @@
 namespace opentxs
 {
 
-NymParameters::~NymParameters() = default;
-
-NymParameters::NymParameters() = default;
+NymParameters::NymParameters(
+    NymParameters::NymParameterType theKeytype,
+    Credential::CredentialType theCredentialtype)
+{
+        setNymParameterType(theKeytype);
+        setCredentialType(theCredentialtype);
+}
 
 NymParameters::NymParameterType NymParameters::nymParameterType() {
     return nymType_;
 }
 
-OTAsymmetricKey::KeyType NymParameters::AsymmetricKeyType() {
-
-    OTAsymmetricKey::KeyType keyType;
-
-    switch (nymType_) {
-        case NymParameters::LEGACY :
-            keyType = OTAsymmetricKey::RSA;
-            break;
-        default :
-            keyType = OTAsymmetricKey::ERROR_TYPE;
-    }
-
-    return keyType;
+OTAsymmetricKey::KeyType NymParameters::AsymmetricKeyType()
+{
+    return Credential::CredentialTypeToKeyType(credentialType_);
 }
 
 void NymParameters::setNymParameterType(NymParameters::NymParameterType theKeytype) {

--- a/src/core/crypto/OTAsymmetricKey.cpp
+++ b/src/core/crypto/OTAsymmetricKey.cpp
@@ -55,6 +55,10 @@
 #include <opentxs/core/crypto/OTAsymmetricKeyOpenSSL.hpp>
 #endif
 
+#if defined(OT_CRYPTO_USING_LIBSECP256K1)
+#include <opentxs/core/crypto/AsymmetricKeySecp256k1.hpp>
+#endif
+
 namespace opentxs
 {
 
@@ -75,11 +79,19 @@ OTAsymmetricKey* OTAsymmetricKey::KeyFactory(OTAsymmetricKey::KeyType keyType) /
 #elif defined(OT_CRYPTO_USING_GPG)
     //  pKey = new OTAsymmetricKey_GPG;
     otErr << __FUNCTION__ << ": Open-Transactions doesn't support GPG (yet), "
-                             "so it's impossible to instantiate a key.\n";
+                             "so it's impossible to instantiate the key.\n";
 #else
     otErr << __FUNCTION__
           << ": Open-Transactions isn't built with any crypto engine, "
-             "so it's impossible to instantiate a key.\n";
+             "so it's impossible to instantiate the key.\n";
+#endif
+    } else if (keyType == OTAsymmetricKey::SECP256K1) {
+#if defined(OT_CRYPTO_USING_LIBSECP256K1)
+        pKey = new AsymmetricKeySecp256k1;
+        validType = true;
+    otErr << __FUNCTION__
+          << ": Open-Transactions isn't built with libsecp256k1 support, "
+             "so it's impossible to instantiate the key.\n";
 #endif
     }
     OT_ASSERT_MSG(validType, keyTypeError.c_str());

--- a/src/core/crypto/OTAsymmetricKey.cpp
+++ b/src/core/crypto/OTAsymmetricKey.cpp
@@ -289,7 +289,7 @@ bool OT_API_Set_PasswordCallback(OTCaller& theCaller) // Caller must have
 // If the password callback isn't set, then it uses the default ("test")
 // password.
 //
-extern "C" int32_t default_pass_cb(char* buf, int32_t size, int32_t,
+extern "C" int32_t default_pass_cb(char* buf, int32_t size, int32_t rwflag,
                                    void* userdata)
 {
     int32_t len = 0;
@@ -301,7 +301,7 @@ extern "C" int32_t default_pass_cb(char* buf, int32_t size, int32_t,
     std::string str_userdata;
 
     if (nullptr != userdata) {
-        pPWData = static_cast<OTPasswordData*>(userdata);
+        pPWData = static_cast<const OTPasswordData*>(userdata);
 
         if (nullptr != pPWData) {
             str_userdata = pPWData->GetDisplayString();
@@ -372,7 +372,7 @@ extern "C" int32_t souped_up_pass_cb(char* buf, int32_t size, int32_t rwflag,
 {
     //  OT_ASSERT(nullptr != buf); // apparently it CAN be nullptr sometimes.
     OT_ASSERT(nullptr != userdata);
-    const OTPasswordData* pPWData = static_cast<OTPasswordData*>(userdata);
+    const OTPasswordData* pPWData = static_cast<const OTPasswordData*>(userdata);
     const std::string str_userdata = pPWData->GetDisplayString();
 
     OTPassword thePassword;

--- a/src/core/crypto/OTAsymmetricKey.cpp
+++ b/src/core/crypto/OTAsymmetricKey.cpp
@@ -72,7 +72,7 @@ OTAsymmetricKey* OTAsymmetricKey::KeyFactory(OTAsymmetricKey::KeyType keyType) /
     keyTypeError += keyTypeName.Get();
     bool validType = false;
 
-    if (keyType == OTAsymmetricKey::RSA) {
+    if (keyType == OTAsymmetricKey::LEGACY) {
 #if defined(OT_CRYPTO_USING_OPENSSL)
         pKey = new OTAsymmetricKey_OpenSSL;
         validType = true;
@@ -875,8 +875,8 @@ String OTAsymmetricKey::KeyTypeToString(const OTAsymmetricKey::KeyType keyType)
     String keytypeString;
 
     switch (keyType) {
-        case OTAsymmetricKey::RSA :
-            keytypeString="rsa";
+        case OTAsymmetricKey::LEGACY :
+            keytypeString="legacy";
             break;
         case OTAsymmetricKey::SECP256K1 :
             keytypeString="secp256k1";
@@ -890,8 +890,8 @@ String OTAsymmetricKey::KeyTypeToString(const OTAsymmetricKey::KeyType keyType)
 OTAsymmetricKey::KeyType OTAsymmetricKey::StringToKeyType(const String& keyType)
 
 {
-    if (keyType.Compare("rsa"))
-        return OTAsymmetricKey::RSA;
+    if (keyType.Compare("legacy"))
+        return OTAsymmetricKey::LEGACY;
     if (keyType.Compare("secp256k1"))
         return OTAsymmetricKey::SECP256K1;
     return OTAsymmetricKey::ERROR_TYPE;

--- a/src/core/crypto/OTAsymmetricKey.cpp
+++ b/src/core/crypto/OTAsymmetricKey.cpp
@@ -89,6 +89,7 @@ OTAsymmetricKey* OTAsymmetricKey::KeyFactory(OTAsymmetricKey::KeyType keyType) /
 #if defined(OT_CRYPTO_USING_LIBSECP256K1)
         pKey = new AsymmetricKeySecp256k1;
         validType = true;
+#else
     otErr << __FUNCTION__
           << ": Open-Transactions isn't built with libsecp256k1 support, "
              "so it's impossible to instantiate the key.\n";
@@ -871,9 +872,19 @@ void OTAsymmetricKey::Release()
 String OTAsymmetricKey::KeyTypeToString(const OTAsymmetricKey::KeyType keyType)
 
 {
-    if (keyType == OTAsymmetricKey::RSA)
-        return "rsa";
-    return "error";
+    String keytypeString;
+
+    switch (keyType) {
+        case OTAsymmetricKey::RSA :
+            keytypeString="rsa";
+            break;
+        case OTAsymmetricKey::SECP256K1 :
+            keytypeString="secp256k1";
+            break;
+        default :
+            keytypeString="error";
+    }
+    return keytypeString;
 }
 
 OTAsymmetricKey::KeyType OTAsymmetricKey::StringToKeyType(const String& keyType)
@@ -881,6 +892,8 @@ OTAsymmetricKey::KeyType OTAsymmetricKey::StringToKeyType(const String& keyType)
 {
     if (keyType.Compare("rsa"))
         return OTAsymmetricKey::RSA;
+    if (keyType.Compare("secp256k1"))
+        return OTAsymmetricKey::SECP256K1;
     return OTAsymmetricKey::ERROR_TYPE;
 }
 

--- a/src/core/crypto/OTAsymmetricKeyOpenSSL.cpp
+++ b/src/core/crypto/OTAsymmetricKeyOpenSSL.cpp
@@ -80,7 +80,7 @@ OTAsymmetricKey_OpenSSL::OTAsymmetricKey_OpenSSL()
     dp->m_pX509 = nullptr;
     dp->m_pKey = nullptr;
 
-    m_keyType = OTAsymmetricKey::RSA;
+    m_keyType = OTAsymmetricKey::LEGACY;
 }
 
 OTAsymmetricKey_OpenSSL::~OTAsymmetricKey_OpenSSL()

--- a/src/core/crypto/OTAsymmetricKeyOpenSSL.cpp
+++ b/src/core/crypto/OTAsymmetricKeyOpenSSL.cpp
@@ -756,7 +756,7 @@ bool OTAsymmetricKey_OpenSSL::GetPrivateKey(
     return privateSuccess && publicSuccess;
 }
 
-CryptoAsymmetric& OTAsymmetricKey::engine() const
+CryptoAsymmetric& OTAsymmetricKey_OpenSSL::engine() const
 
 {
     return CryptoEngine::Instance().RSA();

--- a/src/core/crypto/OTAsymmetricKeyOpenSSLPrivdp.cpp
+++ b/src/core/crypto/OTAsymmetricKeyOpenSSLPrivdp.cpp
@@ -258,7 +258,7 @@ EVP_PKEY* OTAsymmetricKey_OpenSSL::OTAsymmetricKey_OpenSSLPrivdp::CopyPublicKey(
                         keyBio, nullptr, OTAsymmetricKey::GetPasswordCallback(),
                         nullptr == pPWData
                             ? &thePWData
-                            : const_cast<OTPasswordData*>(pPWData));
+                            :  const_cast<OTPasswordData*>(pPWData));
                 else
                     pReturnKey = PEM_read_bio_PUBKEY(
                         keyBio, nullptr, 0,

--- a/src/core/crypto/OTEnvelope.cpp
+++ b/src/core/crypto/OTEnvelope.cpp
@@ -426,11 +426,12 @@ EXPORT bool OTEnvelope::Seal(const setOfNyms recipients,
 {
     mapOfAsymmetricKeys recipientKeys;
 
+    for (auto& it : recipients) {
+        recipientKeys.insert(std::pair<std::string, OTAsymmetricKey*>(
+            "",const_cast<OTAsymmetricKey*>(&(it->GetPublicEncrKey()))));
+    }
+
     if (!recipientKeys.empty()) {
-        for (auto& it : recipients) {
-            recipientKeys.insert(std::pair<std::string, OTAsymmetricKey*>(
-                "",const_cast<OTAsymmetricKey*>(&(it->GetPublicEncrKey()))));
-        }
         return Seal(recipientKeys, theInput);
     } else {
         return false;

--- a/src/core/crypto/OTEnvelope.cpp
+++ b/src/core/crypto/OTEnvelope.cpp
@@ -421,7 +421,7 @@ bool OTEnvelope::Decrypt(String& theOutput, const OTSymmetricKey& theKey,
     return bDecrypted;
 }
 
-EXPORT bool OTEnvelope::Seal(const setOfNyms recipients,
+EXPORT bool OTEnvelope::Seal(const setOfNyms& recipients,
                  const String& theInput)
 {
     mapOfAsymmetricKeys recipientKeys;

--- a/src/core/crypto/OTEnvelope.cpp
+++ b/src/core/crypto/OTEnvelope.cpp
@@ -421,6 +421,22 @@ bool OTEnvelope::Decrypt(String& theOutput, const OTSymmetricKey& theKey,
     return bDecrypted;
 }
 
+EXPORT bool OTEnvelope::Seal(const setOfNyms recipients,
+                 const String& theInput)
+{
+    mapOfAsymmetricKeys recipientKeys;
+
+    if (!recipientKeys.empty()) {
+        for (auto& it : recipients) {
+            recipientKeys.insert(std::pair<std::string, OTAsymmetricKey*>(
+                "",const_cast<OTAsymmetricKey*>(&(it->GetPublicEncrKey()))));
+        }
+        return Seal(recipientKeys, theInput);
+    } else {
+        return false;
+    }
+}
+
 bool OTEnvelope::Seal(const Nym& theRecipient, const String& theInput)
 {
     return Seal(theRecipient.GetPublicEncrKey(), theInput);
@@ -429,16 +445,20 @@ bool OTEnvelope::Seal(const Nym& theRecipient, const String& theInput)
 bool OTEnvelope::Seal(const OTAsymmetricKey& RecipPubKey,
                       const String& theInput)
 {
-  mapOfAsymmetricKeys theKeys;
-    theKeys.insert(std::pair<std::string, OTAsymmetricKey*>(
-        "", // Normally the NymID goes here, but we don't know what it is, in
-            // this case.
-        const_cast<OTAsymmetricKey*>(&RecipPubKey)));
+    mapOfAsymmetricKeys recipientKeys;
+    recipientKeys.insert(std::pair<std::string, OTAsymmetricKey*>(
+        "",const_cast<OTAsymmetricKey*>(&RecipPubKey)));
 
-    OT_ASSERT_MSG(!theKeys.empty(),
+    return Seal(recipientKeys, theInput);
+}
+
+bool OTEnvelope::Seal(const mapOfAsymmetricKeys& recipientKeys,
+                      const String& theInput)
+{
+    OT_ASSERT_MSG(!recipientKeys.empty(),
                   "OTEnvelope::Seal: ASSERT: RecipPubKeys.size() > 0");
 
-    return Letter::Seal(theKeys, theInput, m_dataContents);
+    return Letter::Seal(recipientKeys, theInput, m_dataContents);
 }
 
 // RSA / AES

--- a/src/core/crypto/OTKeypair.cpp
+++ b/src/core/crypto/OTKeypair.cpp
@@ -72,6 +72,7 @@
 #include <opentxs/core/crypto/LowLevelKeyGenerator.hpp>
 #include <opentxs/core/crypto/OTSignature.hpp>
 #include <opentxs/core/OTStorage.hpp>
+#include <opentxs/core/crypto/OTPasswordData.hpp>
 
 #include <memory>
 // DONE: Add OTKeypair member for m_pMetadata.
@@ -200,7 +201,7 @@ bool OTKeypair::SetPrivateKey(
     return (privateSuccess && publicSuccess);
 }
 
-bool OTKeypair::MakeNewKeypair(const std::shared_ptr<NymParameters>& pKeyData)
+bool OTKeypair::MakeNewKeypair(const std::shared_ptr<NymParameters>& pKeyData, bool ephemeral)
 {
     OT_ASSERT(nullptr != m_pkeyPrivate);
     OT_ASSERT(nullptr != m_pkeyPublic);
@@ -214,7 +215,8 @@ bool OTKeypair::MakeNewKeypair(const std::shared_ptr<NymParameters>& pKeyData)
             return false;
         }
 
-        return lowLevelKeys.SetOntoKeypair(*this);
+        OTPasswordData passwordData("Enter or set the wallet master password.");
+        return lowLevelKeys.SetOntoKeypair(*this, passwordData, ephemeral);
     } else {
         return false;
     }

--- a/src/core/crypto/OTKeypair.cpp
+++ b/src/core/crypto/OTKeypair.cpp
@@ -195,6 +195,8 @@ bool OTKeypair::SetPrivateKey(
     privateSuccess = m_pkeyPrivate->SetPrivateKey(
         strCert, pstrReason, pImportPassword);
 
+    OT_ASSERT(privateSuccess);
+
     publicSuccess = m_pkeyPublic->SetPublicKeyFromPrivateKey(
         strCert, pstrReason, pImportPassword);
 
@@ -315,7 +317,7 @@ int32_t OTKeypair::GetPublicKeyBySignature(
 // Used when importing/exporting a Nym to/from the wallet.
 //
 bool OTKeypair::ReEncrypt(const OTPassword& theExportPassword, bool bImporting,
-                          String& strOutput)
+                          FormattedKey& strOutput)
 {
 
     OT_ASSERT(nullptr != m_pkeyPublic);
@@ -371,11 +373,10 @@ bool OTKeypair::ReEncrypt(const OTPassword& theExportPassword, bool bImporting,
 
     const bool bReEncrypted = m_pkeyPrivate->ReEncryptPrivateKey(
         theExportPassword, bImporting); // <==== IMPORT or EXPORT occurs here.
-    bool bGotCert = false;
 
-    const bool bSuccess = (bReEncrypted && bGotCert);
+    bool haveNewPrivateKey = m_pkeyPrivate->GetPrivateKey(strOutput);
 
-    if (!bSuccess) {
+    if (!(bReEncrypted && haveNewPrivateKey)) {
         strOutput.Release();
         otErr << __FUNCTION__ << ": Failure, either when re-encrypting, or "
                                  "when subsequently retrieving "
@@ -383,7 +384,7 @@ bool OTKeypair::ReEncrypt(const OTPassword& theExportPassword, bool bImporting,
               << (bImporting ? "true" : "false") << "\n";
     }
 
-    return bSuccess;
+    return (bReEncrypted && haveNewPrivateKey);
 }
 
 } // namespace opentxs

--- a/src/core/crypto/OTPassword.cpp
+++ b/src/core/crypto/OTPassword.cpp
@@ -38,6 +38,7 @@
 
 #include <opentxs/core/stdafx.hpp>
 
+#include <opentxs/core/OTData.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
 
 #include <opentxs/core/crypto/CryptoEngine.hpp>
@@ -904,6 +905,16 @@ int32_t OTPassword::addMemory(const void* vAppend, uint32_t nAppendSize)
     size_ += nAppendSize;
 
     return nAppendSize;
+}
+
+int32_t OTPassword::setMemory(const OTData& data)
+{
+    const uint32_t dataSize = data.GetSize();
+    uint32_t returnedSize = dataSize;
+
+    bool memorySet = setMemory(data.GetPointer(), returnedSize);
+    // TODO maybe we should check for truncation?
+    return memorySet;
 }
 
 // Returns size of memory (in case truncation is necessary.)

--- a/src/core/crypto/OTPassword.cpp
+++ b/src/core/crypto/OTPassword.cpp
@@ -568,6 +568,11 @@ bool OTPassword::Compare(OTPassword& rhs) const
     return false;
 }
 
+int32_t OTPassword::setPassword(const std::string& input)
+{
+    return setPassword(input.data(), input.size());
+}
+
 // Returns size of password (in case truncation is necessary.)
 // Returns -1 in case of error.
 //

--- a/src/core/crypto/OTPassword.cpp
+++ b/src/core/crypto/OTPassword.cpp
@@ -980,4 +980,33 @@ int32_t OTPassword::setMemory(const void* vInput, uint32_t nInputSize)
     return size_;
 }
 
+// First use reset() to set the internal position to 0.
+// Then you pass in the buffer where the results go.
+// You pass in the length of that buffer.
+// It returns how much was actually read.
+// If you start at position 0, and read 100 bytes, then
+// you are now on position 100, and the next OTfread will
+// proceed from that position. (Unless you reset().)
+uint32_t OTPassword::OTfread(uint8_t* data, uint32_t size)
+{
+    OT_ASSERT(data != nullptr && size > 0);
+
+    uint32_t sizeToRead = 0;
+
+    if (position_ < size_) {
+        // If the size is 20, and position is 5 (I've already read the first 5
+        // bytes) then the size remaining to read is 15. That is, GetSize()
+        // minus position_.
+        sizeToRead = size_ - position_;
+
+        if (size < sizeToRead) {
+            sizeToRead = size;
+        }
+        addMemory(data, sizeToRead);
+        position_ += sizeToRead;
+    }
+
+    return sizeToRead;
+}
+
 } // namespace opentxs

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -2881,10 +2881,10 @@ bool OpenSSL::Digest(
     uint32_t inputSize;
 
     if (data.isMemory()) {
-        inputStart = static_cast<const uint8_t*>(data.getMemory());
+        inputStart = data.getMemory_uint8();
         inputSize = data.getMemorySize();
     } else {
-        inputStart = reinterpret_cast<const uint8_t*>(data.getPassword());
+        inputStart = data.getPassword_uint8();
         inputSize = data.getPasswordSize();
     }
 

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -1234,11 +1234,11 @@ bool OpenSSL::Encrypt(
 {
     const char* szFunc = "OpenSSL::Encrypt";
 
-    OT_ASSERT(CryptoConfig::SymmetricIvSize() == theIV.GetSize());
-    OT_ASSERT(CryptoConfig::SymmetricKeySize() ==
-              theRawSymmetricKey.getMemorySize());
-    OT_ASSERT(nullptr != szInput);
-    OT_ASSERT(lInputLength > 0);
+    OT_ASSERT_MSG((CryptoConfig::SymmetricIvSize() == theIV.GetSize()), "Wrong iv size.\n");
+    OT_ASSERT_MSG((CryptoConfig::SymmetricKeySize() ==
+              theRawSymmetricKey.getMemorySize()), "Wrong symmetric key size.\n");
+    OT_ASSERT_MSG((nullptr != szInput), "Null input.\n");
+    OT_ASSERT_MSG((lInputLength > 0), "Empty input.\n");
 
     EVP_CIPHER_CTX ctx;
 
@@ -1360,11 +1360,11 @@ bool OpenSSL::Decrypt(
 {
     const char* szFunc = "OpenSSL::Decrypt";
 
-    OT_ASSERT(CryptoConfig::SymmetricIvSize() == theIV.GetSize());
-    OT_ASSERT(CryptoConfig::SymmetricKeySize() ==
-              theRawSymmetricKey.getMemorySize());
-    OT_ASSERT(nullptr != szInput);
-    OT_ASSERT(lInputLength > 0);
+    OT_ASSERT_MSG((CryptoConfig::SymmetricIvSize() == theIV.GetSize()), "Wrong iv size.\n");
+    OT_ASSERT_MSG((CryptoConfig::SymmetricKeySize() ==
+              theRawSymmetricKey.getMemorySize()), "Wrong symmetric key size.\n");
+    OT_ASSERT_MSG((nullptr != szInput), "Null input.\n");
+    OT_ASSERT_MSG((lInputLength > 0), "Empty input.\n");
 
     EVP_CIPHER_CTX ctx;
 

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -2628,26 +2628,25 @@ bool OpenSSL::Digest(
 // Calculate an HMAC given some input data and a key
 bool OpenSSL::HMAC(
         const CryptoHash::HashType hashType,
-        const OTData& inputKey,
+        const OTPassword& inputKey,
         const OTData& inputData,
-        OTData& outputDigest) const
+        OTPassword& outputDigest) const
 {
-
     unsigned int size = 0;
     const EVP_MD* evp_md = OpenSSLdp::HashTypeToOpenSSLType(hashType);
 
     if (nullptr != evp_md) {
         void* data = ::HMAC(
                         evp_md,
-                        inputKey.GetPointer(),
-                        inputKey.GetSize(),
+                        inputKey.getMemory(),
+                        inputKey.getMemorySize(),
                         static_cast <const unsigned char*>(inputData.GetPointer()),
                         inputData.GetSize(),
                         nullptr,
                         &size);
 
         if (nullptr != data) {
-            outputDigest.Assign(data, size);
+            outputDigest.setMemory(data, size);
             return true;
         } else {
             otErr << __FUNCTION__ << ": Failed to produce a valid HMAC.\n";

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -168,7 +168,6 @@ extern "C" {
 
 OpenSSL::OpenSSL()
     : Crypto()
-    , dp(nullptr)
 {
 }
 
@@ -514,7 +513,7 @@ void OpenSSL::EncodeID(const Identifier& theInput,
 }
 
 bool OpenSSL::RandomizeMemory(uint8_t* szDestination,
-                                       uint32_t nNewSize) const
+                              uint32_t nNewSize) const
 {
     OT_ASSERT(nullptr != szDestination);
     OT_ASSERT(nNewSize > 0);
@@ -830,10 +829,14 @@ void OpenSSL::thread_cleanup() const
 
 void OpenSSL::Init_Override() const
 {
-    const char* szFunc = "OpenSSL::Init_Override";
-
-    otWarn << szFunc << ": Setting up OpenSSL:  SSL_library_init, error "
+    otWarn << __FUNCTION__ << ": Setting up OpenSSL:  SSL_library_init, error "
                         "strings and algorithms, and OpenSSL config...\n";
+
+    static bool bNotAlreadyInitialized = true;
+
+    OT_ASSERT_MSG(bNotAlreadyInitialized, "OpenSSL::Init_Override: Tried to initialize twice.");
+
+    bNotAlreadyInitialized = false;
 
 /*
  OPENSSL_VERSION_NUMBER is a numeric release version identifier:
@@ -1094,7 +1097,7 @@ void OpenSSL::Init_Override() const
 #if defined(OPENSSL_THREADS)
     // thread support enabled
 
-    otWarn << szFunc << ": OpenSSL WAS compiled with thread support, FYI. "
+    otWarn << __FUNCTION__ << ": OpenSSL WAS compiled with thread support, FYI. "
                         "Setting up mutexes...\n";
 
     this->thread_setup();
@@ -1138,9 +1141,7 @@ void OpenSSL::Init_Override() const
 
 void OpenSSL::Cleanup_Override() const
 {
-    const char* szFunc = "OpenSSL::Cleanup_Override";
-
-    otLog4 << szFunc << ": Cleaning up OpenSSL...\n";
+    otLog4 << __FUNCTION__ << ": Cleaning up OpenSSL...\n";
 
 // In the future if we start using ENGINEs, then do the cleanup here:
 //#ifndef OPENSSL_NO_ENGINE

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -47,9 +47,9 @@
 #include <opentxs/core/stdafx.hpp>
 
 #include <bitcoin-base58/hash.h> // for Hash()
-#include <opentxs/core/crypto/BitcoinCrypto.hpp>
 #include <opentxs/core/crypto/OpenSSL.hpp>
 #include <opentxs/core/Log.hpp>
+#include <opentxs/core/crypto/BitcoinCrypto.hpp>
 #include <opentxs/core/crypto/Crypto.hpp>
 #include <opentxs/core/crypto/CryptoEngine.hpp>
 #include <opentxs/core/crypto/OTPassword.hpp>
@@ -58,8 +58,6 @@
 #include <opentxs/core/crypto/OTSignature.hpp>
 #include <opentxs/core/OTStorage.hpp>
 #include <opentxs/core/util/stacktrace.h>
-
-#include <bitcoin-base58/base58.h>
 
 #include <thread>
 

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -2928,23 +2928,27 @@ bool OpenSSL::Open(OTData& dataInput, const Nym& theRecipient,
 
 bool OpenSSL::Digest(
     const CryptoHash::HashType hashType,
-    const OTData& data,
-    OTData& digest) const
+    const OTPassword& data,
+    OTPassword& digest) const
 {
     if (CryptoHash::HASH256 == hashType) {
-        const uint8_t* dataStart = static_cast<const uint8_t*>(data.GetPointer());
-        const uint8_t* dataEnd = dataStart + data.GetSize();
+        const uint8_t* dataStart = static_cast<const uint8_t*>(data.getMemory());
+        const uint8_t* dataEnd = dataStart + data.getMemorySize();
 
         unsigned char* vDigest = ::Hash(dataStart, dataEnd);
-        digest.Assign(vDigest, 32);
+        digest.setMemory(vDigest, 32);
+        delete vDigest;
+        vDigest = nullptr;
 
         return true;
     } else if (CryptoHash::HASH160 == hashType) {
-        const uint8_t* dataStart = static_cast<const uint8_t*>(data.GetPointer());
-        const uint8_t* dataEnd = dataStart + data.GetSize();
+        const uint8_t* dataStart = static_cast<const uint8_t*>(data.getMemory());
+        const uint8_t* dataEnd = dataStart + data.getMemorySize();
 
         unsigned char* vDigest = ::Hash160(dataStart, dataEnd);
-        digest.Assign(vDigest, 20);
+        digest.setMemory(vDigest, 20);
+        delete vDigest;
+        vDigest = nullptr;
 
         return true;
     } else {
@@ -2955,11 +2959,11 @@ bool OpenSSL::Digest(
 
         if (nullptr != algorithm) {
             EVP_DigestInit_ex(context, algorithm, NULL);
-            EVP_DigestUpdate(context, data.GetPointer(), data.GetSize());
+            EVP_DigestUpdate(context, data.getMemory(), data.getMemorySize());
             EVP_DigestFinal_ex(context, hash_value, &hash_length);
             EVP_MD_CTX_destroy(context);
 
-            digest.Assign(hash_value, hash_length);
+            digest.setMemory(hash_value, hash_length);
 
             return true;
         } else {

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -2595,7 +2595,6 @@ bool OpenSSL::Hash(
 
         return true;
     } else if (CryptoHash::HASH160 == hashType) {
-
         const uint8_t* dataStart = static_cast<const uint8_t*>(data.GetPointer());
         const uint8_t* dataEnd = dataStart + data.GetSize();
 
@@ -2639,8 +2638,7 @@ bool OpenSSL::OpenSSLdp::SignContractDefaultHash(
     // This stores the message digest, pre-encrypted, but with the padding
     // added.
     OTData hash;
-    OTData plaintext(strContractUnsigned.Get(), strContractUnsigned.GetLength());
-    CryptoEngine::Instance().Hash().Hash(CryptoHash::HASH256, plaintext, hash);
+    CryptoEngine::Instance().Hash().Hash(CryptoHash::HASH256, strContractUnsigned, hash);
 
     // This stores the final signature, when the EM value has been signed by RSA
     // private key.
@@ -2796,8 +2794,7 @@ bool OpenSSL::OpenSSLdp::VerifyContractDefaultHash(
 
     // 32 bytes, double sha256
     OTData hash;
-    OTData plaintext(strContractToVerify.Get(), strContractToVerify.GetLength());
-    CryptoEngine::Instance().Hash().Hash(CryptoHash::HASH256, plaintext, hash);
+    CryptoEngine::Instance().Hash().Hash(CryptoHash::HASH256, strContractToVerify, hash);
 
     std::vector<uint8_t> vDecrypted(
         CryptoConfig::PublicKeysizeMax()); // Contains the decrypted

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -2581,7 +2581,7 @@ bool OpenSSL::Open(OTData& dataInput, const Nym& theRecipient,
     return bSetMem;
 }
 
-bool OpenSSL::Hash(
+bool OpenSSL::Digest(
     const CryptoHash::HashType hashType,
     const OTData& data,
     OTData& digest) const
@@ -2638,7 +2638,7 @@ bool OpenSSL::OpenSSLdp::SignContractDefaultHash(
     // This stores the message digest, pre-encrypted, but with the padding
     // added.
     OTData hash;
-    CryptoEngine::Instance().Hash().Hash(CryptoHash::HASH256, strContractUnsigned, hash);
+    CryptoEngine::Instance().Hash().Digest(CryptoHash::HASH256, strContractUnsigned, hash);
 
     // This stores the final signature, when the EM value has been signed by RSA
     // private key.
@@ -2794,7 +2794,7 @@ bool OpenSSL::OpenSSLdp::VerifyContractDefaultHash(
 
     // 32 bytes, double sha256
     OTData hash;
-    CryptoEngine::Instance().Hash().Hash(CryptoHash::HASH256, strContractToVerify, hash);
+    CryptoEngine::Instance().Hash().Digest(CryptoHash::HASH256, strContractToVerify, hash);
 
     std::vector<uint8_t> vDecrypted(
         CryptoConfig::PublicKeysizeMax()); // Contains the decrypted

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -1303,11 +1303,13 @@ bool OpenSSL::ArgumentCheck(
 
     if  (!ECB && (iv.GetSize() != CryptoSymmetric::IVSize(cipher))) {
         otErr << "OpenSSL::" << __FUNCTION__ << ": Incorrect IV size.\n";
+        otErr << "Actual IV bytes: " << iv.GetSize() << "\n";
         return false;
     }
 
     if  (key.getMemorySize() != CryptoSymmetric::KeySize(cipher)) {
         otErr << "OpenSSL::" << __FUNCTION__ << ": Incorrect key size.\n";
+        otErr << "Actual key bytes: " << key.getMemorySize() << "\n";
         return false;
     }
 

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -713,6 +713,13 @@ OTPassword* OpenSSL::InstantiateBinarySecret() const
     return pNewKey;
 }
 
+BinarySecret OpenSSL::InstantiateBinarySecretSP() const
+{
+    BinarySecret binarySecret;
+    binarySecret.reset(InstantiateBinarySecret());
+    return binarySecret;
+}
+
 #ifndef _PASSWORD_LEN
 #define _PASSWORD_LEN 128
 #endif

--- a/src/opentxs/opentxs.cpp
+++ b/src/opentxs/opentxs.cpp
@@ -86,7 +86,7 @@
 #include "../client/commands/CmdNewAsset.hpp"
 #include "../client/commands/CmdNewBasket.hpp"
 #include "../client/commands/CmdNewKey.hpp"
-#include "../client/commands/CmdNewNym.hpp"
+#include "../client/commands/CmdNewNymLegacy.hpp"
 #include "../client/commands/CmdNewOffer.hpp"
 #include "../client/commands/CmdNewServer.hpp"
 #include "../client/commands/CmdOutbox.hpp"
@@ -188,7 +188,7 @@ CmdBase* cmds[] = {new CmdAcceptAll,       new CmdAcceptInbox,
                    new CmdInpayments,      new CmdIssueAsset,
                    new CmdKillOffer,       new CmdKillPlan,
                    new CmdNewAccount,      new CmdNewAsset,
-                   new CmdNewKey,          new CmdNewNym,
+                   new CmdNewKey,          new CmdNewNymLegacy,
                    new CmdNewOffer,        new CmdNewServer,
                    new CmdOutbox,          new CmdOutmail,
                    new CmdNewBasket,       new CmdOutpayment,

--- a/src/opentxs/opentxs.cpp
+++ b/src/opentxs/opentxs.cpp
@@ -86,6 +86,7 @@
 #include "../client/commands/CmdNewAsset.hpp"
 #include "../client/commands/CmdNewBasket.hpp"
 #include "../client/commands/CmdNewKey.hpp"
+#include "../client/commands/CmdNewNymECDSA.hpp"
 #include "../client/commands/CmdNewNymLegacy.hpp"
 #include "../client/commands/CmdNewOffer.hpp"
 #include "../client/commands/CmdNewServer.hpp"
@@ -188,7 +189,8 @@ CmdBase* cmds[] = {new CmdAcceptAll,       new CmdAcceptInbox,
                    new CmdInpayments,      new CmdIssueAsset,
                    new CmdKillOffer,       new CmdKillPlan,
                    new CmdNewAccount,      new CmdNewAsset,
-                   new CmdNewKey,          new CmdNewNymLegacy,
+                   new CmdNewKey,          new CmdNewNymECDSA,
+                   new CmdNewNymLegacy,
                    new CmdNewOffer,        new CmdNewServer,
                    new CmdOutbox,          new CmdOutmail,
                    new CmdNewBasket,       new CmdOutpayment,

--- a/src/server/UserCommandProcessor.cpp
+++ b/src/server/UserCommandProcessor.cpp
@@ -150,11 +150,11 @@ bool UserCommandProcessor::ProcessUserCommand(Message& theMessage,
 
         OTAsymmetricKey::KeyType keytypeAuthent =
         (OTAsymmetricKey::ERROR_TYPE == theMessage.keytypeAuthent_) ?
-            OTAsymmetricKey::RSA : static_cast<OTAsymmetricKey::KeyType>(theMessage.keytypeAuthent_);   // TODO HARDCODING
+            OTAsymmetricKey::LEGACY : static_cast<OTAsymmetricKey::KeyType>(theMessage.keytypeAuthent_);   // TODO HARDCODING
 
         OTAsymmetricKey::KeyType keytypeEncrypt =
         (OTAsymmetricKey::ERROR_TYPE == theMessage.keytypeEncrypt_) ?
-            OTAsymmetricKey::RSA : static_cast<OTAsymmetricKey::KeyType>(theMessage.keytypeEncrypt_);   // TODO HARDCODING
+            OTAsymmetricKey::LEGACY : static_cast<OTAsymmetricKey::KeyType>(theMessage.keytypeEncrypt_);   // TODO HARDCODING
 
         std::unique_ptr<OTAsymmetricKey> pNymAuthentKey(
             OTAsymmetricKey::KeyFactory(keytypeAuthent));


### PR DESCRIPTION
ECDSA credentials based on Libsepc256k1 are now supported in Open-Transactions.

Secp256k1-based credentials can now be created with the "createnymecdsa" command

RSA credentials have been renamed to "legacy credentials" and are created via the "createnymlegacy" command.

Other changes:
* OTEnvelope now contains a metadata wrapper: opentxs::Letter.
* OTEnvelopes can be sealed to multiple recipients, including a mix of OpenSSL recipients and Libsecp256k1 recipients.
    * The Letter holds the session keys and associated metadata in an OpenSSL-independent format and is extendible for supporting other types of credentials in the future.
* A new abstract interface for hashing-related functions has been added to the CryptoEngine:: CryptoHash.
    * Currently supports Digest() and HMAC() methods
* Multiple AES encryption modes are now defined, including AEAD modes (GCM).
    * The default mode for encrypting session keys and plaintext in an OTEnvelope is aes_256_gcm
    * aes_256_ecb is available for situations where the plaintext consists only a single 32 byte block (such as an secp256k1 private key) and including an IV is not desired.