### PR TITLE
Implement HD credentials

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "deps/bitcoin-secp256k1"]
 	path = deps/bitcoin-secp256k1
 	url = https://github.com/bitcoin/secp256k1.git
+[submodule "deps/trezor-crypto"]
+	path = deps/trezor-crypto
+	url = https://github.com/trezor/trezor-crypto.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ endif()
 if(OT_CRYPTO_USING_TREZOR)
   add_definitions(-DOT_CRYPTO_USING_TREZOR)
   add_definitions(-DOT_CRYPTO_WITH_BIP39)
+  add_definitions(-DOT_CRYPTO_WITH_BIP32)
 endif()
 
 add_definitions(-DOT_CASH_USING_LUCRE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ option(OT_CRYPTO_SUPPORTED_KEY_SECP256K1 "Enable secp256k1 key support" ON)
 
 option(OT_CRYPTO_USING_OPENSSL       "Use OpenSSL crypto implementation" ON)
 option(OT_CRYPTO_USING_LIBSECP256K1  "Use libsecp256k1 crypto implementation" ON)
+option(OT_CRYPTO_USING_TREZOR  "Use trezor crypto implementation" ON)
 
 # SWIG Bindings
 option(JAVA    "Build with Java binding" OFF)
@@ -111,6 +112,7 @@ message(STATUS "secp256k1               ${OT_CRYPTO_SUPPORTED_KEY_SECP256K1}")
 message(STATUS "Crypto library providers---------------------")
 message(STATUS "OpenSSL:                ${OT_CRYPTO_USING_OPENSSL}")
 message(STATUS "libsecp256k1:           ${OT_CRYPTO_USING_LIBSECP256K1}")
+message(STATUS "trezor-crypto:          ${OT_CRYPTO_USING_TREZOR}")
 
 message(STATUS "Bindings ------------------------------------")
 message(STATUS "Java binding:           ${JAVA}")
@@ -331,6 +333,11 @@ endif()
 
 if(OT_CRYPTO_USING_LIBSECP256K1)
   add_definitions(-DOT_CRYPTO_USING_LIBSECP256K1)
+endif()
+
+if(OT_CRYPTO_USING_TREZOR)
+  add_definitions(-DOT_CRYPTO_USING_TREZOR)
+  add_definitions(-DOT_CRYPTO_WITH_BIP39)
 endif()
 
 add_definitions(-DOT_CASH_USING_LUCRE)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -123,3 +123,34 @@ if (OT_CRYPTO_USING_LIBSECP256K1)
     )
     set_property(TARGET libsecp256k1 PROPERTY EXCLUDE_FROM_ALL TRUE)
 endif()
+
+if (OT_CRYPTO_USING_TREZOR)
+    set(trezor-sources
+        trezor-crypto/bignum.c
+        trezor-crypto/ecdsa.c
+        trezor-crypto/secp256k1.c
+        trezor-crypto/nist256p1.c
+        trezor-crypto/rand.c
+        trezor-crypto/hmac.c
+        trezor-crypto/bip32.c
+        trezor-crypto/bip39.c
+        trezor-crypto/pbkdf2.c
+        trezor-crypto/base58.c
+        trezor-crypto/ripemd160.c
+        trezor-crypto/sha2.c
+        trezor-crypto/aescrypt.c
+        trezor-crypto/aeskey.c
+        trezor-crypto/aestab.c
+        trezor-crypto/aes_modes.c
+    )
+
+    file(GLOB trezor-headers
+        "${CMAKE_CURRENT_SOURCE_DIR}/trezor-crypto/*.h"
+    )
+
+    add_library(trezor-crypto
+        STATIC
+        ${trezor-sources}
+        ${trezor-headers}
+    )
+endif()

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -144,6 +144,9 @@ if (OT_CRYPTO_USING_TREZOR)
         trezor-crypto/aes_modes.c
     )
 
+set_source_files_properties(${trezor-sources}
+    PROPERTIES COMPILE_FLAGS "-fPIC"
+)
     file(GLOB trezor-headers
         "${CMAKE_CURRENT_SOURCE_DIR}/trezor-crypto/*.h"
     )

--- a/include/opentxs/client/OTWallet.hpp
+++ b/include/opentxs/client/OTWallet.hpp
@@ -273,8 +273,13 @@ private:
     // While waiting on server response to withdrawal,
     // store private coin data here for unblinding
     Purse* m_pWithdrawalPurse;
+    uint32_t next_hd_key = 0;
 
 public:
+    inline uint32_t NextHDSeed() const {
+        return next_hd_key;
+    }
+
     String m_strFilename;
     String m_strDataFolder;
 };

--- a/include/opentxs/client/OTWallet.hpp
+++ b/include/opentxs/client/OTWallet.hpp
@@ -196,14 +196,14 @@ public:
     EXPORT bool Decrypt_ByKeyID(const std::string& key_id,
                                 const String& strCiphertext, String& strOutput,
                                 const String* pstrDisplay = nullptr);
-    
+
     EXPORT std::shared_ptr<OTSymmetricKey> getOrCreateExtraKey(
         const std::string& str_KeyID,
         const std::string* pReason = nullptr); // Use this one.
-    
+
     EXPORT std::shared_ptr<OTSymmetricKey> getExtraKey(
         const std::string& str_id) const; // Low level.
-    
+
     EXPORT bool addExtraKey(const std::string& str_id,
                             std::shared_ptr<OTSymmetricKey> pKey); // Low level.
     // These functions are low-level. They don't check for dependent data before

--- a/include/opentxs/client/OTWallet.hpp
+++ b/include/opentxs/client/OTWallet.hpp
@@ -202,7 +202,7 @@ public:
         const std::string* pReason = nullptr); // Use this one.
     
     EXPORT std::shared_ptr<OTSymmetricKey> getExtraKey(
-        const std::string& str_id); // Low level.
+        const std::string& str_id) const; // Low level.
     
     EXPORT bool addExtraKey(const std::string& str_id,
                             std::shared_ptr<OTSymmetricKey> pKey); // Low level.
@@ -221,6 +221,7 @@ public:
     EXPORT bool RemoveAccount(const Identifier& theTargetID);
     EXPORT bool RemovePrivateNym(const Identifier& theTargetID);
     EXPORT bool RemovePublicNym(const Identifier& theTargetID);
+    EXPORT std::string GetHDWordlist() const;
 
 private:
     void AddNym(const Nym& theNym, mapOfNyms& map);

--- a/include/opentxs/client/OpenTransactions.hpp
+++ b/include/opentxs/client/OpenTransactions.hpp
@@ -236,7 +236,7 @@ public:
     EXPORT bool IsNym_RegisteredAtServer(const Identifier& NYM_ID,
                                          const Identifier& NOTARY_ID) const;
     EXPORT bool Wallet_ChangePassphrase() const;
-
+    EXPORT static std::string Wallet_GetWords();
     EXPORT bool Wallet_CanRemoveServer(const Identifier& NOTARY_ID) const;
     EXPORT bool Wallet_CanRemoveAssetType(
         const Identifier& INSTRUMENT_DEFINITION_ID) const;

--- a/include/opentxs/core/crypto/Bip32.hpp
+++ b/include/opentxs/core/crypto/Bip32.hpp
@@ -47,6 +47,12 @@
 
 namespace opentxs
 {
+const uint32_t NYM_PURPOSE = 0x4f544e4d; // OTNM
+const uint32_t HARDENED = 0x80000000; // set MSB to indicate hardened derivation
+const uint32_t AUTH_KEY = 0x41555448; // AUTH
+const uint32_t ENCRYPT_KEY = 0x454e4352; // ENCRYPT
+const uint32_t SIGN_KEY = 0x5349474e; // SIGN
+
 class OTPassword;
 
 class Bip32
@@ -58,7 +64,7 @@ public:
         const proto::AsymmetricKey& parent,
         const uint32_t index) const = 0;
     virtual serializedAsymmetricKey PrivateToPublic(
-        const serializedAsymmetricKey& key) const = 0;
+        const proto::AsymmetricKey& key) const = 0;
 
     BinarySecret GetHDSeed() const;
     serializedAsymmetricKey GetHDKey(const proto::HDPath path) const;

--- a/include/opentxs/core/crypto/Bip32.hpp
+++ b/include/opentxs/core/crypto/Bip32.hpp
@@ -36,41 +36,30 @@
  *
  ************************************************************/
 
-#ifndef OPENTXS_CORE_CRYPTO_TREZOR_CRYPTO_HPP
-#define OPENTXS_CORE_CRYPTO_TREZOR_CRYPTO_HPP
+#ifndef OPENTXS_CORE_CRYPTO_BIP32_HPP
+#define OPENTXS_CORE_CRYPTO_BIP32_HPP
 
-extern "C" {
-    #include <trezor-crypto/bip32.h>
-}
-
-#include <memory>
-
-#include <opentxs/core/crypto/Bip32.hpp>
-#include <opentxs/core/crypto/Bip39.hpp>
-#include <opentxs/core/crypto/OTPassword.hpp>
+#include <string>
+#include <opentxs/core/crypto/OTAsymmetricKey.hpp>
 
 namespace opentxs
 {
-
 class OTPassword;
 
-class TrezorCrypto : public Bip39, public Bip32
+class Bip32
 {
-private:
-    std::shared_ptr<HDNode> SerializedToHDNode(
-        const proto::AsymmetricKey& serialized) const;
-    serializedAsymmetricKey HDNodeToSerialized(const HDNode& node) const;
+
 public:
-    virtual std::string toWords(const OTPassword& seed) const;
+
     virtual serializedAsymmetricKey SeedToPrivateKey(
-        const OTPassword& seed) const;
+        const OTPassword& seed) const = 0;
     virtual serializedAsymmetricKey GetChild(
         const proto::AsymmetricKey& parent,
-        const uint32_t index) const;
+        const uint32_t index) const = 0;
     virtual serializedAsymmetricKey PrivateToPublic(
-        const serializedAsymmetricKey& key) const;
+        const serializedAsymmetricKey& key) const = 0;
 };
 
 } // namespace opentxs
 
-#endif // OPENTXS_CORE_CRYPTO_TREZOR_CRYPTO_HPP
+#endif // OPENTXS_CORE_CRYPTO_BIP32_HPP

--- a/include/opentxs/core/crypto/Bip39.hpp
+++ b/include/opentxs/core/crypto/Bip39.hpp
@@ -1,0 +1,59 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CRYPTO_BIP39_HPP
+#define OPENTXS_CORE_CRYPTO_BIP39_HPP
+
+#include <string>
+
+namespace opentxs
+{
+class OTPassword;
+
+class Bip39
+{
+
+public:
+
+    virtual std::string toWords(
+        const OTPassword& seed) const = 0;
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CRYPTO_BIP39_HPP

--- a/include/opentxs/core/crypto/Credential.hpp
+++ b/include/opentxs/core/crypto/Credential.hpp
@@ -102,10 +102,9 @@ public:
     static const SerializationSignatureFlag WITHOUT_SIGNATURES = false;
 
     enum CredentialType: int32_t {
-        ERROR_TYPE,
-        LEGACY,
-        URL,
-        SECP256K1
+        ERROR_TYPE = proto::CREDTYPE_ERROR,
+        LEGACY = proto::CREDTYPE_LEGACY,
+        HD = proto::CREDTYPE_HD
     };
 
     static String CredentialTypeToString(CredentialType credentialType);

--- a/include/opentxs/core/crypto/CryptoEngine.hpp
+++ b/include/opentxs/core/crypto/CryptoEngine.hpp
@@ -39,6 +39,7 @@
 #ifndef OPENTXS_CORE_CRYPTO_CRYPTOENGINE_HPP
 #define OPENTXS_CORE_CRYPTO_CRYPTOENGINE_HPP
 
+#include <opentxs/core/crypto/Bip39.hpp>
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
 #include <opentxs/core/crypto/CryptoHash.hpp>
 #include <opentxs/core/crypto/CryptoSymmetric.hpp>
@@ -52,6 +53,10 @@
 
 #ifdef OT_CRYPTO_USING_LIBSECP256K1
 #include <opentxs/core/crypto/Libsecp256k1.hpp>
+#endif
+
+#ifdef OT_CRYPTO_USING_TREZOR
+#include <opentxs/core/crypto/TrezorCrypto.hpp>
 #endif
 
 namespace opentxs
@@ -68,6 +73,10 @@ typedef OpenSSL SSLImplementation;
 typedef Libsecp256k1 secp256k1;
 #endif
 
+#if defined OT_CRYPTO_USING_TREZOR
+typedef TrezorCrypto bip39;
+#endif
+
 //Singlton class for providing an interface to external crypto libraries
 //and hold the state required by those libraries.
 class CryptoEngine
@@ -81,7 +90,9 @@ private:
 #ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
     secp256k1* psecp256k1_ = nullptr;
 #endif
-
+#ifdef OT_CRYPTO_WITH_BIP39
+    bip39* pBip39_ = nullptr;
+#endif
     static CryptoEngine* pInstance_;
 
 public:
@@ -99,6 +110,9 @@ public:
     //Symmetric encryption engines
 #ifdef OT_CRYPTO_SUPPORTED_KEY_RSA
     EXPORT CryptoSymmetric& AES();
+#endif
+#ifdef OT_CRYPTO_WITH_BIP39
+    EXPORT Bip39& BIP39();
 #endif
 
     EXPORT static CryptoEngine& Instance();

--- a/include/opentxs/core/crypto/CryptoEngine.hpp
+++ b/include/opentxs/core/crypto/CryptoEngine.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_CRYPTO_CRYPTOENGINE_HPP
 
 #include <opentxs/core/crypto/Bip39.hpp>
+#include <opentxs/core/crypto/Bip32.hpp>
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
 #include <opentxs/core/crypto/CryptoHash.hpp>
 #include <opentxs/core/crypto/CryptoSymmetric.hpp>
@@ -74,7 +75,7 @@ typedef Libsecp256k1 secp256k1;
 #endif
 
 #if defined OT_CRYPTO_USING_TREZOR
-typedef TrezorCrypto bip39;
+typedef TrezorCrypto bitcoincrypto;
 #endif
 
 //Singlton class for providing an interface to external crypto libraries
@@ -90,8 +91,8 @@ private:
 #ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
     secp256k1* psecp256k1_ = nullptr;
 #endif
-#ifdef OT_CRYPTO_WITH_BIP39
-    bip39* pBip39_ = nullptr;
+#ifdef OT_CRYPTO_USING_TREZOR
+    bitcoincrypto* pbitcoincrypto_ = nullptr;
 #endif
     static CryptoEngine* pInstance_;
 
@@ -113,6 +114,9 @@ public:
 #endif
 #ifdef OT_CRYPTO_WITH_BIP39
     EXPORT Bip39& BIP39();
+#endif
+#ifdef OT_CRYPTO_WITH_BIP32
+    EXPORT Bip32& BIP32();
 #endif
 
     EXPORT static CryptoEngine& Instance();

--- a/include/opentxs/core/crypto/KeyCredential.hpp
+++ b/include/opentxs/core/crypto/KeyCredential.hpp
@@ -153,11 +153,18 @@ private: // Private prevents erroneous use by other classes.
     bool addKeyCredentialtoSerializedCredential(
         serializedCredential credential,
         const bool addPrivate) const;
-
+    std::shared_ptr<OTKeypair> DeriveHDKeypair(
+        const uint32_t nym,
+        const uint32_t credset,
+        const uint32_t credindex,
+        const proto::KeyRole role);
 
 protected:
     virtual serializedCredential Serialize(bool asPrivate = false, bool asSigned = true) const;
-    KeyCredential(CredentialSet& theOwner, const NymParameters& nymParameters);
+    KeyCredential(
+        CredentialSet& theOwner,
+        const NymParameters& nymParameters,
+        const proto::CredentialRole role);
     KeyCredential(CredentialSet& theOwner, const proto::Credential& serializedCred);
 public:
     std::shared_ptr<OTKeypair> m_SigningKey; // Signing keys, for signing/verifying a "legal

--- a/include/opentxs/core/crypto/Libsecp256k1.hpp
+++ b/include/opentxs/core/crypto/Libsecp256k1.hpp
@@ -127,6 +127,14 @@ public:
         const OTPassword& privkey,
         const OTPassword& password,
         OTAsymmetricKey& asymmetricKey) const;
+    static bool EncryptPrivateKey(
+        const OTPassword& plaintextKey,
+        const OTPassword& password,
+        OTData& encryptedKey);
+    static bool DecryptPrivateKey(
+        const OTData& encryptedKey,
+        const OTPassword& password,
+        OTPassword& plaintextKey);
 
     bool ECDH(
         const OTAsymmetricKey& publicKey,

--- a/include/opentxs/core/crypto/NymParameters.hpp
+++ b/include/opentxs/core/crypto/NymParameters.hpp
@@ -102,10 +102,37 @@ public:
     NymParameters() = default;
     ~NymParameters() = default;
 
-private:
-    NymParameters(const NymParameters&) = delete;
-    NymParameters& operator=(const NymParameters&) = delete;
+#if defined(OT_CRYPTO_WITH_BIP32)
+    inline uint32_t Nym() const
+    {
+        return nym_;
+    }
 
+    inline void SetNym(const uint32_t path)
+    {
+        nym_ = path;
+    }
+    inline uint32_t Credset() const
+    {
+        return credset_;
+    }
+
+    inline void SetCredset(const uint32_t path)
+    {
+        credset_ = path;
+    }
+    inline uint32_t CredIndex() const
+    {
+        return cred_index_;
+    }
+
+    inline void SetCredIndex(const uint32_t path)
+    {
+        cred_index_ = path;
+    }
+#endif
+
+private:
     std::string altLocation_ = "";
 
     proto::SourceType sourceType_ = proto::SOURCETYPE_PUBKEY;
@@ -128,6 +155,11 @@ private:
 //----------------------------------------
 #if defined(OT_CRYPTO_SUPPORTED_KEY_RSA)
   int32_t nBits_ = 1024;
+#endif
+#if defined(OT_CRYPTO_WITH_BIP32)
+  uint32_t nym_ = 0;
+  uint32_t credset_ = 0;
+  uint32_t cred_index_ = 0;
 #endif
 
 };

--- a/include/opentxs/core/crypto/NymParameters.hpp
+++ b/include/opentxs/core/crypto/NymParameters.hpp
@@ -114,7 +114,7 @@ private:
 
 #if defined(OT_CRYPTO_SUPPORTED_KEY_SECP256K1)
     NymParameterType nymType_ = NymParameterType::SECP256K1;
-    Credential::CredentialType credentialType_ = Credential::SECP256K1;
+    Credential::CredentialType credentialType_ = Credential::HD;
 #elif defined(OT_CRYPTO_SUPPORTED_KEY_RSA)
     NymParameterType nymType_ = NymParameterType::LEGACY;
     Credential::CredentialType credentialType_ = Credential::LEGACY;

--- a/include/opentxs/core/crypto/TrezorCrypto.hpp
+++ b/include/opentxs/core/crypto/TrezorCrypto.hpp
@@ -1,0 +1,56 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CRYPTO_TREZOR_CRYPTO_HPP
+#define OPENTXS_CORE_CRYPTO_TREZOR_CRYPTO_HPP
+
+#include <opentxs/core/crypto/Bip39.hpp>
+#include <opentxs/core/crypto/OTPassword.hpp>
+
+namespace opentxs
+{
+
+class TrezorCrypto : public Bip39
+{
+public:
+    virtual std::string toWords(const OTPassword& seed) const;
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CRYPTO_TREZOR_CRYPTO_HPP

--- a/include/opentxs/core/crypto/TrezorCrypto.hpp
+++ b/include/opentxs/core/crypto/TrezorCrypto.hpp
@@ -57,9 +57,15 @@ class OTPassword;
 class TrezorCrypto : public Bip39, public Bip32
 {
 private:
+    typedef bool DerivationMode;
+    const DerivationMode DERIVE_PRIVATE = true;
+    const DerivationMode DERIVE_PUBLIC = false;
+
     std::shared_ptr<HDNode> SerializedToHDNode(
         const proto::AsymmetricKey& serialized) const;
-    serializedAsymmetricKey HDNodeToSerialized(const HDNode& node) const;
+    serializedAsymmetricKey HDNodeToSerialized(
+        const HDNode& node,
+        const DerivationMode privateVersion) const;
 public:
     virtual std::string toWords(const OTPassword& seed) const;
     virtual serializedAsymmetricKey SeedToPrivateKey(
@@ -68,7 +74,7 @@ public:
         const proto::AsymmetricKey& parent,
         const uint32_t index) const;
     virtual serializedAsymmetricKey PrivateToPublic(
-        const serializedAsymmetricKey& key) const;
+        const proto::AsymmetricKey& key) const;
 };
 
 } // namespace opentxs

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -527,7 +527,7 @@ std::string OTAPI_Exec::CreateNymECDSA(
     std::shared_ptr<NymParameters> nymParameters;
     nymParameters = std::make_shared<NymParameters>(
         NymParameters::SECP256K1,
-        Credential::SECP256K1);
+        Credential::HD);
     //nymParameters->SetSource(NYM_ID_SOURCE);
     nymParameters->SetAltLocation(ALT_LOCATION);
 

--- a/src/client/OTWallet.cpp
+++ b/src/client/OTWallet.cpp
@@ -2010,18 +2010,11 @@ bool OTWallet::LoadWallet(const char* szFilename)
 std::string OTWallet::GetHDWordlist() const
 {
     std::string wordlist = "";
+    BinarySecret masterseed = CryptoEngine::Instance().BIP32().GetHDSeed();
 
-    std::shared_ptr<OTCachedKey> encryptedCachedKey(OTCachedKey::It());
-    if (encryptedCachedKey) {
-        OTPassword decryptedCachedKey;
-        std::string pReason = "loading the master HD seed for this wallet";
-        const bool bGotMasterPW = encryptedCachedKey->GetMasterPassword(
-            encryptedCachedKey, decryptedCachedKey, pReason.c_str());
-
-        if (bGotMasterPW) {
-            wordlist = CryptoEngine::Instance().BIP39().toWords(decryptedCachedKey);
-            otErr << "New HD seed: " << wordlist << "\n";
-        }
+    if (masterseed) {
+        wordlist = CryptoEngine::Instance().BIP39().toWords(*masterseed);
+        otErr << "New HD seed: " << wordlist << "\n";
     }
     return wordlist;
 }

--- a/src/client/OpenTransactions.cpp
+++ b/src/client/OpenTransactions.cpp
@@ -1370,6 +1370,25 @@ bool OT_API::Wallet_ChangePassphrase() const
 }
 
 
+std::string OT_API::Wallet_GetWords()
+{
+    bool bInitialized = OTAPI_Wrap::OTAPI()->IsInitialized();
+
+    if (!bInitialized) {
+        otErr << __FUNCTION__
+              << ": Not initialized; call OT_API::Init first.\n";
+        OT_FAIL;
+    }
+
+    OTWallet* pWallet = OTAPI_Wrap::OTAPI()->GetWallet(__FUNCTION__);
+
+    if (nullptr == pWallet) {
+        return "";
+    }
+
+    return pWallet->GetHDWordlist();
+}
+
 bool OT_API::Wallet_CanRemoveServer(const Identifier& NOTARY_ID) const
 {
     bool bInitialized = OTAPI_Wrap::OTAPI()->IsInitialized();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -13,6 +13,12 @@ else()
   set(KEYSECP256K1 "")
 endif()
 
+if(OT_CRYPTO_USING_TREZOR)
+  set(TREZOR_TARGET "trezor-crypto")
+else()
+  set(TREZOR_TARGET "")
+endif()
+
 add_subdirectory(otprotob)
 add_subdirectory(trade)
 add_subdirectory(cron)
@@ -141,7 +147,7 @@ else()
   )
 endif()
 
-target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58 czmq_local)
+target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58 czmq_local ${TREZOR_TARGET})
 target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
 
 add_library(opentxs-proto STATIC IMPORTED)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,8 +15,10 @@ endif()
 
 if(OT_CRYPTO_USING_TREZOR)
   set(TREZOR_TARGET "trezor-crypto")
+  set(LIBTREZORCRYPTO "crypto/TrezorCrypto.cpp")
 else()
   set(TREZOR_TARGET "")
+  set(LIBTREZORCRYPTO "")
 endif()
 
 add_subdirectory(otprotob)
@@ -57,6 +59,7 @@ set(cxx-sources
   crypto/CryptoSymmetric.cpp
   crypto/OpenSSL.cpp
   ${LIBSECP256K1}
+  ${LIBTREZORCRYPTO}
   crypto/CryptoEngine.cpp
   OTData.cpp
   crypto/Letter.cpp
@@ -147,7 +150,7 @@ else()
   )
 endif()
 
-target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58 czmq_local ${TREZOR_TARGET})
+target_link_libraries(opentxs-core PRIVATE opentxs-recurring opentxs-script opentxs-cron opentxs-trade otprotob irrxml bitcoin-base58 czmq_local)
 target_link_libraries(opentxs-core PUBLIC ${PROTOBUF_LIBRARY} ${OPENSSL_LIBRARIES} ${ZLIB_LIBRARY} ${OPENTXS_SYSTEM_LIBRARIES} ${keyring})
 
 add_library(opentxs-proto STATIC IMPORTED)
@@ -164,6 +167,10 @@ if (OT_CRYPTO_USING_LIBSECP256K1)
     set_property(TARGET staticlibsecp256k1 PROPERTY IMPORTED_LOCATION ${CMAKE_BINARY_DIR}/deps/lib/libsecp256k1.a)
     target_link_libraries(opentxs-core PRIVATE staticlibsecp256k1)
     target_link_libraries(opentxs-core PUBLIC ${GMP_LIBRARIES})
+endif()
+
+if (OT_CRYPTO_USING_TREZOR)
+    target_link_libraries(opentxs-core PRIVATE ${TREZOR_TARGET})
 endif()
 
 set_lib_property(opentxs-core)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -95,6 +95,7 @@ set(cxx-sources
   OTTransaction.cpp
   OTTransactionType.cpp
   NymIDSource.cpp
+  crypto/Bip32.cpp
 )
 
 file(GLOB cxx-headers

--- a/src/core/crypto/ChildKeyCredential.cpp
+++ b/src/core/crypto/ChildKeyCredential.cpp
@@ -90,7 +90,7 @@ ChildKeyCredential::ChildKeyCredential(CredentialSet& other, const proto::Creden
 }
 
 ChildKeyCredential::ChildKeyCredential(CredentialSet& other, const NymParameters& nymParameters)
-    : ot_super(other, nymParameters)
+    : ot_super(other, nymParameters, proto::CREDROLE_CHILDKEY)
 {
     m_strContractType = "KEY CREDENTIAL";
     m_Role = proto::CREDROLE_CHILDKEY;

--- a/src/core/crypto/Credential.cpp
+++ b/src/core/crypto/Credential.cpp
@@ -265,11 +265,8 @@ String Credential::CredentialTypeToString(Credential::CredentialType credentialT
         case Credential::LEGACY :
             credentialString="legacy";
             break;
-        case Credential::SECP256K1 :
-            credentialString="secp256k1";
-            break;
-        case Credential::URL :
-            credentialString="url";
+        case Credential::HD :
+            credentialString="hd";
             break;
         default :
             credentialString="error";
@@ -282,10 +279,8 @@ Credential::CredentialType Credential::StringToCredentialType(const String & cre
 {
     if (credentialType.Compare("legacy"))
         return Credential::LEGACY;
-    else if (credentialType.Compare("secp256k1"))
-        return Credential::SECP256K1;
-    else if (credentialType.Compare("url"))
-        return Credential::URL;
+    else if (credentialType.Compare("hd"))
+        return Credential::HD;
     return Credential::ERROR_TYPE;
 }
 
@@ -298,11 +293,8 @@ OTAsymmetricKey::KeyType Credential::CredentialTypeToKeyType(Credential::Credent
         case Credential::LEGACY :
             newKeyType = OTAsymmetricKey::LEGACY;
             break;
-        case Credential::SECP256K1 :
+        case Credential::HD :
             newKeyType = OTAsymmetricKey::SECP256K1;
-            break;
-        case Credential::URL :
-            newKeyType = OTAsymmetricKey::NULL_TYPE;
             break;
         default :
             newKeyType = OTAsymmetricKey::ERROR_TYPE;

--- a/src/core/crypto/CryptoEngine.cpp
+++ b/src/core/crypto/CryptoEngine.cpp
@@ -59,6 +59,9 @@ CryptoEngine::CryptoEngine()
 #ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
     , psecp256k1_(new Libsecp256k1(*pSSL_))
 #endif
+    #ifdef OT_CRYPTO_USING_TREZOR
+    , pBip39_(new TrezorCrypto())
+#endif
 {
     Init();
 }
@@ -125,6 +128,14 @@ CryptoSymmetric& CryptoEngine::AES()
     OT_ASSERT(nullptr != pSSL_);
 
     return *pSSL_;
+}
+#endif
+#ifdef OT_CRYPTO_WITH_BIP39
+Bip39& CryptoEngine::BIP39()
+{
+    OT_ASSERT(nullptr != pBip39_);
+
+    return *pBip39_;
 }
 #endif
 CryptoEngine& CryptoEngine::Instance()

--- a/src/core/crypto/CryptoEngine.cpp
+++ b/src/core/crypto/CryptoEngine.cpp
@@ -59,8 +59,8 @@ CryptoEngine::CryptoEngine()
 #ifdef OT_CRYPTO_SUPPORTED_KEY_SECP256K1
     , psecp256k1_(new Libsecp256k1(*pSSL_))
 #endif
-    #ifdef OT_CRYPTO_USING_TREZOR
-    , pBip39_(new TrezorCrypto())
+#ifdef OT_CRYPTO_USING_TREZOR
+    , pbitcoincrypto_(new TrezorCrypto())
 #endif
 {
     Init();
@@ -133,9 +133,17 @@ CryptoSymmetric& CryptoEngine::AES()
 #ifdef OT_CRYPTO_WITH_BIP39
 Bip39& CryptoEngine::BIP39()
 {
-    OT_ASSERT(nullptr != pBip39_);
+    OT_ASSERT(nullptr != pbitcoincrypto_);
 
-    return *pBip39_;
+    return *pbitcoincrypto_;
+}
+#endif
+#ifdef OT_CRYPTO_WITH_BIP32
+Bip32& CryptoEngine::BIP32()
+{
+    OT_ASSERT(nullptr != pbitcoincrypto_);
+
+    return *pbitcoincrypto_;
 }
 #endif
 CryptoEngine& CryptoEngine::Instance()

--- a/src/core/crypto/Letter.cpp
+++ b/src/core/crypto/Letter.cpp
@@ -246,7 +246,7 @@ bool Letter::Seal(
             // Because maybe the sender only has RSA credentials.
             NymParameters pKeyData(
                 NymParameters::SECP256K1,
-                Credential::SECP256K1);
+                Credential::LEGACY);
 
             OTKeypair ephemeralKeypair(pKeyData);
             ephemeralKeypair.GetPublicKey(ephemeralPubkey);

--- a/src/core/crypto/MasterCredential.cpp
+++ b/src/core/crypto/MasterCredential.cpp
@@ -154,7 +154,7 @@ serializedCred.publiccredential().masterdata().source());
 }
 
 MasterCredential::MasterCredential(CredentialSet& theOwner, const NymParameters& nymParameters)
-    : ot_super(theOwner, nymParameters)
+    : ot_super(theOwner, nymParameters, proto::CREDROLE_MASTERKEY)
 {
     m_strContractType = "MASTER KEY CREDENTIAL";
     m_Role = proto::CREDROLE_MASTERKEY;

--- a/src/core/crypto/TrezorCrypto.cpp
+++ b/src/core/crypto/TrezorCrypto.cpp
@@ -53,4 +53,107 @@ std::string TrezorCrypto::toWords(const OTPassword& seed) const
     return wordlist;
 }
 
+serializedAsymmetricKey TrezorCrypto::SeedToPrivateKey(const OTPassword& seed)
+    const
+{
+    serializedAsymmetricKey derivedKey;
+    HDNode node;
+
+    int result = ::hdnode_from_seed(
+        static_cast<const uint8_t*>(seed.getMemory()),
+        seed.getMemorySize(),
+        &node);
+
+    if (1 == result) {
+        derivedKey = HDNodeToSerialized(node);
+    }
+
+    return derivedKey;
+}
+
+serializedAsymmetricKey TrezorCrypto::GetChild(
+    const proto::AsymmetricKey& parent,
+    const uint32_t index) const
+{
+    std::shared_ptr<HDNode> node = SerializedToHDNode(parent);
+
+    if (proto::KEYMODE_PUBLIC == parent.mode()) {
+        hdnode_private_ckd(node.get(), index);
+    } else {
+        hdnode_public_ckd(node.get(), index);
+    }
+    serializedAsymmetricKey key = HDNodeToSerialized(*node);
+
+    return key;
+}
+
+serializedAsymmetricKey TrezorCrypto::HDNodeToSerialized(const HDNode& node)
+    const
+{
+    serializedAsymmetricKey key = std::make_shared<proto::AsymmetricKey>();
+
+    uint8_t testkey[sizeof(node.private_key)]{};
+    bool isPrivate = !memcmp(
+        testkey,
+        node.private_key,
+        sizeof(node.private_key));
+
+    key->set_version(1);
+    key->set_type(proto::AKEYTYPE_SECP256K1);
+
+    if (isPrivate) {
+        key->set_mode(proto::KEYMODE_PRIVATE);
+        key->set_key(node.private_key, sizeof(node.private_key));
+    } else {
+        key->set_mode(proto::KEYMODE_PUBLIC);
+        key->set_key(node.public_key, sizeof(node.public_key));
+    }
+    key->set_chaincode(node.chain_code, sizeof(node.chain_code));
+
+    return key;
+}
+
+std::shared_ptr<HDNode> TrezorCrypto::SerializedToHDNode(
+    const proto::AsymmetricKey& serialized) const
+{
+    std::shared_ptr<HDNode> node = std::make_shared<HDNode>();
+
+    OTPassword::safe_memcpy(
+        &(node->chain_code[0]),
+        sizeof(node->chain_code),
+        serialized.chaincode().c_str(),
+        serialized.chaincode().size(),
+        false);
+
+    if (proto::KEYMODE_PRIVATE == serialized.mode()) {
+        OTPassword::safe_memcpy(
+            &(node->private_key[0]),
+            sizeof(node->private_key),
+            serialized.key().c_str(),
+            serialized.key().size(),
+            false);
+    } else {
+        OTPassword::safe_memcpy(
+            &(node->public_key[0]),
+            sizeof(node->public_key),
+            serialized.key().c_str(),
+            serialized.key().size(),
+            false);
+    }
+
+    return node;
+}
+
+serializedAsymmetricKey TrezorCrypto::PrivateToPublic(
+    const serializedAsymmetricKey& key) const
+{
+    std::shared_ptr<HDNode> node = SerializedToHDNode(*key);
+    hdnode_fill_public_key(node.get());
+
+    // This will cause the next function to serialize as public
+    OTPassword::zeroMemory(node->private_key, sizeof(node->private_key));
+
+    return HDNodeToSerialized(*node);
+}
+
 } // namespace opentxs

--- a/src/core/crypto/TrezorCrypto.cpp
+++ b/src/core/crypto/TrezorCrypto.cpp
@@ -1,0 +1,56 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include <opentxs/core/crypto/TrezorCrypto.hpp>
+
+extern "C" {
+#include <trezor-crypto/bip39.h>
+}
+
+namespace opentxs
+{
+std::string TrezorCrypto::toWords(const OTPassword& seed) const
+{
+    std::string wordlist(
+        ::mnemonic_from_data(
+            static_cast<const uint8_t*>(seed.getMemory()),
+            seed.getMemorySize()));
+    return wordlist;
+}
+
+} // namespace opentxs


### PR DESCRIPTION
* Add trezor-crypto as a submodule
* Implement BIP39 so the wallet master key can be exported as a word list
* Implement BIP32 derivation for secp256k1 keys
* Change the default credential type to HD. All private keys used by ecdsa credentials are deterministically derived from the wallet master key.