### PR TITLE
Use BIP39 derivation

### DIFF
--- a/include/opentxs/core/crypto/Bip39.hpp
+++ b/include/opentxs/core/crypto/Bip39.hpp
@@ -52,6 +52,10 @@ public:
 
     virtual std::string toWords(
         const OTPassword& seed) const = 0;
+    virtual void WordsToSeed(
+        const std::string words,
+        OTPassword& seed,
+        const std::string passphrase = "OTX") const = 0;
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/TrezorCrypto.hpp
+++ b/include/opentxs/core/crypto/TrezorCrypto.hpp
@@ -67,14 +67,18 @@ private:
         const HDNode& node,
         const DerivationMode privateVersion) const;
 public:
-    virtual std::string toWords(const OTPassword& seed) const;
-    virtual serializedAsymmetricKey SeedToPrivateKey(
-        const OTPassword& seed) const;
-    virtual serializedAsymmetricKey GetChild(
+    std::string toWords(const OTPassword& seed) const override;
+    void WordsToSeed(
+        const std::string words,
+        OTPassword& seed,
+        const std::string passphrase = "OTX") const override;
+    serializedAsymmetricKey SeedToPrivateKey(
+        const OTPassword& seed) const override;
+    serializedAsymmetricKey GetChild(
         const proto::AsymmetricKey& parent,
-        const uint32_t index) const;
-    virtual serializedAsymmetricKey PrivateToPublic(
-        const proto::AsymmetricKey& key) const;
+        const uint32_t index) const override;
+    serializedAsymmetricKey PrivateToPublic(
+        const proto::AsymmetricKey& key) const override;
 };
 
 } // namespace opentxs

--- a/src/core/crypto/Bip32.cpp
+++ b/src/core/crypto/Bip32.cpp
@@ -54,7 +54,19 @@ serializedAsymmetricKey Bip32::GetHDKey(const proto::HDPath path) const
 {
     uint32_t depth = path.child_size();
     if (0 == depth) {
-        BinarySecret seed = GetHDSeed();
+        BinarySecret masterseed = GetHDSeed();
+        std::string wordlist;
+
+        if (masterseed) {
+            wordlist = App::Me().Crypto().BIP39().toWords(*masterseed);
+        }
+
+        BinarySecret seed = App::Me().Crypto().AES().InstantiateBinarySecretSP();
+
+        App::Me().Crypto().BIP39().WordsToSeed(
+            wordlist,
+            *seed);
+
         serializedAsymmetricKey node = SeedToPrivateKey(*seed);
         return node;
     } else {

--- a/src/core/crypto/TrezorCrypto.cpp
+++ b/src/core/crypto/TrezorCrypto.cpp
@@ -47,6 +47,7 @@ extern "C" {
 
 namespace opentxs
 {
+
 std::string TrezorCrypto::toWords(const OTPassword& seed) const
 {
     std::string wordlist(
@@ -54,6 +55,23 @@ std::string TrezorCrypto::toWords(const OTPassword& seed) const
             static_cast<const uint8_t*>(seed.getMemory()),
             seed.getMemorySize()));
     return wordlist;
+}
+
+void TrezorCrypto::WordsToSeed(
+    const std::string words,
+    OTPassword& seed,
+    const std::string passphrase) const
+{
+    OT_ASSERT_MSG(!words.empty(), "Mnemonic was blank.");
+    OT_ASSERT_MSG(!passphrase.empty(), "Passphrase was blank.");
+
+    seed.SetSize(512/8);
+
+    ::mnemonic_to_seed(
+        words.c_str(),
+        passphrase.c_str(),
+        static_cast<uint8_t*>(seed.getMemoryWritable()),
+        nullptr);
 }
 
 serializedAsymmetricKey TrezorCrypto::SeedToPrivateKey(const OTPassword& seed)


### PR DESCRIPTION
Derive wallet seeds for HD keys using BIP39 with a fixed passphrase of "OTX".

This makes OT wallet seeds compatible with Bitcoin wallets which use BIP39

