### PR TITLE
Fix for generated protobuf headers not being found

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -94,9 +94,8 @@ file(GLOB cxx-headers
      "${CMAKE_CURRENT_SOURCE_DIR}/../../include/opentxs/core/util/*.hpp"
 )
 
-include_directories(
-  ${CMAKE_BINARY_DIR}/src/core/otprotob
-)
+include_directories(${ProtobufIncludePath})
+
 
 if(KEYRING_GNOME)
   include(GNUInstallDirs)

--- a/src/core/otprotob/CMakeLists.txt
+++ b/src/core/otprotob/CMakeLists.txt
@@ -6,6 +6,9 @@ endif()
 
 PROTOBUF_GENERATE_CPP(PROTO_SRC PROTO_HEADER Generics.proto Bitcoin.proto Markets.proto Moneychanger.proto)
 
+set(ProtobufIncludePath ${CMAKE_CURRENT_BINARY_DIR}
+        CACHE INTERNAL "Path to generated protobuf files.")
+
 if (WIN32)
   # suppress std::_Copy_impl being unsafe warnings 
   add_definitions("/wd4996")


### PR DESCRIPTION
Tested by building a crypto object with "Moneychanger.pb.h", and then recompiling with it removed. 

Both compiled successfully without issues.