### PR TITLE
Correct Identifier calculations

### DIFF
--- a/include/opentxs/core/crypto/CryptoHash.hpp
+++ b/include/opentxs/core/crypto/CryptoHash.hpp
@@ -69,6 +69,10 @@ public:
         const HashType hashType,
         const OTPassword& data,
         OTPassword& digest) const = 0;
+    virtual bool Digest(
+        const HashType hashType,
+        const OTData& data,
+        OTData& digest) const = 0;
     virtual bool HMAC(
         const CryptoHash::HashType hashType,
         const OTPassword& inputKey,
@@ -77,10 +81,6 @@ public:
     bool Digest(
         const HashType hashType,
         const String& data,
-        OTData& digest);
-    bool Digest(
-        const HashType hashType,
-        const OTData& data,
         OTData& digest);
     bool HMAC(
         const CryptoHash::HashType hashType,

--- a/include/opentxs/core/crypto/OpenSSL.hpp
+++ b/include/opentxs/core/crypto/OpenSSL.hpp
@@ -216,6 +216,10 @@ public:
         const CryptoHash::HashType hashType,
         const OTPassword& data,
         OTPassword& digest) const;
+    virtual bool Digest(
+        const CryptoHash::HashType hashType,
+        const OTData& data,
+        OTData& digest) const;
     virtual bool HMAC(
         const CryptoHash::HashType hashType,
         const OTPassword& inputKey,

--- a/src/core/crypto/CryptoHash.cpp
+++ b/src/core/crypto/CryptoHash.cpp
@@ -55,25 +55,6 @@ bool CryptoHash::Digest(
     return Digest(hashType, plaintext, digest);
 }
 
-bool CryptoHash::Digest(
-    const HashType hashType,
-    const OTData& data,
-    OTData& digest)
-{
-    OTPassword plaintext, result;
-    plaintext.setMemory(data);
-
-    bool success =  Digest(hashType, plaintext, result);
-
-    if (success) {
-        digest.Assign(result.getMemory(), result.getMemorySize());
-
-        return true;
-    }
-
-    return false;
-}
-
 bool CryptoHash::HMAC(
         const CryptoHash::HashType hashType,
         const OTPassword& inputKey,


### PR DESCRIPTION
Conversions from OTData to OTPassword are lossy except for very small OTData sizes.

Add an implementation of OpenSSL::Digest() that accepts OTData