### PR TITLE
Correct behavior of OTPassword::OTfread

### DIFF
--- a/src/core/crypto/OTPassword.cpp
+++ b/src/core/crypto/OTPassword.cpp
@@ -1002,7 +1002,7 @@ uint32_t OTPassword::OTfread(uint8_t* data, uint32_t size)
         if (size < sizeToRead) {
             sizeToRead = size;
         }
-        addMemory(data, sizeToRead);
+        safe_memcpy(data, sizeToRead, getMemory_uint8(), sizeToRead);
         position_ += sizeToRead;
     }
 


### PR DESCRIPTION
Fixes bug that prevented RSA session key encryption from working