### PR TITLE
add OTAPI_Exec::AddClaim

### DIFF
--- a/include/opentxs/client/OTAPI.hpp
+++ b/include/opentxs/client/OTAPI.hpp
@@ -3990,6 +3990,23 @@ public:
         const std::uint32_t section,
         const std::string claim);
 
+    /**   Add a single claim to the target nym's contact credential
+     *    \param[in]  nymID the indentifier of the target nym
+     *    \param[in]  section section containing the claim
+     *    \param[in]  type claim type (proto::ContactItemType enum value)
+     *    \param[in]  value claim value
+     *    \param[in]  active true if the claim should have an active attribute
+     *    \param[in]  primary true if the claim should have a primary attribute
+     *    \return true for success, false for error
+     */
+    EXPORT static bool AddClaim(
+        const std::string& nymID,
+        const std::uint32_t& section,
+        const std::uint32_t& type,
+        const std::string& value,
+        const bool active,
+        const bool primary);
+
     /**   Remove a single claim from the target nym's contact credential
      *    \param[in]  nymID the indentifier of the target nym
      *    \param[in]  claimID the indentifier of the target claim

--- a/include/opentxs/client/OTAPI_Exec.hpp
+++ b/include/opentxs/client/OTAPI_Exec.hpp
@@ -525,6 +525,27 @@ public:
         const std::uint32_t& section,
         const std::string& claim) const;
 
+    /**   Add a single claim to the target nym's contact credential
+     *    \param[in]  nymID the indentifier of the target nym
+     *    \param[in]  section section containing the claim
+     *    \param[in]  type claim type (proto::ContactItemType enum value)
+     *    \param[in]  value claim value
+     *    \param[in]  active true if the claim should have an active attribute
+     *    \param[in]  primary true if the claim should have a primary attribute
+     *    \param[in]  start beginning of valid time for the claim
+     *    \param[in]  end end of valid time for the claim
+     *    \return true for success, false for error
+     */
+    EXPORT bool AddClaim(
+        const std::string& nymID,
+        const std::uint32_t& section,
+        const std::uint32_t& type,
+        const std::string& value,
+        const bool active = true,
+        const bool primary = false,
+        const int64_t start = 0,
+        const int64_t end = 0) const;
+
     /**   Remove a single claim from the target nym's contact credential
      *    \param[in]  nymID the indentifier of the target nym
      *    \param[in]  claimID the indentifier of the target claim

--- a/src/client/OTAPI.cpp
+++ b/src/client/OTAPI.cpp
@@ -2569,6 +2569,17 @@ bool OTAPI_Wrap::SetClaim(
     return Exec()->SetClaim(nymID, section, claim);
 }
 
+bool OTAPI_Wrap::AddClaim(
+    const std::string& nymID,
+    const std::uint32_t& section,
+    const std::uint32_t& type,
+    const std::string& value,
+    const bool active,
+    const bool primary)
+{
+    return Exec()->AddClaim(nymID, section, type, value, active, primary);
+}
+
 bool OTAPI_Wrap::DeleteClaim(
         const std::string nymID,
         const std::string claimID)

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -16750,4 +16750,34 @@ std::string OTAPI_Exec::Wallet_GetWords() const
     return OTAPI()->Wallet_GetWords();
 }
 
+bool OTAPI_Exec::AddClaim(
+    const std::string& nymID,
+    const std::uint32_t& section,
+    const std::uint32_t& type,
+    const std::string& value,
+    const bool active,
+    const bool primary,
+    const int64_t start,
+    const int64_t end) const
+{
+    std::unique_ptr<proto::ContactItem> claim(new proto::ContactItem);
+
+    if (!claim) { return false; }
+
+    claim->set_version(1);
+    claim->set_type(static_cast<proto::ContactItemType>(type));
+    claim->set_value(value);
+    claim->set_start(start);
+    claim->set_end(end);
+
+    if (active) {
+        claim->add_attribute(proto::CITEMATTR_ACTIVE);
+    }
+
+    if (primary) {
+        claim->add_attribute(proto::CITEMATTR_PRIMARY);
+    }
+
+    return SetClaim(nymID, section,  proto::ProtoAsString(*claim));
+}
 }  // namespace opentxs


### PR DESCRIPTION
Allows a claim to be added to a nym without requiring the caller to construct a native protobuf object.

This call is intended as a fallback until the stabilization of non-c++ bindings to opentxs-proto.