### PR TITLE
Add BIP47 NymID sources

### DIFF
--- a/include/opentxs/client/OTAPI.hpp
+++ b/include/opentxs/client/OTAPI.hpp
@@ -415,13 +415,11 @@ public:
     // is that master credentials be signed by the corresponding private key.
     */
     EXPORT static std::string CreateNymLegacy(
-        const int32_t& nKeySize, const std::string& NYM_ID_SOURCE,
-        const std::string& ALT_LOCATION); // source and location can be empty.
+        const int32_t& nKeySize, const std::string& NYM_ID_SOURCE); // source can be empty.
                                           // (OT will generate a Nym with a
                                           // public key as the source.)
     EXPORT static std::string CreateNymECDSA(
-        const std::string& NYM_ID_SOURCE,
-        const std::string& ALT_LOCATION); // source and location can be empty.
+        const std::string& NYM_ID_SOURCE); // source and location can be empty.
                                           // (OT will generate a Nym with a
                                           // public key as the source.)
 
@@ -431,7 +429,7 @@ public:
                                                 int64_t lTransNum);
 
     EXPORT static std::string GetNym_SourceForID(const std::string& NYM_ID);
-    EXPORT static std::string GetNym_AltSourceLocation(
+    EXPORT static std::string GetNym_Description(
         const std::string& NYM_ID);
 
     EXPORT static int32_t GetNym_MasterCredentialCount(const std::string& NYM_ID);

--- a/include/opentxs/client/OTAPI_Exec.hpp
+++ b/include/opentxs/client/OTAPI_Exec.hpp
@@ -416,14 +416,12 @@ public:
     // is that master credentials be signed by the corresponding private key.
     */
     EXPORT std::string CreateNymLegacy(const int32_t& nKeySize,
-                                 const std::string& NYM_ID_SOURCE,
-                                 const std::string& ALT_LOCATION)
+                                 const std::string& NYM_ID_SOURCE)
         const; // source and location can be empty.
                // (OT will generate a Nym with a
                // public key as the source.)
     EXPORT std::string CreateNymECDSA(
-                                 const std::string& NYM_ID_SOURCE,
-                                 const std::string& ALT_LOCATION)
+                                 const std::string& NYM_ID_SOURCE)
         const; // source and location can be empty.
                // (OT will generate a Nym with a
                // public key as the source.)
@@ -435,7 +433,7 @@ public:
                                          int64_t lTransNum) const;
 
     EXPORT std::string GetNym_SourceForID(const std::string& NYM_ID) const;
-    EXPORT std::string GetNym_AltSourceLocation(
+    EXPORT std::string GetNym_Description(
         const std::string& NYM_ID) const;
 
     EXPORT int32_t GetNym_MasterCredentialCount(const std::string& NYM_ID) const;

--- a/include/opentxs/client/OTWallet.hpp
+++ b/include/opentxs/client/OTWallet.hpp
@@ -273,11 +273,11 @@ private:
     // While waiting on server response to withdrawal,
     // store private coin data here for unblinding
     Purse* m_pWithdrawalPurse;
-    uint32_t next_hd_key = 0;
+    uint32_t next_hd_key_ = 0;
 
 public:
     inline uint32_t NextHDSeed() const {
-        return next_hd_key;
+        return next_hd_key_;
     }
 
     String m_strFilename;

--- a/include/opentxs/client/OT_ME.hpp
+++ b/include/opentxs/client/OT_ME.hpp
@@ -113,12 +113,10 @@ public:
                                  const std::string& TARGET_NYM_ID) const;
 
     EXPORT std::string create_nym_ecdsa(
-                                  const std::string& NYM_ID_SOURCE,
-                                  const std::string& ALT_LOCATION) const;
+                                  const std::string& NYM_ID_SOURCE) const;
 
     EXPORT std::string create_nym_legacy(int32_t nKeybits,
-                                  const std::string& NYM_ID_SOURCE,
-                                  const std::string& ALT_LOCATION) const;
+                                  const std::string& NYM_ID_SOURCE) const;
 
     EXPORT std::string issue_asset_type(const std::string& NOTARY_ID,
                                         const std::string& NYM_ID,
@@ -156,7 +154,7 @@ public:
                                  const std::string& NYM_ID,
                                  const std::string& ACCOUNT_ID,
                                  bool bForceDownload = false) const;
-    
+
     EXPORT bool retrieve_nym(const std::string& NOTARY_ID,
                              const std::string& NYM_ID,
                              bool bForceDownload = true) const;
@@ -349,7 +347,7 @@ public:
 
 //    EXPORT bool networkFailureRaw(); // This returns m_bNetworkFailure
 //    EXPORT bool networkFailure();    // This returns m_bNetworkFailure but also resets it back to false.
-    
+
 private:
     OT_ME(const OT_ME&);
     OT_ME& operator=(const OT_ME&);
@@ -360,7 +358,7 @@ private:
     std::shared_ptr<OTScript> m_pScript;
 
     bool m_bNetworkFailure;
-    
+
     bool HaveWorkingScript();
 
     bool Register_OTDB_With_Script();

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -107,12 +107,7 @@ private:
                                           // be a
                                 // public key, or a URL, or DN info from a
                                 // cert, etc.
-    String m_strAltLocation; // If the Nym's credential IDs cannot be directly
-                             // downloaded from the source, the download
-                             // location is placed here instead. For example,
-                             // if the source is DN info from a cert, the alt
-                             // location might contain the URL to download it
-                             // from.
+    String m_strDescription;
     Identifier m_nymID; // Hashed-ID formed by hashing the Nym's public key.
     Identifier m_NymboxHash; // (Server-side) Hash of the Nymbox
 
@@ -435,9 +430,9 @@ public:
     {
         return *source_;
     } // Source for NymID for this credential. (Hash it to get ID.)
-    EXPORT const String& GetAltLocation() const
+    EXPORT const String& GetDescription() const
     {
-        return m_strAltLocation;
+        return m_strDescription;
     } // Alternate download location for Nym's credential IDs. (Primary location
       // being the source itself, but sometimes that's not feasible.)
 
@@ -447,9 +442,9 @@ public:
         std::make_shared<NymIDSource>(source);
         source_ = pSource;
     }
-    EXPORT void SetAltLocation(const String& strLocation)
+    EXPORT void SetDescription(const String& strLocation)
     {
-        m_strAltLocation = strLocation;
+        m_strDescription = strLocation;
     }
 private:
     EXPORT void SerializeNymIDSource(Tag& parent) const;

--- a/include/opentxs/core/NymIDSource.hpp
+++ b/include/opentxs/core/NymIDSource.hpp
@@ -87,6 +87,7 @@ public:
         proto::Signature& sig) const;
 
     String asString() const;
+    String Description() const;
 
     static serializedNymIDSource ExtractArmoredSource(
         const OTASCIIArmor& armoredSource);

--- a/include/opentxs/core/NymIDSource.hpp
+++ b/include/opentxs/core/NymIDSource.hpp
@@ -46,6 +46,7 @@
 #include "Identifier.hpp"
 #include "OTData.hpp"
 #include "String.hpp"
+#include "crypto/PaymentCode.hpp"
 
 namespace opentxs
 {
@@ -64,6 +65,7 @@ private:
     uint32_t version_ = 0;
     proto::SourceType type_ = proto::SOURCETYPE_ERROR;
     std::shared_ptr<OTAsymmetricKey> pubkey_;
+    std::shared_ptr<PaymentCode> payment_code_;
 
     OTData asData() const;
 

--- a/include/opentxs/core/NymIDSource.hpp
+++ b/include/opentxs/core/NymIDSource.hpp
@@ -75,11 +75,16 @@ public:
     NymIDSource(
         const NymParameters& nymParameters,
         proto::AsymmetricKey& pubkey);
+    NymIDSource(std::unique_ptr<PaymentCode>& source);
 
     Identifier NymID() const;
 
     serializedNymIDSource Serialize() const;
     bool Verify(const MasterCredential& credential) const;
+    bool Sign(
+        const NymParameters& nymParameters,
+        const MasterCredential& credential,
+        proto::Signature& sig) const;
 
     String asString() const;
 

--- a/include/opentxs/core/NymIDSource.hpp
+++ b/include/opentxs/core/NymIDSource.hpp
@@ -84,7 +84,8 @@ public:
     bool Sign(
         const NymParameters& nymParameters,
         const MasterCredential& credential,
-        proto::Signature& sig) const;
+        proto::Signature& sig,
+        const OTPasswordData* pPWData = nullptr) const;
 
     String asString() const;
     String Description() const;

--- a/include/opentxs/core/crypto/Bip32.hpp
+++ b/include/opentxs/core/crypto/Bip32.hpp
@@ -40,17 +40,21 @@
 #define OPENTXS_CORE_CRYPTO_BIP32_HPP
 
 #include <string>
+
 #include <opentxs-proto/verify/VerifyCredentials.hpp>
 
 #include <opentxs/core/crypto/CryptoSymmetric.hpp>
 #include <opentxs/core/crypto/OTAsymmetricKey.hpp>
+#include <opentxs/core/crypto/PaymentCode.hpp>
 
 namespace opentxs
 {
 const uint32_t NYM_PURPOSE = 0x4f544e4d; // OTNM
+const uint32_t PC_PURPOSE = 47; // BIP-47
 const uint32_t HARDENED = 0x80000000; // set MSB to indicate hardened derivation
+const uint32_t BITCOIN_TYPE = 0; // coin type
 const uint32_t AUTH_KEY = 0x41555448; // AUTH
-const uint32_t ENCRYPT_KEY = 0x454e4352; // ENCRYPT
+const uint32_t ENCRYPT_KEY = 0x454e4352; // ENCR
 const uint32_t SIGN_KEY = 0x5349474e; // SIGN
 
 class OTPassword;

--- a/include/opentxs/core/crypto/Bip32.hpp
+++ b/include/opentxs/core/crypto/Bip32.hpp
@@ -72,6 +72,7 @@ public:
 
     BinarySecret GetHDSeed() const;
     serializedAsymmetricKey GetHDKey(const proto::HDPath path) const;
+    serializedAsymmetricKey GetPaymentCode(const uint32_t nym) const;
 
 };
 

--- a/include/opentxs/core/crypto/Credential.hpp
+++ b/include/opentxs/core/crypto/Credential.hpp
@@ -154,12 +154,12 @@ protected:
     virtual serializedCredential Serialize(
         SerializationModeFlag asPrivate,
         SerializationSignatureFlag asSigned) const;
-    virtual serializedCredential SerializeForPublicSignature() const;
     virtual serializedCredential SerializeForPrivateSignature() const;
     virtual serializedCredential SerializeForIdentifier() const;
     OTData SerializeCredToData(const proto::Credential& serializedCred) const;
 
 public:
+    virtual serializedCredential SerializeForPublicSignature() const;
     serializedSignature GetSelfSignature(CredentialModeFlag version = PUBLIC_VERSION) const;
     serializedSignature GetSourceSignature() const;
     EXPORT virtual bool LoadContractFromString(const String& theStr);

--- a/include/opentxs/core/crypto/Credential.hpp
+++ b/include/opentxs/core/crypto/Credential.hpp
@@ -161,6 +161,7 @@ protected:
 
 public:
     serializedSignature GetSelfSignature(CredentialModeFlag version = PUBLIC_VERSION) const;
+    serializedSignature GetSourceSignature() const;
     EXPORT virtual bool LoadContractFromString(const String& theStr);
 
     static serializedCredential ExtractArmoredCredential(const String stringCredential);

--- a/include/opentxs/core/crypto/CryptoSymmetric.hpp
+++ b/include/opentxs/core/crypto/CryptoSymmetric.hpp
@@ -99,6 +99,7 @@ public:
     enum Mode: int32_t {
         ERROR_MODE,
         AES_128_CBC,
+        AES_256_CBC,
         AES_256_ECB,
         AES_128_GCM,
         AES_256_GCM

--- a/include/opentxs/core/crypto/KeyCredential.hpp
+++ b/include/opentxs/core/crypto/KeyCredential.hpp
@@ -195,11 +195,18 @@ public:
     void Release_KeyCredential();
 
     virtual bool Sign(
-        const proto::Credential& credential,
-        const CryptoHash::HashType hashType,
-        OTData& signature, // output
+        const OTData& plaintext,
+        proto::Signature& sig,
+        const OTPasswordData* pPWData = nullptr,
         const OTPassword* exportPassword = nullptr,
-        const OTPasswordData* pPWData = nullptr) const;
+        const proto::SignatureRole role = proto::SIGROLE_ERROR,
+        proto::KeyRole key = proto::KEYROLE_SIGN) const;
+    virtual bool Sign(
+        const Credential& plaintext,
+        proto::Signature& sig,
+        const OTPasswordData* pPWData = nullptr,
+        const OTPassword* exportPassword = nullptr,
+        const proto::SignatureRole role = proto::SIGROLE_PUBCREDENTIAL) const;
     virtual bool SelfSign(
         const OTPassword* exportPassword = nullptr,
         const OTPasswordData* pPWData = nullptr,

--- a/include/opentxs/core/crypto/KeyCredential.hpp
+++ b/include/opentxs/core/crypto/KeyCredential.hpp
@@ -208,8 +208,7 @@ public:
     EXPORT virtual bool VerifySig(
                                 const proto::Signature& sig,
                                 const OTAsymmetricKey& theKey,
-                                const bool asPrivate = true,
-                                const OTPasswordData* pPWData = nullptr) const;
+                                const bool asPrivate = true) const;
 
 
 };

--- a/include/opentxs/core/crypto/NymParameters.hpp
+++ b/include/opentxs/core/crypto/NymParameters.hpp
@@ -66,9 +66,6 @@ public:
 
     void setCredentialType(Credential::CredentialType theCredentialtype);
 
-    const std::string& AltLocation() const;
-    void SetAltLocation(const std::string& location);
-
     inline proto::SourceType SourceType() const
     {
         return sourceType_;
@@ -133,8 +130,6 @@ public:
 #endif
 
 private:
-    std::string altLocation_ = "";
-
     proto::SourceType sourceType_ = proto::SOURCETYPE_PUBKEY;
     proto::SourceProofType sourceProofType_ =
         proto::SOURCEPROOFTYPE_SELF_SIGNATURE;

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -315,6 +315,13 @@ public:
     virtual bool Verify(
         const OTData& plaintext,
         const proto::Signature& sig) const;
+    virtual bool Sign(
+        const OTData& plaintext,
+        proto::Signature& sig,
+        const OTPasswordData* pPWData = nullptr,
+        const OTPassword* exportPassword = nullptr,
+        const String credID = "",
+        const proto::SignatureRole role = proto::SIGROLE_ERROR) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -41,6 +41,7 @@
 
 #include <opentxs/core/crypto/CryptoAsymmetric.hpp>
 #include <opentxs/core/util/Timer.hpp>
+#include <opentxs/core/OTData.hpp>
 #include <opentxs-proto/verify/VerifyCredentials.hpp>
 
 #include <memory>
@@ -132,6 +133,7 @@ public:
     KeyType keyType() const;
 
     virtual CryptoAsymmetric& engine() const = 0;
+    const std::string Path() const;
 
 private:
     static OTAsymmetricKey* KeyFactory(
@@ -142,6 +144,8 @@ protected:
     KeyType m_keyType = ERROR_TYPE;
     proto::KeyRole role_ = proto::KEYROLE_ERROR;
     OTAsymmetricKey(const KeyType keyType, const proto::KeyRole role);
+    std::shared_ptr<proto::HDPath> path_;
+    OTData chain_code_;
 
 public:                                           // INSTANTIATION
     EXPORT static OTAsymmetricKey* KeyFactory(const KeyType keyType, const String& pubkey);  // Caller IS responsible to

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -308,6 +308,9 @@ public:
                                      bool bImporting) const = 0;
 
     virtual serializedAsymmetricKey Serialize() const;
+    virtual bool Verify(
+        const OTData& plaintext,
+        const proto::Signature& sig) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/PaymentCode.hpp
+++ b/include/opentxs/core/crypto/PaymentCode.hpp
@@ -86,8 +86,8 @@ public:
     bool Verify(const MasterCredential& credential) const;
     bool Sign(
         const uint32_t nym,
-        Credential& credential,
-        proto::Signature sig,
+        const Credential& credential,
+        proto::Signature& sig,
         const OTPasswordData* pPWData = nullptr) const;
 };
 

--- a/include/opentxs/core/crypto/PaymentCode.hpp
+++ b/include/opentxs/core/crypto/PaymentCode.hpp
@@ -70,12 +70,14 @@ private:
     PaymentCode() = delete;
 
 public:
-    PaymentCode(proto::PaymentCode& paycode);
+    PaymentCode(const proto::PaymentCode& paycode);
     PaymentCode(
         const uint32_t nym,
         const bool bitmessage = false,
         const uint8_t bitmessageVersion = 0,
         const uint8_t bitmessageStream = 0);
+
+    bool operator==(const proto::PaymentCode& rhs) const;
 
     Identifier ID() const;
     const std::string asBase58() const;

--- a/include/opentxs/core/crypto/PaymentCode.hpp
+++ b/include/opentxs/core/crypto/PaymentCode.hpp
@@ -62,14 +62,20 @@ private:
     std::shared_ptr<OTAsymmetricKey> pubkey_;
     OTData chain_code_;
     bool hasBitmessage_ = false;
-    uint8_t bitmessage_version = 0;
-    uint8_t bitmessage_stream = 0;
+    uint8_t bitmessage_version_ = 0;
+    uint8_t bitmessage_stream_ = 0;
 
     const OTData Pubkey() const;
     void ConstructKey(const OTData& pubkey, const OTData& chaincode);
     PaymentCode() = delete;
+
 public:
     PaymentCode(proto::PaymentCode& paycode);
+    PaymentCode(
+        const uint32_t nym,
+        const bool bitmessage = false,
+        const uint8_t bitmessageVersion = 0,
+        const uint8_t bitmessageStream = 0);
 
     Identifier ID() const;
     const std::string asBase58() const;

--- a/include/opentxs/core/crypto/PaymentCode.hpp
+++ b/include/opentxs/core/crypto/PaymentCode.hpp
@@ -51,6 +51,7 @@ namespace opentxs
 
 typedef std::shared_ptr<proto::PaymentCode> SerializedPaymentCode;
 
+class Credential;
 class MasterCredential;
 
 class PaymentCode
@@ -83,7 +84,11 @@ public:
     const std::string asBase58() const;
     const SerializedPaymentCode Serialize() const;
     bool Verify(const MasterCredential& credential) const;
-
+    bool Sign(
+        const uint32_t nym,
+        Credential& credential,
+        proto::Signature sig,
+        const OTPasswordData* pPWData = nullptr) const;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/PaymentCode.hpp
+++ b/include/opentxs/core/crypto/PaymentCode.hpp
@@ -1,0 +1,83 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CRYPTO_PAYMENTCODE_HPP
+#define OPENTXS_CORE_CRYPTO_PAYMENTCODE_HPP
+
+#include <memory>
+#include <opentxs-proto/verify/VerifyCredentials.hpp>
+
+#include <opentxs/core/Identifier.hpp>
+#include <opentxs/core/OTData.hpp>
+#include <opentxs/core/crypto/OTAsymmetricKey.hpp>
+
+namespace opentxs
+{
+
+typedef std::shared_ptr<proto::PaymentCode> SerializedPaymentCode;
+
+class MasterCredential;
+
+class PaymentCode
+{
+private:
+    const uint8_t BIP47_VERSION_BYTE = 0x47;
+
+    uint8_t version_ = 1;
+    std::shared_ptr<OTAsymmetricKey> pubkey_;
+    OTData chain_code_;
+    bool hasBitmessage_ = false;
+    uint8_t bitmessage_version = 0;
+    uint8_t bitmessage_stream = 0;
+
+    const OTData Pubkey() const;
+    void ConstructKey(const OTData& pubkey, const OTData& chaincode);
+    PaymentCode() = delete;
+public:
+    PaymentCode(proto::PaymentCode& paycode);
+
+    Identifier ID() const;
+    const std::string asBase58() const;
+    const SerializedPaymentCode Serialize() const;
+    bool Verify(const MasterCredential& credential) const;
+
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CRYPTO_PAYMENTCODE_HPP

--- a/include/opentxs/core/crypto/PaymentCode.hpp
+++ b/include/opentxs/core/crypto/PaymentCode.hpp
@@ -80,9 +80,9 @@ public:
 
     bool operator==(const proto::PaymentCode& rhs) const;
 
-    Identifier ID() const;
+    const Identifier ID() const;
     const std::string asBase58() const;
-    const SerializedPaymentCode Serialize() const;
+    SerializedPaymentCode Serialize() const;
     bool Verify(const MasterCredential& credential) const;
     bool Sign(
         const uint32_t nym,

--- a/src/client/OTAPI.cpp
+++ b/src/client/OTAPI.cpp
@@ -273,17 +273,15 @@ bool OTAPI_Wrap::IsValidID(const std::string& strPurportedID)
 }
 
 std::string OTAPI_Wrap::CreateNymLegacy(const int32_t& nKeySize,
-                                  const std::string& NYM_ID_SOURCE,
-                                  const std::string& ALT_LOCATION)
+                                  const std::string& NYM_ID_SOURCE)
 {
-    return Exec()->CreateNymLegacy(nKeySize, NYM_ID_SOURCE, ALT_LOCATION);
+    return Exec()->CreateNymLegacy(nKeySize, NYM_ID_SOURCE);
 }
 
 std::string OTAPI_Wrap::CreateNymECDSA(
-                                  const std::string& NYM_ID_SOURCE,
-                                  const std::string& ALT_LOCATION)
+                                  const std::string& NYM_ID_SOURCE)
 {
-    return Exec()->CreateNymECDSA(NYM_ID_SOURCE, ALT_LOCATION);
+    return Exec()->CreateNymECDSA(NYM_ID_SOURCE);
 }
 
 std::string OTAPI_Wrap::GetNym_ActiveCronItemIDs(const std::string& NYM_ID,
@@ -302,9 +300,9 @@ std::string OTAPI_Wrap::GetNym_SourceForID(const std::string& NYM_ID)
     return Exec()->GetNym_SourceForID(NYM_ID);
 }
 
-std::string OTAPI_Wrap::GetNym_AltSourceLocation(const std::string& NYM_ID)
+std::string OTAPI_Wrap::GetNym_Description(const std::string& NYM_ID)
 {
-    return Exec()->GetNym_AltSourceLocation(NYM_ID);
+    return Exec()->GetNym_Description(NYM_ID);
 }
 
 int32_t OTAPI_Wrap::GetNym_MasterCredentialCount(const std::string& NYM_ID)

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -480,8 +480,7 @@ bool OTAPI_Exec::IsValidID(const std::string& strPurportedID) const
 //
 std::string OTAPI_Exec::CreateNymLegacy(
     const int32_t& nKeySize,               // must be 1024, 2048, 4096, or 8192
-    __attribute__((unused)) const std::string& NYM_ID_SOURCE,
-    const std::string& ALT_LOCATION) const // Can be empty.
+    __attribute__((unused)) const std::string& NYM_ID_SOURCE) const // Can be empty.
 {
     if (0 >= nKeySize) {
         otErr << __FUNCTION__
@@ -519,8 +518,7 @@ std::string OTAPI_Exec::CreateNymLegacy(
 }
 
 std::string OTAPI_Exec::CreateNymECDSA(
-    __attribute__((unused)) const std::string& NYM_ID_SOURCE,
-    const std::string& ALT_LOCATION) const // Can be empty.
+    __attribute__((unused)) const std::string& NYM_ID_SOURCE) const // Can be empty.
 {
     std::shared_ptr<NymParameters> nymParameters;
     nymParameters = std::make_shared<NymParameters>(
@@ -605,7 +603,7 @@ std::string OTAPI_Exec::GetNym_SourceForID(const std::string& NYM_ID) const
     return str_return;
 }
 
-std::string OTAPI_Exec::GetNym_AltSourceLocation(
+std::string OTAPI_Exec::GetNym_Description(
     const std::string& NYM_ID) const
 {
     if (NYM_ID.empty()) {
@@ -618,7 +616,7 @@ std::string OTAPI_Exec::GetNym_AltSourceLocation(
     // private.
     Nym* pNym = OTAPI()->GetOrLoadNym(nym_id, false, __FUNCTION__, &thePWData);
     if (nullptr == pNym) return "";
-    const std::string str_return(pNym->GetAltLocation().Get());
+    const std::string str_return(pNym->GetDescription().Get());
     return str_return;
 }
 

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -504,8 +504,6 @@ std::string OTAPI_Exec::CreateNymLegacy(
 
     std::shared_ptr<NymParameters> nymParameters;
     nymParameters = std::make_shared<NymParameters>(nKeySize);
-    //nymParameters->SetSource(NYM_ID_SOURCE);
-    nymParameters->SetAltLocation(ALT_LOCATION);
 
     Nym* pNym = OTAPI()->CreateNym(*nymParameters);
     if (nullptr == pNym) // Creation failed.
@@ -528,8 +526,6 @@ std::string OTAPI_Exec::CreateNymECDSA(
     nymParameters = std::make_shared<NymParameters>(
         NymParameters::SECP256K1,
         Credential::HD);
-    //nymParameters->SetSource(NYM_ID_SOURCE);
-    nymParameters->SetAltLocation(ALT_LOCATION);
 
     Nym* pNym = OTAPI()->CreateNym(*nymParameters);
     if (nullptr == pNym) // Creation failed.

--- a/src/client/OTWallet.cpp
+++ b/src/client/OTWallet.cpp
@@ -196,7 +196,7 @@ Nym * OTWallet::CreateNym(const NymParameters& nymParameters)
 
     if (Credential::HD == nymParameters.credentialType()) {
         revisedParameters.SetNym(NextHDSeed());
-        next_hd_key++;
+        next_hd_key_++;
     }
 
     Nym* pNym = new Nym(revisedParameters);
@@ -1215,7 +1215,7 @@ bool OTWallet::SaveContract(String& strContract)
                                      : m_strVersion.Get());
 
     TagPtr hdTag = std::make_shared<Tag>("hd");
-    hdTag->add_attribute("index", std::to_string(next_hd_key));
+    hdTag->add_attribute("index", std::to_string(next_hd_key_));
     tag.add_tag(hdTag);
 
     if (OTCachedKey::It()->IsGenerated()) // If it exists, then serialize it.
@@ -1963,7 +1963,7 @@ bool OTWallet::LoadWallet(const char* szFilename)
                     }
                 }
                 else if (strNodeName.Compare("hd")) {
-                    next_hd_key = std::stoi(xml->getAttributeValue("index"));
+                    next_hd_key_ = std::stoi(xml->getAttributeValue("index"));
                 }
                 else {
                     // unknown element type

--- a/src/client/OT_ME.cpp
+++ b/src/client/OT_ME.cpp
@@ -309,11 +309,10 @@ std::string OT_ME::check_nym(const std::string& NOTARY_ID,
 // returns new Nym ID
 //
 std::string OT_ME::create_nym_ecdsa(
-                              const std::string& strNymIDSource,
-                              const std::string& strAltLocation) const
+                              const std::string& strNymIDSource) const
 {
     std::string strNymID =
-        OTAPI_Wrap::CreateNymECDSA(strNymIDSource, strAltLocation);
+        OTAPI_Wrap::CreateNymECDSA(strNymIDSource);
 
     if (!VerifyStringVal(strNymID)) {
         otOut << "OT_ME_create_nym_ecdsa: Failed in "
@@ -327,11 +326,10 @@ std::string OT_ME::create_nym_ecdsa(
 // returns new Nym ID
 //
 std::string OT_ME::create_nym_legacy(int32_t nKeybits,
-                              const std::string& strNymIDSource,
-                              const std::string& strAltLocation) const
+                              const std::string& strNymIDSource) const
 {
     std::string strNymID =
-        OTAPI_Wrap::CreateNymLegacy(nKeybits, strNymIDSource, strAltLocation);
+        OTAPI_Wrap::CreateNymLegacy(nKeybits, strNymIDSource);
 
     if (!VerifyStringVal(strNymID)) {
         otOut << "OT_ME_create_nym_legacy: Failed in "
@@ -1901,8 +1899,8 @@ bool OT_ME::Register_API_With_Script_Chai(const OTScriptChai& theScript) const
 
         theScript.chai->add(fun(&OTAPI_Wrap::GetNym_SourceForID),
                             "OT_API_GetNym_SourceForID");
-        theScript.chai->add(fun(&OTAPI_Wrap::GetNym_AltSourceLocation),
-                            "OT_API_GetNym_AltSourceLocation");
+        theScript.chai->add(fun(&OTAPI_Wrap::GetNym_Description),
+                            "OT_API_GetNym_Description");
         theScript.chai->add(fun(&OTAPI_Wrap::GetNym_MasterCredentialCount),
                             "OT_API_GetNym_MasterCredentialCount");
         theScript.chai->add(fun(&OTAPI_Wrap::GetNym_MasterCredentialID),

--- a/src/client/commands/CmdNewNymECDSA.cpp
+++ b/src/client/commands/CmdNewNymECDSA.cpp
@@ -61,18 +61,14 @@ CmdNewNymECDSA::~CmdNewNymECDSA()
 
 int32_t CmdNewNymECDSA::runWithOptions()
 {
-    return run(getOption("label"), getOption("source"),
-               getOption("location"));
+    return run(getOption("label"), getOption("source"));
 }
 
 // FYI, a source can be a URL, a Bitcoin address, a Namecoin address,
 // a public key, or the unique DN info from a traditionally-issued cert.
 // Hashing the source should produce the NymID. Also, the source should
 // always (somehow) validate the credential IDs, if they are to be trusted
-// for their purported Nym. Another optional parameter is 'altlocation'
-// which, in the case of DN info as a source, would be the download location
-// where a Cert should be found with that DN info, or a PKI where the Cert
-// can be found.
+// for their purported Nym.
 //
 // NOTE: If you leave the source BLANK, then OT will just generate a public
 // key to serve as the source. The public key will be hashed to form the
@@ -82,15 +78,14 @@ int32_t CmdNewNymECDSA::runWithOptions()
 
 int32_t CmdNewNymECDSA::run(
     string label,
-    string source,
-    string location)
+    string source)
 {
     if (!checkMandatory("label", label)) {
         return -1;
     }
 
     OT_ME ot_me;
-    string mynym = ot_me.create_nym_ecdsa(source, location);
+    string mynym = ot_me.create_nym_ecdsa(source);
     if ("" == mynym) {
         otOut << "Error: cannot create new nym.\n";
         return -1;

--- a/src/client/commands/CmdNewNymECDSA.hpp
+++ b/src/client/commands/CmdNewNymECDSA.hpp
@@ -145,7 +145,7 @@ public:
     virtual ~CmdNewNymECDSA();
 
     EXPORT int32_t run(std::string label,
-                       std::string source, std::string location);
+                       std::string source);
 
 protected:
     virtual int32_t runWithOptions();

--- a/src/client/commands/CmdNewNymLegacy.cpp
+++ b/src/client/commands/CmdNewNymLegacy.cpp
@@ -62,18 +62,14 @@ CmdNewNymLegacy::~CmdNewNymLegacy()
 
 int32_t CmdNewNymLegacy::runWithOptions()
 {
-    return run(getOption("keybits"), getOption("label"), getOption("source"),
-               getOption("location"));
+    return run(getOption("keybits"), getOption("label"), getOption("source"));
 }
 
 // FYI, a source can be a URL, a Bitcoin address, a Namecoin address,
 // a public key, or the unique DN info from a traditionally-issued cert.
 // Hashing the source should produce the NymID. Also, the source should
 // always (somehow) validate the credential IDs, if they are to be trusted
-// for their purported Nym. Another optional parameter is 'altlocation'
-// which, in the case of DN info as a source, would be the download location
-// where a Cert should be found with that DN info, or a PKI where the Cert
-// can be found.
+// for their purported Nym.
 //
 // NOTE: If you leave the source BLANK, then OT will just generate a public
 // key to serve as the source. The public key will be hashed to form the
@@ -81,8 +77,7 @@ int32_t CmdNewNymLegacy::runWithOptions()
 // corresponding private key. That's the only way they can be 'verified by
 // their source.'
 
-int32_t CmdNewNymLegacy::run(string keybits, string label, string source,
-                       string location)
+int32_t CmdNewNymLegacy::run(string keybits, string label, string source)
 {
     if (!checkMandatory("label", label)) {
         return -1;
@@ -99,7 +94,7 @@ int32_t CmdNewNymLegacy::run(string keybits, string label, string source,
     }
 
     OT_ME ot_me;
-    string mynym = ot_me.create_nym_legacy(bits, source, location);
+    string mynym = ot_me.create_nym_legacy(bits, source);
     if ("" == mynym) {
         otOut << "Error: cannot create new nym.\n";
         return -1;

--- a/src/client/commands/CmdNewNymLegacy.hpp
+++ b/src/client/commands/CmdNewNymLegacy.hpp
@@ -144,8 +144,7 @@ public:
     EXPORT CmdNewNymLegacy();
     virtual ~CmdNewNymLegacy();
 
-    EXPORT int32_t run(std::string keybits, std::string label,
-                       std::string source, std::string location);
+    EXPORT int32_t run(std::string keybits, std::string label, std::string source);
 
 protected:
     virtual int32_t runWithOptions();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -96,6 +96,7 @@ set(cxx-sources
   OTTransactionType.cpp
   NymIDSource.cpp
   crypto/Bip32.cpp
+  crypto/PaymentCode.cpp
 )
 
 file(GLOB cxx-headers

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -4823,6 +4823,8 @@ Nym::Nym(const NymParameters& nymParameters)
     SetSource(pNewCredentialSet->Source());
     m_nymID = source_->NymID();
 
+    SetAltLocation(source_->Description());
+
     m_mapCredentialSets.insert(std::pair<std::string, CredentialSet*>(
         pNewCredentialSet->GetMasterCredID().Get(), pNewCredentialSet));
 

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -2683,7 +2683,7 @@ void Nym::DisplayStatistics(String& strOutput)
     } // for
 
     strOutput.Concatenate("Source for ID:\n%s\n", source_->asString().Get());
-    strOutput.Concatenate("Alt. location: %s\n\n", m_strAltLocation.Get());
+    strOutput.Concatenate("Description: %s\n\n", m_strDescription.Get());
 
     const size_t nMasterCredCount = GetMasterCredentialCount();
     if (nMasterCredCount > 0) {
@@ -2859,12 +2859,12 @@ void Nym::SerializeNymIDSource(Tag& parent) const
 
         TagPtr pTag(new Tag("nymIDSource", source_->asString().Get()));
 
-        if (m_strAltLocation.Exists()) {
-            OTASCIIArmor ascAltLocation;
-            ascAltLocation.SetString(m_strAltLocation,
+        if (m_strDescription.Exists()) {
+            OTASCIIArmor ascDescription;
+            ascDescription.SetString(m_strDescription,
                                      false); // bLineBreaks=true by default.
 
-            pTag->add_attribute("altLocation", ascAltLocation.Get());
+            pTag->add_attribute("Description", ascDescription.Get());
         }
         parent.add_tag(pTag);
     }
@@ -3674,11 +3674,11 @@ bool Nym::LoadNymFromString(const String& strNym,
             }
             else if (strNodeName.Compare("nymIDSource")) {
                 //                  otLog3 << "Loading nymIDSource...\n");
-                OTASCIIArmor ascAltLocation =
-                    xml->getAttributeValue("altLocation"); // optional.
-                if (ascAltLocation.Exists())
-                    ascAltLocation.GetString(
-                        m_strAltLocation,
+                OTASCIIArmor ascDescription =
+                    xml->getAttributeValue("Description"); // optional.
+                if (ascDescription.Exists())
+                    ascDescription.GetString(
+                        m_strDescription,
                         false); // bLineBreaks=true by default.
 
                 OTASCIIArmor stringSource;
@@ -4823,7 +4823,7 @@ Nym::Nym(const NymParameters& nymParameters)
     SetSource(pNewCredentialSet->Source());
     m_nymID = source_->NymID();
 
-    SetAltLocation(source_->Description());
+    SetDescription(source_->Description());
 
     m_mapCredentialSets.insert(std::pair<std::string, CredentialSet*>(
         pNewCredentialSet->GetMasterCredID().Get(), pNewCredentialSet));

--- a/src/core/NymIDSource.cpp
+++ b/src/core/NymIDSource.cpp
@@ -211,7 +211,8 @@ bool NymIDSource::Verify(
 bool NymIDSource::Sign(
     const NymParameters& nymParameters,
     const MasterCredential& credential,
-    proto::Signature& sig) const
+    proto::Signature& sig,
+    const OTPasswordData* pPWData) const
 {
     bool goodsig = false;
 
@@ -225,7 +226,8 @@ bool NymIDSource::Sign(
                 goodsig = payment_code_->Sign(
                     nymParameters.Nym(),
                     credential,
-                    sig);
+                    sig,
+                    pPWData);
             }
 
             break;

--- a/src/core/NymIDSource.cpp
+++ b/src/core/NymIDSource.cpp
@@ -258,4 +258,30 @@ serializedNymIDSource NymIDSource::ExtractArmoredSource(
     return protoSource;
 }
 
+String NymIDSource::Description() const
+{
+    String description;
+    Identifier keyID;
+
+    switch (type_) {
+        case (proto::SOURCETYPE_PUBKEY) :
+            if (pubkey_) {
+                pubkey_->CalculateID(keyID);
+                description = keyID;
+            }
+
+            break;
+        case (proto::SOURCETYPE_BIP47) :
+            if (payment_code_) {
+                description = payment_code_->asBase58();
+            }
+
+            break;
+        default :
+            break;
+    }
+
+    return description;
+}
+
 } // namespace opentxs

--- a/src/core/crypto/Bip32.cpp
+++ b/src/core/crypto/Bip32.cpp
@@ -81,4 +81,14 @@ serializedAsymmetricKey Bip32::GetHDKey(const proto::HDPath path) const
     }
 }
 
+serializedAsymmetricKey Bip32::GetPaymentCode(const uint32_t nym) const
+{
+    proto::HDPath path;
+    path.add_child(PC_PURPOSE | HARDENED);
+    path.add_child(BITCOIN_TYPE | HARDENED);
+    path.add_child(nym | HARDENED);
+
+    return GetHDKey(path);
+}
+
 } // namespace opentxs

--- a/src/core/crypto/Bip32.cpp
+++ b/src/core/crypto/Bip32.cpp
@@ -56,13 +56,14 @@ serializedAsymmetricKey Bip32::GetHDKey(const proto::HDPath path) const
     if (0 == depth) {
         BinarySecret seed = GetHDSeed();
         serializedAsymmetricKey node = SeedToPrivateKey(*seed);
-
         return node;
     } else {
         proto::HDPath newpath = path;
         newpath.mutable_child()->RemoveLast();
         serializedAsymmetricKey parentnode = GetHDKey(newpath);
-        uint32_t root = parentnode->path().root();
+        OTData root(
+            parentnode->path().root().c_str(),
+            parentnode->path().root().size());
 
         serializedAsymmetricKey node = GetChild(
             *parentnode,
@@ -72,7 +73,9 @@ serializedAsymmetricKey Bip32::GetHDKey(const proto::HDPath path) const
         // fingerprint. Set the list of children, then restore the root
         // fingerprint that we saved a few lines ago.
         *(node->mutable_path()) = path;
-        node->mutable_path()->set_root(root);
+        node->mutable_path()->set_root(
+            root.GetPointer(),
+            root.GetSize());
 
         return node;
     }

--- a/src/core/crypto/ChildKeyCredential.cpp
+++ b/src/core/crypto/ChildKeyCredential.cpp
@@ -146,27 +146,17 @@ bool ChildKeyCredential::AddMasterSignature()
         return false;
     }
 
-    String credID = m_pOwner->GetMasterCredID();
-    OTData masterSignature;
-    serializedSignature serializedMasterSignature;
-    serializedMasterSignature.reset(new proto::Signature);
+    serializedSignature serializedMasterSignature =
+        std::make_shared<proto::Signature>();
 
-    serializedCredential publicVersion = SerializeForPublicSignature();
     bool havePublicSig = m_pOwner->GetMasterCredential().Sign(
-        *publicVersion,
-        Identifier::DefaultHashAlgorithm,
-        masterSignature);
+        *this,
+        *serializedMasterSignature);
 
     if (!havePublicSig) {
         otErr << __FUNCTION__ << ": Failed to obtain signature from master credential.\n";
         return false;
     }
-
-    serializedMasterSignature->set_version(1);
-    serializedMasterSignature->set_credentialid(credID.Get());
-    serializedMasterSignature->set_role(proto::SIGROLE_PUBCREDENTIAL);
-    serializedMasterSignature->set_hashtype(static_cast<proto::HashType>(Identifier::DefaultHashAlgorithm));
-    serializedMasterSignature->set_signature(masterSignature.GetPointer(), masterSignature.GetSize());
 
     m_listSerializedSignatures.push_back(serializedMasterSignature);
 

--- a/src/core/crypto/Credential.cpp
+++ b/src/core/crypto/Credential.cpp
@@ -421,6 +421,20 @@ serializedSignature Credential::GetSelfSignature(CredentialModeFlag version) con
     return nullptr;
 }
 
+serializedSignature Credential::GetSourceSignature() const
+{
+    serializedSignature signature;
+
+    for (auto& it : m_listSerializedSignatures) {
+        if (it->role() == proto::SIGROLE_NYMIDSOURCE) {
+            *signature = *it;
+            break;
+        }
+    }
+
+    return signature;
+}
+
 bool Credential::SaveContract(const char* szFoldername, const char* szFilename)
 {
     OT_ASSERT_MSG(nullptr != szFilename,

--- a/src/core/crypto/Credential.cpp
+++ b/src/core/crypto/Credential.cpp
@@ -298,7 +298,7 @@ serializedCredential Credential::Serialize(
     serializedCredential serializedCredential = std::make_shared<proto::Credential>();
 
     serializedCredential->set_version(1);
-    serializedCredential->set_type(proto::CREDTYPE_LEGACY);
+    serializedCredential->set_type(static_cast<proto::CredentialType>(m_Type));
 
     if (asPrivate) {
         OT_ASSERT(proto::KEYMODE_PRIVATE == m_mode);
@@ -382,7 +382,6 @@ bool Credential::SaveContract()
     }
 
     serializedCredential serializedProto = Serialize(serializationMode, WITH_SIGNATURES);
-
 
     bool validProto = proto::Verify(*serializedProto, m_Role, WITH_SIGNATURES);
 

--- a/src/core/crypto/Credential.cpp
+++ b/src/core/crypto/Credential.cpp
@@ -311,9 +311,11 @@ serializedCredential Credential::Serialize(
     if (asSigned) {
         serializedSignature publicSig;
         serializedSignature privateSig;
+        serializedSignature sourceSig;
 
         proto::Signature* pPrivateSig;
         proto::Signature* pPublicSig;
+        proto::Signature* pSourceSig;
 
         if (asPrivate) {
             privateSig = GetSelfSignature(true);
@@ -332,6 +334,14 @@ serializedCredential Credential::Serialize(
             pPublicSig = serializedCredential->add_signature();
             *pPublicSig = *GetSelfSignature(false);
         }
+
+        sourceSig = GetSourceSignature();
+        if (sourceSig) {
+            pSourceSig = serializedCredential->add_signature();
+            *pSourceSig = *sourceSig;
+        }
+    } else {
+        serializedCredential->clear_signature(); // just in case...
     }
 
     String credID;
@@ -426,11 +436,11 @@ serializedSignature Credential::GetSourceSignature() const
 
     for (auto& it : m_listSerializedSignatures) {
         if (it->role() == proto::SIGROLE_NYMIDSOURCE) {
-            *signature = *it;
+            signature = std::make_shared<proto::Signature>(*it);
+
             break;
         }
     }
-
     return signature;
 }
 

--- a/src/core/crypto/Crypto.cpp
+++ b/src/core/crypto/Crypto.cpp
@@ -60,9 +60,9 @@ namespace opentxs
 //
 #define OT_DEFAULT_ITERATION_COUNT 65535      // in bytes
 #define OT_DEFAULT_SYMMETRIC_SALT_SIZE 8      // in bytes
-#define OT_DEFAULT_SYMMETRIC_KEY_SIZE 16      // in bytes
+#define OT_DEFAULT_SYMMETRIC_KEY_SIZE 32      // in bytes
 #define OT_DEFAULT_SYMMETRIC_KEY_SIZE_MAX 64  // in bytes == 512 bits
-#define OT_DEFAULT_SYMMETRIC_IV_SIZE 16       // in bytes
+#define OT_DEFAULT_SYMMETRIC_IV_SIZE 32       // in bytes
 #define OT_DEFAULT_SYMMETRIC_BUFFER_SIZE 4096 // in bytes
 #define OT_DEFAULT_PUBLIC_KEYSIZE 128         // in bytes == 4096 bits
 #define OT_DEFAULT_PUBLIC_KEYSIZE_MAX 512     // in bytes == 1024 bits

--- a/src/core/crypto/CryptoSymmetric.cpp
+++ b/src/core/crypto/CryptoSymmetric.cpp
@@ -163,6 +163,9 @@ String CryptoSymmetric::ModeToString(const Mode Mode)
         case CryptoSymmetric::AES_128_CBC :
             modeString="aes-128-cbc";
             break;
+        case CryptoSymmetric::AES_256_CBC :
+            modeString="aes-256-cbc";
+            break;
         case CryptoSymmetric::AES_256_ECB  :
             modeString="aes-256-ecb";
             break;
@@ -182,6 +185,8 @@ CryptoSymmetric::Mode CryptoSymmetric::StringToMode(const String& Mode)
 {
     if (Mode.Compare("aes-128-cbc"))
         return CryptoSymmetric::AES_128_CBC ;
+    if (Mode.Compare("aes-256-cbc"))
+        return CryptoSymmetric::AES_256_CBC ;
     if (Mode.Compare("aes-256-ecb"))
         return CryptoSymmetric::AES_256_ECB ;
     if (Mode.Compare("aes-128-gcm"))
@@ -198,6 +203,9 @@ uint32_t CryptoSymmetric::KeySize(const Mode Mode)
     switch (Mode) {
         case CryptoSymmetric::AES_128_CBC :
             keySize= 16;
+            break;
+        case CryptoSymmetric::AES_256_CBC :
+            keySize= 32;
             break;
         case CryptoSymmetric::AES_256_ECB  :
             keySize= 32;

--- a/src/core/crypto/KeyCredential.cpp
+++ b/src/core/crypto/KeyCredential.cpp
@@ -60,10 +60,10 @@
 // ChildCredentials are used for all other actions, and never sign other
 // Credentials
 
-#include <opentxs/core/stdafx.hpp>
-
 #include <opentxs/core/crypto/KeyCredential.hpp>
 
+#include <opentxs/core/stdafx.hpp>
+#include <opentxs/core/Proto.hpp>
 #include <opentxs/core/crypto/CredentialSet.hpp>
 #include <opentxs/core/crypto/CryptoEngine.hpp>
 #include <opentxs/core/crypto/OTPasswordData.hpp>
@@ -481,21 +481,47 @@ bool KeyCredential::addKeyCredentialtoSerializedCredential(
 }
 
 bool KeyCredential::Sign(
-    const proto::Credential& credential,
-    const CryptoHash::HashType hashType,
-    OTData& signature, // output
+    const OTData& plaintext,
+    proto::Signature& sig,
+    const OTPasswordData* pPWData,
     const OTPassword* exportPassword,
-    const OTPasswordData* pPWData) const
+    const proto::SignatureRole role,
+    proto::KeyRole key) const
 {
-    OTData plaintext = SerializeCredToData(credential);
+    const OTAsymmetricKey* keyToUse;
 
-    return this->m_SigningKey->GetPrivateKey().engine().Sign(
-                                                            plaintext,
-                                                            this->m_SigningKey->GetPrivateKey(),
-                                                            hashType,
-                                                            signature,
-                                                            pPWData,
-                                                            exportPassword);
+    switch (key) {
+        case (proto::KEYROLE_AUTH) :
+            keyToUse = &(this->m_AuthentKey->GetPrivateKey());
+            break;
+        case (proto::KEYROLE_SIGN) :
+            keyToUse = &(this->m_SigningKey->GetPrivateKey());
+            break;
+        default :
+            otErr << __FUNCTION__ << ": Can not sign with the specified key.\n";
+            return false;
+    }
+
+    String credID;
+    GetIdentifier(credID);
+
+    return keyToUse->Sign(plaintext, sig, pPWData, exportPassword, credID, role);
+}
+
+bool KeyCredential::Sign(
+        const Credential& plaintext,
+        proto::Signature& sig,
+        const OTPasswordData* pPWData,
+        const OTPassword* exportPassword,
+        const proto::SignatureRole role) const
+{
+    serializedCredential serialized = plaintext.SerializeForPublicSignature();
+    return Sign(
+        proto::ProtoAsData<proto::Credential>(*serialized),
+        sig,
+        pPWData,
+        exportPassword,
+        role);
 }
 
 bool KeyCredential::SelfSign(
@@ -510,44 +536,31 @@ bool KeyCredential::SelfSign(
         std::make_shared<proto::Signature>();
     serializedSignature privateSignature =
         std::make_shared<proto::Signature>();
-    OTData signature;
 
     bool havePublicSig = false;
     if (!onlyPrivate) {
-        serializedCredential publicVersion = SerializeForPublicSignature();
+        const serializedCredential publicVersion = SerializeForPublicSignature();
         havePublicSig = Sign(
-            *publicVersion,
-            Identifier::DefaultHashAlgorithm,
-            signature,
+            proto::ProtoAsData<proto::Credential>(*publicVersion),
+            *publicSignature,
+            pPWData,
             exportPassword,
-            pPWData);
+            proto::SIGROLE_PUBCREDENTIAL);
 
         if (havePublicSig) {
-            publicSignature->set_version(1);
-            publicSignature->set_credentialid(credID.Get());
-            publicSignature->set_role(proto::SIGROLE_PUBCREDENTIAL);
-            publicSignature->set_hashtype(static_cast<proto::HashType>(Identifier::DefaultHashAlgorithm));
-            publicSignature->set_signature(signature.GetPointer(), signature.GetSize());
-
             m_listSerializedSignatures.push_back(publicSignature);
         }
     }
 
     serializedCredential privateVersion = SerializeForPrivateSignature();
     bool havePrivateSig = Sign(
-        *privateVersion,
-        Identifier::DefaultHashAlgorithm,
-        signature,
+        proto::ProtoAsData<proto::Credential>(*privateVersion),
+        *privateSignature,
+        pPWData,
         exportPassword,
-        pPWData);
+        proto::SIGROLE_PRIVCREDENTIAL);
 
     if (havePrivateSig) {
-        privateSignature->set_version(1);
-        privateSignature->set_credentialid(credID.Get());
-        privateSignature->set_role(proto::SIGROLE_PRIVCREDENTIAL);
-        privateSignature->set_hashtype(static_cast<proto::HashType>(Identifier::DefaultHashAlgorithm));
-        privateSignature->set_signature(signature.GetPointer(), signature.GetSize());
-
         m_listSerializedSignatures.push_back(privateSignature);
     }
 

--- a/src/core/crypto/KeyCredential.cpp
+++ b/src/core/crypto/KeyCredential.cpp
@@ -557,16 +557,8 @@ bool KeyCredential::SelfSign(
 bool KeyCredential::VerifySig(
                             const proto::Signature& sig,
                             const OTAsymmetricKey& theKey,
-                            const bool asPrivate,
-                            const OTPasswordData* pPWData) const
+                            const bool asPrivate) const
 {
-    bool verified = false;
-
-    OTData signature;
-    signature.Assign(sig.signature().c_str(), sig.signature().size());
-
-    OTPasswordData thePWData("KeyCredential::VerifyWithKey");
-
     serializedCredential serialized;
 
     if ((proto::KEYMODE_PRIVATE != m_mode) && asPrivate) {
@@ -581,14 +573,8 @@ bool KeyCredential::VerifySig(
     }
 
     OTData plaintext = SerializeCredToData(*serialized);
-    verified = theKey.engine().Verify(
-                                plaintext,
-                                theKey,
-                                signature,
-                                static_cast<CryptoHash::HashType>(sig.hashtype()),
-                                pPWData);
 
-    return verified;
+    return theKey.Verify(plaintext, sig);
 }
 
 } // namespace opentxs

--- a/src/core/crypto/NymParameters.cpp
+++ b/src/core/crypto/NymParameters.cpp
@@ -84,18 +84,26 @@ Credential::CredentialType NymParameters::credentialType() const {
     return credentialType_;
 }
 
-void NymParameters::setCredentialType(Credential::CredentialType theCredentialtype) {
+void NymParameters::setCredentialType(
+    Credential::CredentialType theCredentialtype)
+{
     credentialType_ = theCredentialtype;
-}
 
-const std::string& NymParameters::AltLocation() const
-{
-    return altLocation_;
-}
+    switch (theCredentialtype) {
+        case (Credential::LEGACY) :
+            SetSourceType(proto::SOURCETYPE_PUBKEY);
+            SetSourceProofType(proto::SOURCEPROOFTYPE_SELF_SIGNATURE);
 
-void NymParameters::SetAltLocation(const std::string& location)
-{
-    altLocation_ = location;
+            break;
+        case (Credential::HD) :
+            SetSourceType(proto::SOURCETYPE_BIP47);
+            SetSourceProofType(proto::SOURCEPROOFTYPE_SIGNATURE);
+
+            break;
+        default :
+
+            break;
+    }
 }
 
 #if defined(OT_CRYPTO_SUPPORTED_KEY_RSA)

--- a/src/core/crypto/OTAsymmetricKey.cpp
+++ b/src/core/crypto/OTAsymmetricKey.cpp
@@ -1035,4 +1035,19 @@ bool OTAsymmetricKey::operator==(const proto::AsymmetricKey& rhs) const
     return (LHData == RHData);
 }
 
+bool OTAsymmetricKey::Verify(
+    const OTData& plaintext,
+    const proto::Signature& sig) const
+{
+    OTData signature;
+    signature.Assign(sig.signature().c_str(), sig.signature().size());
+
+    return engine().Verify(
+        plaintext,
+        *this,
+        signature,
+        static_cast<CryptoHash::HashType>(sig.hashtype()),
+        nullptr);
+}
+
 } // namespace opentxs

--- a/src/core/crypto/OpenSSL.cpp
+++ b/src/core/crypto/OpenSSL.cpp
@@ -690,6 +690,9 @@ const EVP_CIPHER* OpenSSL::OpenSSLdp::CipherModeToOpenSSLMode(
         case CryptoSymmetric::AES_128_CBC :
             OpenSSLCipher = EVP_aes_128_cbc();
             break;
+        case CryptoSymmetric::AES_256_CBC :
+            OpenSSLCipher = EVP_aes_256_cbc();
+            break;
         case CryptoSymmetric::AES_256_ECB :
             OpenSSLCipher = EVP_aes_256_ecb();
             break;
@@ -1332,7 +1335,7 @@ bool OpenSSL::Encrypt(
     OTData& theEncryptedOutput) const                 // OUTPUT. (Ciphertext.)
 {
     return Encrypt(
-        CryptoSymmetric::AES_128_CBC, // What OT was using before
+        CryptoSymmetric::AES_256_CBC, // What OT was using before
         theRawSymmetricKey,
         theIV,
         szInput,
@@ -1571,7 +1574,7 @@ bool OpenSSL::Decrypt(
                                                       // will work.)
 {
     return Decrypt(
-        CryptoSymmetric::AES_128_CBC, // What OT was using before
+        CryptoSymmetric::AES_256_CBC, // What OT was using before
         theRawSymmetricKey,
         theIV,
         szInput,
@@ -2078,7 +2081,7 @@ bool OpenSSL::EncryptSessionKey(
     //
     dataOutput.Release();
 
-    const EVP_CIPHER* cipher_type = EVP_aes_128_cbc(); // todo hardcoding.
+    const EVP_CIPHER* cipher_type = EVP_aes_256_cbc(); // todo hardcoding.
 
     /*
     int32_t EVP_SealInit(EVP_CIPHER_CTX* ctx, const EVP_CIPHER* type,
@@ -2807,7 +2810,7 @@ bool OpenSSL::DecryptSessionKey(OTData& dataInput, const Nym& theRecipient,
                       dataInput.GetSize() - nRunningTotal);
 
     //
-    const EVP_CIPHER* cipher_type = EVP_aes_128_cbc(); // todo hardcoding.
+    const EVP_CIPHER* cipher_type = EVP_aes_256_cbc(); // todo hardcoding.
 
     // int32_t EVP_OpenInit(
     //          EVP_CIPHER_CTX *ctx,

--- a/src/core/crypto/PaymentCode.cpp
+++ b/src/core/crypto/PaymentCode.cpp
@@ -144,7 +144,7 @@ const std::string PaymentCode::asBase58() const
     return CryptoEngine::Instance().Util().Base58CheckEncode(binaryVersion).Get();
 }
 
-const SerializedPaymentCode PaymentCode::Serialize() const
+SerializedPaymentCode PaymentCode::Serialize() const
 {
     SerializedPaymentCode serialized = std::make_shared<proto::PaymentCode>();
 
@@ -162,7 +162,7 @@ const SerializedPaymentCode PaymentCode::Serialize() const
     return serialized;
 }
 
-Identifier PaymentCode::ID() const
+const Identifier PaymentCode::ID() const
 {
 
     uint8_t core[65]{};

--- a/src/core/crypto/PaymentCode.cpp
+++ b/src/core/crypto/PaymentCode.cpp
@@ -1,0 +1,204 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include <opentxs/core/crypto/PaymentCode.hpp>
+
+#include <opentxs/core/Log.hpp>
+#include <opentxs/core/Proto.hpp>
+#include <opentxs/core/crypto/AsymmetricKeySecp256k1.hpp>
+#include <opentxs/core/crypto/CryptoEngine.hpp>
+#include <opentxs/core/crypto/MasterCredential.hpp>
+#include <opentxs/core/crypto/OTPassword.hpp>
+
+namespace opentxs
+{
+
+PaymentCode::PaymentCode(proto::PaymentCode& paycode)
+    : version_(paycode.version())
+    , chain_code_(paycode.chaincode().c_str(), paycode.chaincode().size())
+    , hasBitmessage_(paycode.has_bitmessage())
+{
+    OT_ASSERT(paycode.has_key());
+
+    OTData key(paycode.key().c_str(), paycode.key().size());
+    OTData chaincode(paycode.chaincode().c_str(), paycode.chaincode().size());
+    ConstructKey(key, chaincode);
+
+    if (paycode.has_bitmessageversion()) {
+        bitmessage_version = paycode.bitmessageversion();
+    }
+    if (paycode.has_bitmessagestream()) {
+        bitmessage_stream = paycode.bitmessagestream();
+    }
+}
+
+const OTData PaymentCode::Pubkey() const
+{
+    OTData pubkey;
+    pubkey.SetSize(33);
+
+    if (pubkey_) {
+        std::dynamic_pointer_cast<AsymmetricKeySecp256k1>(pubkey_)->GetKey(pubkey);
+    }
+
+    OT_ASSERT(33 == pubkey.GetSize());
+
+    return pubkey;
+}
+
+const std::string PaymentCode::asBase58() const
+{
+    OTData pubkey = Pubkey();
+
+    uint8_t serialized[81]{};
+
+    serialized[0] = PaymentCode::BIP47_VERSION_BYTE;
+    serialized[1] = version_;
+    serialized[2] = hasBitmessage_ ? 0x80 : 0;
+    OTPassword::safe_memcpy(
+        &serialized[3],
+        33,
+        pubkey.GetPointer(),
+        pubkey.GetSize(),
+        false);
+    OTPassword::safe_memcpy(
+        &serialized[36],
+        32,
+        chain_code_.GetPointer(),
+        chain_code_.GetSize(),
+        false);
+    serialized[68] = bitmessage_version;
+    serialized[69] = bitmessage_stream;
+
+    OTData binaryVersion(serialized, sizeof(serialized));
+
+    return CryptoEngine::Instance().Util().Base58CheckEncode(binaryVersion).Get();
+}
+
+const SerializedPaymentCode PaymentCode::Serialize() const
+{
+    SerializedPaymentCode serialized = std::make_shared<proto::PaymentCode>();
+
+    serialized->set_version(version_);
+
+    if (pubkey_) {
+        OTData pubkey = Pubkey();
+        serialized->set_key(pubkey.GetPointer(), pubkey.GetSize());
+    }
+
+    serialized->set_chaincode(chain_code_.GetPointer(), chain_code_.GetSize());
+    serialized->set_bitmessageversion(bitmessage_version);
+    serialized->set_bitmessagestream(bitmessage_stream);
+
+    return serialized;
+}
+
+Identifier PaymentCode::ID() const
+{
+
+    uint8_t core[65]{};
+
+    OTData pubkey = Pubkey();
+    OTPassword::safe_memcpy(
+        &core[0],
+        33,
+        pubkey.GetPointer(),
+        pubkey.GetSize(),
+        false);
+    OTPassword::safe_memcpy(
+        &core[33],
+        32,
+        chain_code_.GetPointer(),
+        chain_code_.GetSize(),
+        false);
+
+    OTData dataVersion(core, sizeof(core));
+
+    Identifier paymentCodeID;
+
+    paymentCodeID.CalculateDigest(dataVersion);
+
+    return paymentCodeID;
+}
+
+bool PaymentCode::Verify(const MasterCredential& credential) const
+{
+    serializedCredential serializedMaster =
+        credential.Serialize(
+            Credential::AS_PUBLIC,
+            Credential::WITH_SIGNATURES);
+
+    if (!proto::Verify(*serializedMaster, proto::CREDROLE_MASTERKEY, true)) {
+        otErr << __FUNCTION__ << ": Invalid master credential syntax.\n";
+        return false;
+    }
+
+    serializedSignature sourceSig = credential.GetSourceSignature();
+
+    if (!sourceSig) {
+        otErr << __FUNCTION__ << ": Credential not signed by a source.\n";
+        return false;
+    }
+
+    if (!pubkey_) {
+        otErr << __FUNCTION__ << ": Payment code is missing public key.\n";
+        return false;
+    }
+
+    return pubkey_->Verify(
+        proto::ProtoAsData<proto::Credential>(*serializedMaster),
+        *sourceSig);
+}
+
+void PaymentCode::ConstructKey(const OTData& pubkey, const OTData& chaincode)
+{
+    proto::AsymmetricKey newKey;
+
+    newKey.set_version(1);
+    newKey.set_type(proto::AKEYTYPE_SECP256K1);
+    newKey.set_mode(proto::KEYMODE_PUBLIC);
+    newKey.set_role(proto::KEYROLE_SIGN);
+    newKey.set_key(pubkey.GetPointer(), pubkey.GetSize());
+    newKey.set_chaincode(chaincode.GetPointer(), chaincode.GetSize());
+
+    OTAsymmetricKey* key = OTAsymmetricKey::KeyFactory(newKey);
+
+    pubkey_.reset(key);
+}
+
+} // namespace opentxs

--- a/src/core/crypto/TrezorCrypto.cpp
+++ b/src/core/crypto/TrezorCrypto.cpp
@@ -72,7 +72,14 @@ serializedAsymmetricKey TrezorCrypto::SeedToPrivateKey(const OTPassword& seed)
     if (1 == result) {
         derivedKey = HDNodeToSerialized(node, TrezorCrypto::DERIVE_PRIVATE);
     }
-    derivedKey->mutable_path()->set_root(node.fingerprint);
+    OTPassword root;
+    CryptoEngine::Instance().Hash().Digest(
+        CryptoHash::HASH160,
+        seed,
+        root);
+    derivedKey->mutable_path()->set_root(
+        root.getMemory(),
+        root.getMemorySize());
 
     return derivedKey;
 }


### PR DESCRIPTION
Every HD nym now has a BIP-47 payment code associated with it.

This payment code is used as the NymID source, and signs all master credentials which are part of the nym.

The unused "alt location" property of a nym has been renamed to "description" and contains the ID of the nym source.

In the case of HD nyms, the description is the base58 serialized version of the nym's payment code.

All symmetric encryption now uses AES-256.