### PR TITLE
Add peer communication API

### DIFF
--- a/include/opentxs/client/OTAPI.hpp
+++ b/include/opentxs/client/OTAPI.hpp
@@ -2840,33 +2840,81 @@ public:
     In this message, you are requesting the server to send a message to
     another user, encrypted to his public key and dropped in his nymbox.
 
+    *   sendNymMessage does this:
+    *   -- Puts user message as encrypted Payload on an OTMessage (1)...
+    *   -- Also puts user message as a CLEAR payload on an OTMessage (2)...
+    *   -- (1) is sent to server, and (2) is added to Outmail messages.
+    *   -- (1) gets added to recipient's Nymbox as "in ref to" string on a
+    *   "message" transaction.
+    *   -- When recipient processes Nymbox, OTMessage (1) is extracted and
+    *   added to recipient's nym Mail.
+    *   -- When recipient gets mail contents, decryption occurs from (1)
+    *   payload, before returning contents as original user message string.
+    *   -- When sender gets outmail contents, original user message string is
+    *   returned from (2) payload, with no decryption necessary.
+    *
+    *   \Returns int32_t:
+    *   -1 means error; no message was sent.
+    *   0 means NO error, but also: no message was sent.
+    *   >0 means NO error, and the message was sent, and the request number fits
+    *   into an integer...
+    *   ...and in fact the requestNum IS the return value!
+    *   ===> In 99% of cases, this LAST option is what actually happens!!
     */
-    // Returns int32_t:
-    // -1 means error; no message was sent.
-    // 0 means NO error, but also: no message was sent.
-    // >0 means NO error, and the message was sent, and the request number fits
-    // into an integer...
-    // ...and in fact the requestNum IS the return value!
-    // ===> In 99% of cases, this LAST option is what actually happens!!
-    //
-    EXPORT static int32_t sendNymMessage(const std::string& NOTARY_ID,
-                                         const std::string& NYM_ID,
-                                         const std::string& NYM_ID_RECIPIENT,
-                                         const std::string& THE_MESSAGE);
-    /**
-    sendNymMessage does this:
-    -- Puts user message as encrypted Payload on an OTMessage (1)...
-    -- Also puts user message as a CLEAR payload on an OTMessage (2)...
-    -- (1) is sent to server, and (2) is added to Outmail messages.
-    -- (1) gets added to recipient's Nymbox as "in ref to" string on a
-    "message" transaction.
-    -- When recipient processes Nymbox, OTMessage (1) is extracted and
-    added to recipient's nym Mail.
-    -- When recipient gets mail contents, decryption occurs from (1) payload,
-    before returning contents as original user message string.
-    -- When sender gets outmail contents, original user message string is
-    returned from (2) payload, with no decryption necessary.
-    */
+    EXPORT static int32_t sendNymMessage(
+        const std::string& NOTARY_ID,
+        const std::string& NYM_ID,
+        const std::string& NYM_ID_RECIPIENT,
+        const std::string& THE_MESSAGE);
+
+    EXPORT static int32_t initiateBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& unitID);
+
+    EXPORT static int32_t initiateOutBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& unitID,
+        const std::string& terms);
+
+    EXPORT static int32_t acknowledgeBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& requestID,
+        const std::string& terms);
+
+    EXPORT static int32_t acknowledgeOutBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& requestID,
+        const std::string& terms);
+
+    EXPORT static int32_t completePeerReply(
+        const std::string& nymID,
+        const std::string& replyID);
+
+    EXPORT static int32_t completePeerRequest(
+        const std::string& nymID,
+        const std::string& requestID);
+
+    EXPORT static std::string getIncomingRequests(
+        const std::string& nymID);
+
+    EXPORT static std::string getIncomingReplies(
+        const std::string& nymID);
+
+    EXPORT static std::string getRequest(
+        const std::string& nymID,
+        const std::string& requestID);
+
+    EXPORT static std::string getReply(
+        const std::string& nymID,
+        const std::string& replyID);
 
     /**
     SEND USER INSTRUMENT --- (Send a financial instrument to another user,

--- a/include/opentxs/client/OTAPI_Exec.hpp
+++ b/include/opentxs/client/OTAPI_Exec.hpp
@@ -3050,33 +3050,81 @@ public:
     In this message, you are requesting the server to send a message to
     another user, encrypted to his public key and dropped in his nymbox.
 
+    *   sendNymMessage does this:
+    *   -- Puts user message as encrypted Payload on an OTMessage (1)...
+    *   -- Also puts user message as a CLEAR payload on an OTMessage (2)...
+    *   -- (1) is sent to server, and (2) is added to Outmail messages.
+    *   -- (1) gets added to recipient's Nymbox as "in ref to" string on a
+    *   "message" transaction.
+    *   -- When recipient processes Nymbox, OTMessage (1) is extracted and
+    *   added to recipient's nym Mail.
+    *   -- When recipient gets mail contents, decryption occurs from (1)
+    *   payload, before returning contents as original user message string.
+    *   -- When sender gets outmail contents, original user message string is
+    *   returned from (2) payload, with no decryption necessary.
+    *
+    *   \Returns int32_t:
+    *   -1 means error; no message was sent.
+    *   0 means NO error, but also: no message was sent.
+    *   >0 means NO error, and the message was sent, and the request number fits
+    *   into an integer...
+    *   ...and in fact the requestNum IS the return value!
+    *   ===> In 99% of cases, this LAST option is what actually happens!!
     */
-    // Returns int32_t:
-    // -1 means error; no message was sent.
-    // 0 means NO error, but also: no message was sent.
-    // >0 means NO error, and the message was sent, and the request number fits
-    // into an integer...
-    // ...and in fact the requestNum IS the return value!
-    // ===> In 99% of cases, this LAST option is what actually happens!!
-    //
-    EXPORT int32_t sendNymMessage(const std::string& NOTARY_ID,
-                                  const std::string& NYM_ID,
-                                  const std::string& NYM_ID_RECIPIENT,
-                                  const std::string& THE_MESSAGE) const;
-    /**
-    sendNymMessage does this:
-    -- Puts user message as encrypted Payload on an OTMessage (1)...
-    -- Also puts user message as a CLEAR payload on an OTMessage (2)...
-    -- (1) is sent to server, and (2) is added to Outmail messages.
-    -- (1) gets added to recipient's Nymbox as "in ref to" string on a
-    "message" transaction.
-    -- When recipient processes Nymbox, OTMessage (1) is extracted and
-    added to recipient's nym Mail.
-    -- When recipient gets mail contents, decryption occurs from (1) payload,
-    before returning contents as original user message string.
-    -- When sender gets outmail contents, original user message string is
-    returned from (2) payload, with no decryption necessary.
-    */
+    EXPORT int32_t sendNymMessage(
+        const std::string& NOTARY_ID,
+        const std::string& NYM_ID,
+        const std::string& NYM_ID_RECIPIENT,
+        const std::string& THE_MESSAGE) const;
+
+    EXPORT int32_t initiateBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& unitID) const;
+
+    EXPORT int32_t initiateOutBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& unitID,
+        const std::string& terms) const;
+
+    EXPORT int32_t acknowledgeBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& requestID,
+        const std::string& terms) const;
+
+    EXPORT int32_t acknowledgeOutBailment(
+        const std::string& serverID,
+        const std::string& senderNymID,
+        const std::string& recipientNymID,
+        const std::string& requestID,
+        const std::string& terms) const;
+
+    EXPORT int32_t completePeerReply(
+        const std::string& nymID,
+        const std::string& replyID) const;
+
+    EXPORT int32_t completePeerRequest(
+        const std::string& nymID,
+        const std::string& requestID) const;
+
+    EXPORT std::list<std::string> getIncomingRequests(
+        const std::string& nymID) const;
+
+    EXPORT std::list<std::string> getIncomingReplies(
+        const std::string& nymID) const;
+
+    EXPORT std::string getRequest(
+        const std::string& nymID,
+        const std::string& requestID) const;
+
+    EXPORT std::string getReply(
+        const std::string& nymID,
+        const std::string& replyID) const;
 
     /**
     SEND USER INSTRUMENT --- (Send a financial instrument to another user,
@@ -3095,15 +3143,14 @@ public:
     (by way
     of his nymbox.)
 
+    \Returns int32_t:
+    -1 means error; no message was sent.
+    0 means NO error, but also: no message was sent.
+    >0 means NO error, and the message was sent, and the request number fits
+    into an integer...
+    ...and in fact the requestNum IS the return value!
+    ===> In 99% of cases, this LAST option is what actually happens!!
     */
-    // Returns int32_t:
-    // -1 means error; no message was sent.
-    // 0 means NO error, but also: no message was sent.
-    // >0 means NO error, and the message was sent, and the request number fits
-    // into an integer...
-    // ...and in fact the requestNum IS the return value!
-    // ===> In 99% of cases, this LAST option is what actually happens!!
-    //
     EXPORT int32_t sendNymInstrument(
         const std::string& NOTARY_ID, const std::string& NYM_ID,
         const std::string& NYM_ID_RECIPIENT,

--- a/include/opentxs/client/OT_ME.hpp
+++ b/include/opentxs/client/OT_ME.hpp
@@ -355,8 +355,32 @@ public:
         const std::string& NOTARY_ID, const std::string& USER_NYM_ID,
         const std::string& TARGET_NYM_ID, const std::string& ADJUSTMENT) const;
 
-//    EXPORT bool networkFailureRaw(); // This returns m_bNetworkFailure
-//    EXPORT bool networkFailure();    // This returns m_bNetworkFailure but also resets it back to false.
+    EXPORT std::string initiate_bailment(
+        const std::string& NOTARY_ID,
+        const std::string& NYM_ID,
+        const std::string& TARGET_NYM_ID,
+        const std::string& INSTRUMENT_DEFINITION_ID) const;
+
+    EXPORT std::string initiate_outbailment(
+        const std::string& NOTARY_ID,
+        const std::string& NYM_ID,
+        const std::string& TARGET_NYM_ID,
+        const std::string& INSTRUMENT_DEFINITION_ID,
+        const std::string& THE_MESSAGE) const;
+
+    EXPORT std::string acknowledge_bailment(
+        const std::string& NOTARY_ID,
+        const std::string& NYM_ID,
+        const std::string& TARGET_NYM_ID,
+        const std::string& REQUEST_ID,
+        const std::string& THE_MESSAGE) const;
+
+    EXPORT std::string acknowledge_outbailment(
+        const std::string& NOTARY_ID,
+        const std::string& NYM_ID,
+        const std::string& TARGET_NYM_ID,
+        const std::string& REQUEST_ID,
+        const std::string& THE_MESSAGE) const;
 
 private:
     OT_ME(const OT_ME&);

--- a/include/opentxs/client/OpenTransactions.hpp
+++ b/include/opentxs/client/OpenTransactions.hpp
@@ -42,6 +42,7 @@
 #include "opentxs/core/String.hpp"
 #include "opentxs/core/Types.hpp"
 #include "opentxs/core/app/Wallet.hpp"
+#include "opentxs/core/contract/peer/PeerObject.hpp"
 #include "opentxs/core/crypto/NymParameters.hpp"
 #include "opentxs/core/util/Common.hpp"
 
@@ -659,6 +660,12 @@ public:
                                   const Identifier& NYM_ID,
                                   const Identifier& NYM_ID_RECIPIENT,
                                   const String& THE_MESSAGE) const;
+
+    EXPORT int32_t sendNymObject(const Identifier& NOTARY_ID,
+                                  const Identifier& NYM_ID,
+                                  const Identifier& NYM_ID_RECIPIENT,
+                                  const PeerObject& OBJECT,
+                                  int64_t& requestNumber) const;
 
     EXPORT int32_t sendNymInstrument(
         const Identifier& NOTARY_ID, const Identifier& NYM_ID,

--- a/include/opentxs/client/commands/CmdAcknowledgeBailment.hpp
+++ b/include/opentxs/client/commands/CmdAcknowledgeBailment.hpp
@@ -1,0 +1,163 @@
+/************************************************************
+ *
+ *  CmdAcknowledgeBailment.hpp
+ *
+ */
+
+/************************************************************
+ -----BEGIN PGP SIGNED MESSAGE-----
+ Hash: SHA1
+
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  Copyright (C) 2010-2013 by "Fellow Traveler" (A pseudonym)
+ *
+ *  EMAIL:
+ *  FellowTraveler@rayservers.net
+ *
+ *  BITCOIN:  1NtTPVVjDsUfDWybS4BwvHpG2pdS9RnYyQ
+ *
+ *  KEY FINGERPRINT (PGP Key in license file):
+ *  9DD5 90EB 9292 4B48 0484  7910 0308 00ED F951 BB8E
+ *
+ *  OFFICIAL PROJECT WIKI(s):
+ *  https://github.com/FellowTraveler/Moneychanger
+ *  https://github.com/FellowTraveler/Open-Transactions/wiki
+ *
+ *  WEBSITE:
+ *  http://www.OpenTransactions.org/
+ *
+ *  Components and licensing:
+ *   -- Moneychanger..A Java client GUI.....LICENSE:.....GPLv3
+ *   -- otlib.........A class library.......LICENSE:...LAGPLv3
+ *   -- otapi.........A client API..........LICENSE:...LAGPLv3
+ *   -- opentxs/ot....Command-line client...LICENSE:...LAGPLv3
+ *   -- otserver......Server Application....LICENSE:....AGPLv3
+ *  Github.com/FellowTraveler/Open-Transactions/wiki/Components
+ *
+ *  All of the above OT components were designed and written by
+ *  Fellow Traveler, with the exception of Moneychanger, which
+ *  was contracted out to Vicky C (bitcointrader4@gmail.com).
+ *  The open-source community has since actively contributed.
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This program is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU Affero
+ *   General Public License as published by the Free Software
+ *   Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   ADDITIONAL PERMISSION under the GNU Affero GPL version 3
+ *   section 7: (This paragraph applies only to the LAGPLv3
+ *   components listed above.) If you modify this Program, or
+ *   any covered work, by linking or combining it with other
+ *   code, such other code is not for that reason alone subject
+ *   to any of the requirements of the GNU Affero GPL version 3.
+ *   (==> This means if you are only using the OT API, then you
+ *   don't have to open-source your code--only your changes to
+ *   Open-Transactions itself must be open source. Similar to
+ *   LGPLv3, except it applies to software-as-a-service, not
+ *   just to distributing binaries.)
+ *
+ *   Extra WAIVER for OpenSSL, Lucre, and all other libraries
+ *   used by Open Transactions: This program is released under
+ *   the AGPL with the additional exemption that compiling,
+ *   linking, and/or using OpenSSL is allowed. The same is true
+ *   for any other open source libraries included in this
+ *   project: complete waiver from the AGPL is hereby granted to
+ *   compile, link, and/or use them with Open-Transactions,
+ *   according to their own terms, as long as the rest of the
+ *   Open-Transactions terms remain respected, with regard to
+ *   the Open-Transactions code itself.
+ *
+ *   Lucre License:
+ *   This code is also "dual-license", meaning that Ben Lau-
+ *   rie's license must also be included and respected, since
+ *   the code for Lucre is also included with Open Transactions.
+ *   See Open-Transactions/src/otlib/lucre/LUCRE_LICENSE.txt
+ *   The Laurie requirements are light, but if there is any
+ *   problem with his license, simply remove the Lucre code.
+ *   Although there are no other blind token algorithms in Open
+ *   Transactions (yet. credlib is coming), the other functions
+ *   will continue to operate.
+ *   See Lucre on Github:  https://github.com/benlaurie/lucre
+ *   -----------------------------------------------------
+ *   You should have received a copy of the GNU Affero General
+ *   Public License along with this program.  If not, see:
+ *   http://www.gnu.org/licenses/
+ *
+ *   If you would like to use this software outside of the free
+ *   software license, please contact FellowTraveler.
+ *   (Unfortunately many will run anonymously and untraceably,
+ *   so who could really stop them?)
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE.  See the GNU Affero General Public License for
+ *   more details.
+
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.9 (Darwin)
+
+ iQIcBAEBAgAGBQJRSsfJAAoJEAMIAO35UbuOQT8P/RJbka8etf7wbxdHQNAY+2cC
+ vDf8J3X8VI+pwMqv6wgTVy17venMZJa4I4ikXD/MRyWV1XbTG0mBXk/7AZk7Rexk
+ KTvL/U1kWiez6+8XXLye+k2JNM6v7eej8xMrqEcO0ZArh/DsLoIn1y8p8qjBI7+m
+ aE7lhstDiD0z8mwRRLKFLN2IH5rAFaZZUvj5ERJaoYUKdn4c+RcQVei2YOl4T0FU
+ LWND3YLoH8naqJXkaOKEN4UfJINCwxhe5Ke9wyfLWLUO7NamRkWD2T7CJ0xocnD1
+ sjAzlVGNgaFDRflfIF4QhBx1Ddl6wwhJfw+d08bjqblSq8aXDkmFA7HeunSFKkdn
+ oIEOEgyj+veuOMRJC5pnBJ9vV+7qRdDKQWaCKotynt4sWJDGQ9kWGWm74SsNaduN
+ TPMyr9kNmGsfR69Q2Zq/FLcLX/j8ESxU+HYUB4vaARw2xEOu2xwDDv6jt0j3Vqsg
+ x7rWv4S/Eh18FDNDkVRChiNoOIilLYLL6c38uMf1pnItBuxP3uhgY6COm59kVaRh
+ nyGTYCDYD2TK+fI9o89F1297uDCwEJ62U0Q7iTDp5QuXCoxkPfv8/kX6lS6T3y9G
+ M9mqIoLbIQ1EDntFv7/t6fUTS2+46uCrdZWbQ5RjYXdrzjij02nDmJAm2BngnZvd
+ kamH0Y/n11lCvo1oQxM+
+ =uSzz
+ -----END PGP SIGNATURE-----
+ **************************************************************/
+
+#ifndef OPENTXS_CLIENT_CMDACKNOWLEDGEBAILMENT_HPP
+#define OPENTXS_CLIENT_CMDACKNOWLEDGEBAILMENT_HPP
+
+#include "opentxs/client/commands/CmdBase.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace opentxs
+{
+
+class CmdAcknowledgeBailment : public CmdBase
+{
+public:
+    EXPORT CmdAcknowledgeBailment();
+    virtual ~CmdAcknowledgeBailment();
+
+    EXPORT std::int32_t
+        run(
+            std::string server,
+            std::string mynym,
+            std::string hisnym,
+            std::string mypurse);
+
+protected:
+    virtual std::int32_t runWithOptions();
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CLIENT_CMDACKNOWLEDGEBAILMENT_HPP

--- a/include/opentxs/client/commands/CmdAcknowledgeOutBailment.hpp
+++ b/include/opentxs/client/commands/CmdAcknowledgeOutBailment.hpp
@@ -1,0 +1,163 @@
+/************************************************************
+ *
+ *  CmdAcknowledgeOutBailment.hpp
+ *
+ */
+
+/************************************************************
+ -----BEGIN PGP SIGNED MESSAGE-----
+ Hash: SHA1
+
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  Copyright (C) 2010-2013 by "Fellow Traveler" (A pseudonym)
+ *
+ *  EMAIL:
+ *  FellowTraveler@rayservers.net
+ *
+ *  BITCOIN:  1NtTPVVjDsUfDWybS4BwvHpG2pdS9RnYyQ
+ *
+ *  KEY FINGERPRINT (PGP Key in license file):
+ *  9DD5 90EB 9292 4B48 0484  7910 0308 00ED F951 BB8E
+ *
+ *  OFFICIAL PROJECT WIKI(s):
+ *  https://github.com/FellowTraveler/Moneychanger
+ *  https://github.com/FellowTraveler/Open-Transactions/wiki
+ *
+ *  WEBSITE:
+ *  http://www.OpenTransactions.org/
+ *
+ *  Components and licensing:
+ *   -- Moneychanger..A Java client GUI.....LICENSE:.....GPLv3
+ *   -- otlib.........A class library.......LICENSE:...LAGPLv3
+ *   -- otapi.........A client API..........LICENSE:...LAGPLv3
+ *   -- opentxs/ot....Command-line client...LICENSE:...LAGPLv3
+ *   -- otserver......Server Application....LICENSE:....AGPLv3
+ *  Github.com/FellowTraveler/Open-Transactions/wiki/Components
+ *
+ *  All of the above OT components were designed and written by
+ *  Fellow Traveler, with the exception of Moneychanger, which
+ *  was contracted out to Vicky C (bitcointrader4@gmail.com).
+ *  The open-source community has since actively contributed.
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This program is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU Affero
+ *   General Public License as published by the Free Software
+ *   Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   ADDITIONAL PERMISSION under the GNU Affero GPL version 3
+ *   section 7: (This paragraph applies only to the LAGPLv3
+ *   components listed above.) If you modify this Program, or
+ *   any covered work, by linking or combining it with other
+ *   code, such other code is not for that reason alone subject
+ *   to any of the requirements of the GNU Affero GPL version 3.
+ *   (==> This means if you are only using the OT API, then you
+ *   don't have to open-source your code--only your changes to
+ *   Open-Transactions itself must be open source. Similar to
+ *   LGPLv3, except it applies to software-as-a-service, not
+ *   just to distributing binaries.)
+ *
+ *   Extra WAIVER for OpenSSL, Lucre, and all other libraries
+ *   used by Open Transactions: This program is released under
+ *   the AGPL with the additional exemption that compiling,
+ *   linking, and/or using OpenSSL is allowed. The same is true
+ *   for any other open source libraries included in this
+ *   project: complete waiver from the AGPL is hereby granted to
+ *   compile, link, and/or use them with Open-Transactions,
+ *   according to their own terms, as long as the rest of the
+ *   Open-Transactions terms remain respected, with regard to
+ *   the Open-Transactions code itself.
+ *
+ *   Lucre License:
+ *   This code is also "dual-license", meaning that Ben Lau-
+ *   rie's license must also be included and respected, since
+ *   the code for Lucre is also included with Open Transactions.
+ *   See Open-Transactions/src/otlib/lucre/LUCRE_LICENSE.txt
+ *   The Laurie requirements are light, but if there is any
+ *   problem with his license, simply remove the Lucre code.
+ *   Although there are no other blind token algorithms in Open
+ *   Transactions (yet. credlib is coming), the other functions
+ *   will continue to operate.
+ *   See Lucre on Github:  https://github.com/benlaurie/lucre
+ *   -----------------------------------------------------
+ *   You should have received a copy of the GNU Affero General
+ *   Public License along with this program.  If not, see:
+ *   http://www.gnu.org/licenses/
+ *
+ *   If you would like to use this software outside of the free
+ *   software license, please contact FellowTraveler.
+ *   (Unfortunately many will run anonymously and untraceably,
+ *   so who could really stop them?)
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE.  See the GNU Affero General Public License for
+ *   more details.
+
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.9 (Darwin)
+
+ iQIcBAEBAgAGBQJRSsfJAAoJEAMIAO35UbuOQT8P/RJbka8etf7wbxdHQNAY+2cC
+ vDf8J3X8VI+pwMqv6wgTVy17venMZJa4I4ikXD/MRyWV1XbTG0mBXk/7AZk7Rexk
+ KTvL/U1kWiez6+8XXLye+k2JNM6v7eej8xMrqEcO0ZArh/DsLoIn1y8p8qjBI7+m
+ aE7lhstDiD0z8mwRRLKFLN2IH5rAFaZZUvj5ERJaoYUKdn4c+RcQVei2YOl4T0FU
+ LWND3YLoH8naqJXkaOKEN4UfJINCwxhe5Ke9wyfLWLUO7NamRkWD2T7CJ0xocnD1
+ sjAzlVGNgaFDRflfIF4QhBx1Ddl6wwhJfw+d08bjqblSq8aXDkmFA7HeunSFKkdn
+ oIEOEgyj+veuOMRJC5pnBJ9vV+7qRdDKQWaCKotynt4sWJDGQ9kWGWm74SsNaduN
+ TPMyr9kNmGsfR69Q2Zq/FLcLX/j8ESxU+HYUB4vaARw2xEOu2xwDDv6jt0j3Vqsg
+ x7rWv4S/Eh18FDNDkVRChiNoOIilLYLL6c38uMf1pnItBuxP3uhgY6COm59kVaRh
+ nyGTYCDYD2TK+fI9o89F1297uDCwEJ62U0Q7iTDp5QuXCoxkPfv8/kX6lS6T3y9G
+ M9mqIoLbIQ1EDntFv7/t6fUTS2+46uCrdZWbQ5RjYXdrzjij02nDmJAm2BngnZvd
+ kamH0Y/n11lCvo1oQxM+
+ =uSzz
+ -----END PGP SIGNATURE-----
+ **************************************************************/
+
+#ifndef OPENTXS_CLIENT_CMDACKNOWLEDGEOUTBAILMENT_HPP
+#define OPENTXS_CLIENT_CMDACKNOWLEDGEOUTBAILMENT_HPP
+
+#include "opentxs/client/commands/CmdBase.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace opentxs
+{
+
+class CmdAcknowledgeOutBailment : public CmdBase
+{
+public:
+    EXPORT CmdAcknowledgeOutBailment();
+    virtual ~CmdAcknowledgeOutBailment();
+
+    EXPORT std::int32_t
+        run(
+            std::string server,
+            std::string mynym,
+            std::string hisnym,
+            std::string mypurse);
+
+protected:
+    virtual std::int32_t runWithOptions();
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CLIENT_CMDACKNOWLEDGEOUTBAILMENT_HPP

--- a/include/opentxs/client/commands/CmdGetPeerReplies.hpp
+++ b/include/opentxs/client/commands/CmdGetPeerReplies.hpp
@@ -1,0 +1,159 @@
+/************************************************************
+ *
+ *  CmdGetPeerReplies.hpp
+ *
+ */
+
+/************************************************************
+ -----BEGIN PGP SIGNED MESSAGE-----
+ Hash: SHA1
+
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  Copyright (C) 2010-2013 by "Fellow Traveler" (A pseudonym)
+ *
+ *  EMAIL:
+ *  FellowTraveler@rayservers.net
+ *
+ *  BITCOIN:  1NtTPVVjDsUfDWybS4BwvHpG2pdS9RnYyQ
+ *
+ *  KEY FINGERPRINT (PGP Key in license file):
+ *  9DD5 90EB 9292 4B48 0484  7910 0308 00ED F951 BB8E
+ *
+ *  OFFICIAL PROJECT WIKI(s):
+ *  https://github.com/FellowTraveler/Moneychanger
+ *  https://github.com/FellowTraveler/Open-Transactions/wiki
+ *
+ *  WEBSITE:
+ *  http://www.OpenTransactions.org/
+ *
+ *  Components and licensing:
+ *   -- Moneychanger..A Java client GUI.....LICENSE:.....GPLv3
+ *   -- otlib.........A class library.......LICENSE:...LAGPLv3
+ *   -- otapi.........A client API..........LICENSE:...LAGPLv3
+ *   -- opentxs/ot....Command-line client...LICENSE:...LAGPLv3
+ *   -- otserver......Server Application....LICENSE:....AGPLv3
+ *  Github.com/FellowTraveler/Open-Transactions/wiki/Components
+ *
+ *  All of the above OT components were designed and written by
+ *  Fellow Traveler, with the exception of Moneychanger, which
+ *  was contracted out to Vicky C (bitcointrader4@gmail.com).
+ *  The open-source community has since actively contributed.
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This program is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU Affero
+ *   General Public License as published by the Free Software
+ *   Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   ADDITIONAL PERMISSION under the GNU Affero GPL version 3
+ *   section 7: (This paragraph applies only to the LAGPLv3
+ *   components listed above.) If you modify this Program, or
+ *   any covered work, by linking or combining it with other
+ *   code, such other code is not for that reason alone subject
+ *   to any of the requirements of the GNU Affero GPL version 3.
+ *   (==> This means if you are only using the OT API, then you
+ *   don't have to open-source your code--only your changes to
+ *   Open-Transactions itself must be open source. Similar to
+ *   LGPLv3, except it applies to software-as-a-service, not
+ *   just to distributing binaries.)
+ *
+ *   Extra WAIVER for OpenSSL, Lucre, and all other libraries
+ *   used by Open Transactions: This program is released under
+ *   the AGPL with the additional exemption that compiling,
+ *   linking, and/or using OpenSSL is allowed. The same is true
+ *   for any other open source libraries included in this
+ *   project: complete waiver from the AGPL is hereby granted to
+ *   compile, link, and/or use them with Open-Transactions,
+ *   according to their own terms, as long as the rest of the
+ *   Open-Transactions terms remain respected, with regard to
+ *   the Open-Transactions code itself.
+ *
+ *   Lucre License:
+ *   This code is also "dual-license", meaning that Ben Lau-
+ *   rie's license must also be included and respected, since
+ *   the code for Lucre is also included with Open Transactions.
+ *   See Open-Transactions/src/otlib/lucre/LUCRE_LICENSE.txt
+ *   The Laurie requirements are light, but if there is any
+ *   problem with his license, simply remove the Lucre code.
+ *   Although there are no other blind token algorithms in Open
+ *   Transactions (yet. credlib is coming), the other functions
+ *   will continue to operate.
+ *   See Lucre on Github:  https://github.com/benlaurie/lucre
+ *   -----------------------------------------------------
+ *   You should have received a copy of the GNU Affero General
+ *   Public License along with this program.  If not, see:
+ *   http://www.gnu.org/licenses/
+ *
+ *   If you would like to use this software outside of the free
+ *   software license, please contact FellowTraveler.
+ *   (Unfortunately many will run anonymously and untraceably,
+ *   so who could really stop them?)
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE.  See the GNU Affero General Public License for
+ *   more details.
+
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.9 (Darwin)
+
+ iQIcBAEBAgAGBQJRSsfJAAoJEAMIAO35UbuOQT8P/RJbka8etf7wbxdHQNAY+2cC
+ vDf8J3X8VI+pwMqv6wgTVy17venMZJa4I4ikXD/MRyWV1XbTG0mBXk/7AZk7Rexk
+ KTvL/U1kWiez6+8XXLye+k2JNM6v7eej8xMrqEcO0ZArh/DsLoIn1y8p8qjBI7+m
+ aE7lhstDiD0z8mwRRLKFLN2IH5rAFaZZUvj5ERJaoYUKdn4c+RcQVei2YOl4T0FU
+ LWND3YLoH8naqJXkaOKEN4UfJINCwxhe5Ke9wyfLWLUO7NamRkWD2T7CJ0xocnD1
+ sjAzlVGNgaFDRflfIF4QhBx1Ddl6wwhJfw+d08bjqblSq8aXDkmFA7HeunSFKkdn
+ oIEOEgyj+veuOMRJC5pnBJ9vV+7qRdDKQWaCKotynt4sWJDGQ9kWGWm74SsNaduN
+ TPMyr9kNmGsfR69Q2Zq/FLcLX/j8ESxU+HYUB4vaARw2xEOu2xwDDv6jt0j3Vqsg
+ x7rWv4S/Eh18FDNDkVRChiNoOIilLYLL6c38uMf1pnItBuxP3uhgY6COm59kVaRh
+ nyGTYCDYD2TK+fI9o89F1297uDCwEJ62U0Q7iTDp5QuXCoxkPfv8/kX6lS6T3y9G
+ M9mqIoLbIQ1EDntFv7/t6fUTS2+46uCrdZWbQ5RjYXdrzjij02nDmJAm2BngnZvd
+ kamH0Y/n11lCvo1oQxM+
+ =uSzz
+ -----END PGP SIGNATURE-----
+ **************************************************************/
+
+#ifndef OPENTXS_CLIENT_CMDGETPEERREPLIES_HPP
+#define OPENTXS_CLIENT_CMDGETPEERREPLIES_HPP
+
+#include "opentxs/client/commands/CmdBase.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace opentxs
+{
+
+class CmdGetPeerReplies : public CmdBase
+{
+public:
+    EXPORT CmdGetPeerReplies();
+    virtual ~CmdGetPeerReplies();
+
+    EXPORT std::int32_t
+        run(std::string mynym);
+
+protected:
+    virtual std::int32_t runWithOptions();
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CLIENT_CMDGETPEERREPLIES_HPP

--- a/include/opentxs/client/commands/CmdGetPeerRequests.hpp
+++ b/include/opentxs/client/commands/CmdGetPeerRequests.hpp
@@ -1,0 +1,159 @@
+/************************************************************
+ *
+ *  CmdGetPeerRequests.hpp
+ *
+ */
+
+/************************************************************
+ -----BEGIN PGP SIGNED MESSAGE-----
+ Hash: SHA1
+
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  Copyright (C) 2010-2013 by "Fellow Traveler" (A pseudonym)
+ *
+ *  EMAIL:
+ *  FellowTraveler@rayservers.net
+ *
+ *  BITCOIN:  1NtTPVVjDsUfDWybS4BwvHpG2pdS9RnYyQ
+ *
+ *  KEY FINGERPRINT (PGP Key in license file):
+ *  9DD5 90EB 9292 4B48 0484  7910 0308 00ED F951 BB8E
+ *
+ *  OFFICIAL PROJECT WIKI(s):
+ *  https://github.com/FellowTraveler/Moneychanger
+ *  https://github.com/FellowTraveler/Open-Transactions/wiki
+ *
+ *  WEBSITE:
+ *  http://www.OpenTransactions.org/
+ *
+ *  Components and licensing:
+ *   -- Moneychanger..A Java client GUI.....LICENSE:.....GPLv3
+ *   -- otlib.........A class library.......LICENSE:...LAGPLv3
+ *   -- otapi.........A client API..........LICENSE:...LAGPLv3
+ *   -- opentxs/ot....Command-line client...LICENSE:...LAGPLv3
+ *   -- otserver......Server Application....LICENSE:....AGPLv3
+ *  Github.com/FellowTraveler/Open-Transactions/wiki/Components
+ *
+ *  All of the above OT components were designed and written by
+ *  Fellow Traveler, with the exception of Moneychanger, which
+ *  was contracted out to Vicky C (bitcointrader4@gmail.com).
+ *  The open-source community has since actively contributed.
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This program is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU Affero
+ *   General Public License as published by the Free Software
+ *   Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   ADDITIONAL PERMISSION under the GNU Affero GPL version 3
+ *   section 7: (This paragraph applies only to the LAGPLv3
+ *   components listed above.) If you modify this Program, or
+ *   any covered work, by linking or combining it with other
+ *   code, such other code is not for that reason alone subject
+ *   to any of the requirements of the GNU Affero GPL version 3.
+ *   (==> This means if you are only using the OT API, then you
+ *   don't have to open-source your code--only your changes to
+ *   Open-Transactions itself must be open source. Similar to
+ *   LGPLv3, except it applies to software-as-a-service, not
+ *   just to distributing binaries.)
+ *
+ *   Extra WAIVER for OpenSSL, Lucre, and all other libraries
+ *   used by Open Transactions: This program is released under
+ *   the AGPL with the additional exemption that compiling,
+ *   linking, and/or using OpenSSL is allowed. The same is true
+ *   for any other open source libraries included in this
+ *   project: complete waiver from the AGPL is hereby granted to
+ *   compile, link, and/or use them with Open-Transactions,
+ *   according to their own terms, as long as the rest of the
+ *   Open-Transactions terms remain respected, with regard to
+ *   the Open-Transactions code itself.
+ *
+ *   Lucre License:
+ *   This code is also "dual-license", meaning that Ben Lau-
+ *   rie's license must also be included and respected, since
+ *   the code for Lucre is also included with Open Transactions.
+ *   See Open-Transactions/src/otlib/lucre/LUCRE_LICENSE.txt
+ *   The Laurie requirements are light, but if there is any
+ *   problem with his license, simply remove the Lucre code.
+ *   Although there are no other blind token algorithms in Open
+ *   Transactions (yet. credlib is coming), the other functions
+ *   will continue to operate.
+ *   See Lucre on Github:  https://github.com/benlaurie/lucre
+ *   -----------------------------------------------------
+ *   You should have received a copy of the GNU Affero General
+ *   Public License along with this program.  If not, see:
+ *   http://www.gnu.org/licenses/
+ *
+ *   If you would like to use this software outside of the free
+ *   software license, please contact FellowTraveler.
+ *   (Unfortunately many will run anonymously and untraceably,
+ *   so who could really stop them?)
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE.  See the GNU Affero General Public License for
+ *   more details.
+
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.9 (Darwin)
+
+ iQIcBAEBAgAGBQJRSsfJAAoJEAMIAO35UbuOQT8P/RJbka8etf7wbxdHQNAY+2cC
+ vDf8J3X8VI+pwMqv6wgTVy17venMZJa4I4ikXD/MRyWV1XbTG0mBXk/7AZk7Rexk
+ KTvL/U1kWiez6+8XXLye+k2JNM6v7eej8xMrqEcO0ZArh/DsLoIn1y8p8qjBI7+m
+ aE7lhstDiD0z8mwRRLKFLN2IH5rAFaZZUvj5ERJaoYUKdn4c+RcQVei2YOl4T0FU
+ LWND3YLoH8naqJXkaOKEN4UfJINCwxhe5Ke9wyfLWLUO7NamRkWD2T7CJ0xocnD1
+ sjAzlVGNgaFDRflfIF4QhBx1Ddl6wwhJfw+d08bjqblSq8aXDkmFA7HeunSFKkdn
+ oIEOEgyj+veuOMRJC5pnBJ9vV+7qRdDKQWaCKotynt4sWJDGQ9kWGWm74SsNaduN
+ TPMyr9kNmGsfR69Q2Zq/FLcLX/j8ESxU+HYUB4vaARw2xEOu2xwDDv6jt0j3Vqsg
+ x7rWv4S/Eh18FDNDkVRChiNoOIilLYLL6c38uMf1pnItBuxP3uhgY6COm59kVaRh
+ nyGTYCDYD2TK+fI9o89F1297uDCwEJ62U0Q7iTDp5QuXCoxkPfv8/kX6lS6T3y9G
+ M9mqIoLbIQ1EDntFv7/t6fUTS2+46uCrdZWbQ5RjYXdrzjij02nDmJAm2BngnZvd
+ kamH0Y/n11lCvo1oQxM+
+ =uSzz
+ -----END PGP SIGNATURE-----
+ **************************************************************/
+
+#ifndef OPENTXS_CLIENT_CMDGETPEERREQUESTS_HPP
+#define OPENTXS_CLIENT_CMDGETPEERREQUESTS_HPP
+
+#include "opentxs/client/commands/CmdBase.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace opentxs
+{
+
+class CmdGetPeerRequests : public CmdBase
+{
+public:
+    EXPORT CmdGetPeerRequests();
+    virtual ~CmdGetPeerRequests();
+
+    EXPORT std::int32_t
+        run(std::string mynym);
+
+protected:
+    virtual std::int32_t runWithOptions();
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CLIENT_CMDGETPEERREQUESTS_HPP

--- a/include/opentxs/client/commands/CmdRequestBailment.hpp
+++ b/include/opentxs/client/commands/CmdRequestBailment.hpp
@@ -1,0 +1,163 @@
+/************************************************************
+ *
+ *  CmdRequestBailment.hpp
+ *
+ */
+
+/************************************************************
+ -----BEGIN PGP SIGNED MESSAGE-----
+ Hash: SHA1
+
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  Copyright (C) 2010-2013 by "Fellow Traveler" (A pseudonym)
+ *
+ *  EMAIL:
+ *  FellowTraveler@rayservers.net
+ *
+ *  BITCOIN:  1NtTPVVjDsUfDWybS4BwvHpG2pdS9RnYyQ
+ *
+ *  KEY FINGERPRINT (PGP Key in license file):
+ *  9DD5 90EB 9292 4B48 0484  7910 0308 00ED F951 BB8E
+ *
+ *  OFFICIAL PROJECT WIKI(s):
+ *  https://github.com/FellowTraveler/Moneychanger
+ *  https://github.com/FellowTraveler/Open-Transactions/wiki
+ *
+ *  WEBSITE:
+ *  http://www.OpenTransactions.org/
+ *
+ *  Components and licensing:
+ *   -- Moneychanger..A Java client GUI.....LICENSE:.....GPLv3
+ *   -- otlib.........A class library.......LICENSE:...LAGPLv3
+ *   -- otapi.........A client API..........LICENSE:...LAGPLv3
+ *   -- opentxs/ot....Command-line client...LICENSE:...LAGPLv3
+ *   -- otserver......Server Application....LICENSE:....AGPLv3
+ *  Github.com/FellowTraveler/Open-Transactions/wiki/Components
+ *
+ *  All of the above OT components were designed and written by
+ *  Fellow Traveler, with the exception of Moneychanger, which
+ *  was contracted out to Vicky C (bitcointrader4@gmail.com).
+ *  The open-source community has since actively contributed.
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This program is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU Affero
+ *   General Public License as published by the Free Software
+ *   Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   ADDITIONAL PERMISSION under the GNU Affero GPL version 3
+ *   section 7: (This paragraph applies only to the LAGPLv3
+ *   components listed above.) If you modify this Program, or
+ *   any covered work, by linking or combining it with other
+ *   code, such other code is not for that reason alone subject
+ *   to any of the requirements of the GNU Affero GPL version 3.
+ *   (==> This means if you are only using the OT API, then you
+ *   don't have to open-source your code--only your changes to
+ *   Open-Transactions itself must be open source. Similar to
+ *   LGPLv3, except it applies to software-as-a-service, not
+ *   just to distributing binaries.)
+ *
+ *   Extra WAIVER for OpenSSL, Lucre, and all other libraries
+ *   used by Open Transactions: This program is released under
+ *   the AGPL with the additional exemption that compiling,
+ *   linking, and/or using OpenSSL is allowed. The same is true
+ *   for any other open source libraries included in this
+ *   project: complete waiver from the AGPL is hereby granted to
+ *   compile, link, and/or use them with Open-Transactions,
+ *   according to their own terms, as long as the rest of the
+ *   Open-Transactions terms remain respected, with regard to
+ *   the Open-Transactions code itself.
+ *
+ *   Lucre License:
+ *   This code is also "dual-license", meaning that Ben Lau-
+ *   rie's license must also be included and respected, since
+ *   the code for Lucre is also included with Open Transactions.
+ *   See Open-Transactions/src/otlib/lucre/LUCRE_LICENSE.txt
+ *   The Laurie requirements are light, but if there is any
+ *   problem with his license, simply remove the Lucre code.
+ *   Although there are no other blind token algorithms in Open
+ *   Transactions (yet. credlib is coming), the other functions
+ *   will continue to operate.
+ *   See Lucre on Github:  https://github.com/benlaurie/lucre
+ *   -----------------------------------------------------
+ *   You should have received a copy of the GNU Affero General
+ *   Public License along with this program.  If not, see:
+ *   http://www.gnu.org/licenses/
+ *
+ *   If you would like to use this software outside of the free
+ *   software license, please contact FellowTraveler.
+ *   (Unfortunately many will run anonymously and untraceably,
+ *   so who could really stop them?)
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE.  See the GNU Affero General Public License for
+ *   more details.
+
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.9 (Darwin)
+
+ iQIcBAEBAgAGBQJRSsfJAAoJEAMIAO35UbuOQT8P/RJbka8etf7wbxdHQNAY+2cC
+ vDf8J3X8VI+pwMqv6wgTVy17venMZJa4I4ikXD/MRyWV1XbTG0mBXk/7AZk7Rexk
+ KTvL/U1kWiez6+8XXLye+k2JNM6v7eej8xMrqEcO0ZArh/DsLoIn1y8p8qjBI7+m
+ aE7lhstDiD0z8mwRRLKFLN2IH5rAFaZZUvj5ERJaoYUKdn4c+RcQVei2YOl4T0FU
+ LWND3YLoH8naqJXkaOKEN4UfJINCwxhe5Ke9wyfLWLUO7NamRkWD2T7CJ0xocnD1
+ sjAzlVGNgaFDRflfIF4QhBx1Ddl6wwhJfw+d08bjqblSq8aXDkmFA7HeunSFKkdn
+ oIEOEgyj+veuOMRJC5pnBJ9vV+7qRdDKQWaCKotynt4sWJDGQ9kWGWm74SsNaduN
+ TPMyr9kNmGsfR69Q2Zq/FLcLX/j8ESxU+HYUB4vaARw2xEOu2xwDDv6jt0j3Vqsg
+ x7rWv4S/Eh18FDNDkVRChiNoOIilLYLL6c38uMf1pnItBuxP3uhgY6COm59kVaRh
+ nyGTYCDYD2TK+fI9o89F1297uDCwEJ62U0Q7iTDp5QuXCoxkPfv8/kX6lS6T3y9G
+ M9mqIoLbIQ1EDntFv7/t6fUTS2+46uCrdZWbQ5RjYXdrzjij02nDmJAm2BngnZvd
+ kamH0Y/n11lCvo1oQxM+
+ =uSzz
+ -----END PGP SIGNATURE-----
+ **************************************************************/
+
+#ifndef OPENTXS_CLIENT_CMDREQUESTBAILMENT_HPP
+#define OPENTXS_CLIENT_CMDREQUESTBAILMENT_HPP
+
+#include "opentxs/client/commands/CmdBase.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace opentxs
+{
+
+class CmdRequestBailment : public CmdBase
+{
+public:
+    EXPORT CmdRequestBailment();
+    virtual ~CmdRequestBailment();
+
+    EXPORT std::int32_t
+        run(
+            std::string server,
+            std::string mynym,
+            std::string hisnym,
+            std::string mypurse);
+
+protected:
+    virtual std::int32_t runWithOptions();
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CLIENT_CMDREQUESTBAILMENT_HPP

--- a/include/opentxs/client/commands/CmdRequestOutBailment.hpp
+++ b/include/opentxs/client/commands/CmdRequestOutBailment.hpp
@@ -1,0 +1,163 @@
+/************************************************************
+ *
+ *  CmdRequestOutBailment.hpp
+ *
+ */
+
+/************************************************************
+ -----BEGIN PGP SIGNED MESSAGE-----
+ Hash: SHA1
+
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  Copyright (C) 2010-2013 by "Fellow Traveler" (A pseudonym)
+ *
+ *  EMAIL:
+ *  FellowTraveler@rayservers.net
+ *
+ *  BITCOIN:  1NtTPVVjDsUfDWybS4BwvHpG2pdS9RnYyQ
+ *
+ *  KEY FINGERPRINT (PGP Key in license file):
+ *  9DD5 90EB 9292 4B48 0484  7910 0308 00ED F951 BB8E
+ *
+ *  OFFICIAL PROJECT WIKI(s):
+ *  https://github.com/FellowTraveler/Moneychanger
+ *  https://github.com/FellowTraveler/Open-Transactions/wiki
+ *
+ *  WEBSITE:
+ *  http://www.OpenTransactions.org/
+ *
+ *  Components and licensing:
+ *   -- Moneychanger..A Java client GUI.....LICENSE:.....GPLv3
+ *   -- otlib.........A class library.......LICENSE:...LAGPLv3
+ *   -- otapi.........A client API..........LICENSE:...LAGPLv3
+ *   -- opentxs/ot....Command-line client...LICENSE:...LAGPLv3
+ *   -- otserver......Server Application....LICENSE:....AGPLv3
+ *  Github.com/FellowTraveler/Open-Transactions/wiki/Components
+ *
+ *  All of the above OT components were designed and written by
+ *  Fellow Traveler, with the exception of Moneychanger, which
+ *  was contracted out to Vicky C (bitcointrader4@gmail.com).
+ *  The open-source community has since actively contributed.
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This program is free software: you can redistribute it
+ *   and/or modify it under the terms of the GNU Affero
+ *   General Public License as published by the Free Software
+ *   Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   ADDITIONAL PERMISSION under the GNU Affero GPL version 3
+ *   section 7: (This paragraph applies only to the LAGPLv3
+ *   components listed above.) If you modify this Program, or
+ *   any covered work, by linking or combining it with other
+ *   code, such other code is not for that reason alone subject
+ *   to any of the requirements of the GNU Affero GPL version 3.
+ *   (==> This means if you are only using the OT API, then you
+ *   don't have to open-source your code--only your changes to
+ *   Open-Transactions itself must be open source. Similar to
+ *   LGPLv3, except it applies to software-as-a-service, not
+ *   just to distributing binaries.)
+ *
+ *   Extra WAIVER for OpenSSL, Lucre, and all other libraries
+ *   used by Open Transactions: This program is released under
+ *   the AGPL with the additional exemption that compiling,
+ *   linking, and/or using OpenSSL is allowed. The same is true
+ *   for any other open source libraries included in this
+ *   project: complete waiver from the AGPL is hereby granted to
+ *   compile, link, and/or use them with Open-Transactions,
+ *   according to their own terms, as long as the rest of the
+ *   Open-Transactions terms remain respected, with regard to
+ *   the Open-Transactions code itself.
+ *
+ *   Lucre License:
+ *   This code is also "dual-license", meaning that Ben Lau-
+ *   rie's license must also be included and respected, since
+ *   the code for Lucre is also included with Open Transactions.
+ *   See Open-Transactions/src/otlib/lucre/LUCRE_LICENSE.txt
+ *   The Laurie requirements are light, but if there is any
+ *   problem with his license, simply remove the Lucre code.
+ *   Although there are no other blind token algorithms in Open
+ *   Transactions (yet. credlib is coming), the other functions
+ *   will continue to operate.
+ *   See Lucre on Github:  https://github.com/benlaurie/lucre
+ *   -----------------------------------------------------
+ *   You should have received a copy of the GNU Affero General
+ *   Public License along with this program.  If not, see:
+ *   http://www.gnu.org/licenses/
+ *
+ *   If you would like to use this software outside of the free
+ *   software license, please contact FellowTraveler.
+ *   (Unfortunately many will run anonymously and untraceably,
+ *   so who could really stop them?)
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE.  See the GNU Affero General Public License for
+ *   more details.
+
+ -----BEGIN PGP SIGNATURE-----
+ Version: GnuPG v1.4.9 (Darwin)
+
+ iQIcBAEBAgAGBQJRSsfJAAoJEAMIAO35UbuOQT8P/RJbka8etf7wbxdHQNAY+2cC
+ vDf8J3X8VI+pwMqv6wgTVy17venMZJa4I4ikXD/MRyWV1XbTG0mBXk/7AZk7Rexk
+ KTvL/U1kWiez6+8XXLye+k2JNM6v7eej8xMrqEcO0ZArh/DsLoIn1y8p8qjBI7+m
+ aE7lhstDiD0z8mwRRLKFLN2IH5rAFaZZUvj5ERJaoYUKdn4c+RcQVei2YOl4T0FU
+ LWND3YLoH8naqJXkaOKEN4UfJINCwxhe5Ke9wyfLWLUO7NamRkWD2T7CJ0xocnD1
+ sjAzlVGNgaFDRflfIF4QhBx1Ddl6wwhJfw+d08bjqblSq8aXDkmFA7HeunSFKkdn
+ oIEOEgyj+veuOMRJC5pnBJ9vV+7qRdDKQWaCKotynt4sWJDGQ9kWGWm74SsNaduN
+ TPMyr9kNmGsfR69Q2Zq/FLcLX/j8ESxU+HYUB4vaARw2xEOu2xwDDv6jt0j3Vqsg
+ x7rWv4S/Eh18FDNDkVRChiNoOIilLYLL6c38uMf1pnItBuxP3uhgY6COm59kVaRh
+ nyGTYCDYD2TK+fI9o89F1297uDCwEJ62U0Q7iTDp5QuXCoxkPfv8/kX6lS6T3y9G
+ M9mqIoLbIQ1EDntFv7/t6fUTS2+46uCrdZWbQ5RjYXdrzjij02nDmJAm2BngnZvd
+ kamH0Y/n11lCvo1oQxM+
+ =uSzz
+ -----END PGP SIGNATURE-----
+ **************************************************************/
+
+#ifndef OPENTXS_CLIENT_CMDREQUESTOUTBAILMENT_HPP
+#define OPENTXS_CLIENT_CMDREQUESTOUTBAILMENT_HPP
+
+#include "opentxs/client/commands/CmdBase.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace opentxs
+{
+
+class CmdRequestOutBailment : public CmdBase
+{
+public:
+    EXPORT CmdRequestOutBailment();
+    virtual ~CmdRequestOutBailment();
+
+    EXPORT std::int32_t
+        run(
+            std::string server,
+            std::string mynym,
+            std::string hisnym,
+            std::string mypurse);
+
+protected:
+    virtual std::int32_t runWithOptions();
+};
+
+} // namespace opentxs
+
+#endif // OPENTXS_CLIENT_CMDREQUESTOUTBAILMENT_HPP

--- a/include/opentxs/client/ot_otapi_ot.hpp
+++ b/include/opentxs/client/ot_otapi_ot.hpp
@@ -140,6 +140,10 @@ typedef enum {
     GET_MINT = 30,
     GET_BOX_RECEIPT = 32,
     ADJUST_USAGE_CREDITS = 33,
+    INITIATE_BAILMENT = 34,
+    INITIATE_OUTBAILMENT = 35,
+    ACKNOWLEDGE_BAILMENT = 36,
+    ACKNOWLEDGE_OUTBAILMENT = 37,
 } OTAPI_Func_Type;
 
 class the_lambda_struct

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -927,6 +927,8 @@ public:
     bool Sign(proto::ServerContract& contract) const;
     bool Sign(const proto::UnitDefinition& contract, proto::Signature& sig)
         const;
+    bool Sign(const proto::PeerRequest& contract, proto::Signature& sig) const;
+    bool Sign(const proto::PeerReply& contract, proto::Signature& sig) const;
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;
     bool Verify(const proto::Verification& item) const;
     zcert_t* TransportKey() const;

--- a/include/opentxs/core/Proto.hpp
+++ b/include/opentxs/core/Proto.hpp
@@ -43,6 +43,7 @@
 #include <opentxs-proto/verify/VerifyContacts.hpp>
 #include <opentxs-proto/verify/VerifyContracts.hpp>
 #include <opentxs-proto/verify/VerifyCredentials.hpp>
+#include <opentxs-proto/verify/VerifyPeer.hpp>
 #include <opentxs-proto/verify/VerifyStorage.hpp>
 // IWYU pragma: end_exports
 

--- a/include/opentxs/core/Types.hpp
+++ b/include/opentxs/core/Types.hpp
@@ -64,10 +64,27 @@ typedef std::tuple<
  */
 typedef std::set<Claim> ClaimSet;
 
+/** A list of object IDs and their associated aliases
+    *  * string: id of the stored object
+    *  * string: alias of the stored object
+    */
+typedef std::list<std::pair<std::string, std::string>> ObjectList;
+
 enum class ClaimPolarity : std::uint8_t {
     NEUTRAL  = 0,
     POSITIVE = 1,
     NEGATIVE = 2
+};
+
+enum class StorageBox : std::uint8_t {
+    SENTPEERREQUEST  = 0,
+    INCOMINGPEERREQUEST = 1,
+    SENTPEERREPLY = 2,
+    INCOMINGPEERREPLY = 3,
+    FINISHEDPEERREQUEST = 4,
+    FINISHEDPEERREPLY = 5,
+    PROCESSEDPEERREQUEST = 6,
+    PROCESSEDPEERREPLY = 7
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/app/Wallet.hpp
+++ b/include/opentxs/core/app/Wallet.hpp
@@ -40,6 +40,7 @@
 #define OPENTXS_CORE_APP_WALLET_HPP
 
 #include "opentxs/core/Nym.hpp"
+#include "opentxs/core/Types.hpp"
 #include "opentxs/core/contract/ServerContract.hpp"
 #include "opentxs/core/contract/UnitDefinition.hpp"
 #include "opentxs/storage/Storage.hpp"
@@ -217,7 +218,7 @@ public:
 
     /**   Returns a list of all available server contracts and their aliases
      */
-    Storage::ObjectList ServerList();
+    ObjectList ServerList();
 
     /**   Updates the alias for the specified nym.
      *
@@ -255,7 +256,7 @@ public:
     /**   Obtain a list of all available unit definition contracts and their
      *    aliases
      */
-    Storage::ObjectList UnitDefinitionList();
+    ObjectList UnitDefinitionList();
 
     /**   Obtain a smart pointer to an instantiated unit definition contract.
      *

--- a/include/opentxs/core/app/Wallet.hpp
+++ b/include/opentxs/core/app/Wallet.hpp
@@ -147,6 +147,158 @@ public:
      */
     ConstNym Nym(const proto::CredentialIndex& nym);
 
+    /**   Load a peer reply object
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the identifier of the peer reply object
+     *    \param[in] box the box from which to retrive the peer object
+     *    \returns A smart pointer to the object. The smart pointer will not be
+     *             instantiated if the object does not exist or is invalid.
+     */
+    std::shared_ptr<proto::PeerReply> PeerReply(
+        const Identifier& nym,
+        const Identifier& reply,
+        const StorageBox& box) const;
+
+    /**   Clean up the recipient's copy of a peer reply
+     *
+     *    The peer reply is moved from the nym's SentPeerReply
+     *    box to the FinishedPeerReply box.
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] reply the identifier of the peer reply object
+     *    \returns true if the request is successfully stored
+     */
+    bool PeerReplyComplete(
+        const Identifier& nym,
+        const Identifier& reply);
+
+    /**   Store the recipient's copy of a peer reply
+     *
+     *    The peer reply is stored in the SendPeerReply box for the
+     *    specified nym.
+     *
+     *    The corresponding request is moved from the nym's IncomingPeerRequest
+     *    box to the ProcessedPeerRequest box.
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the identifier of the corresponding request
+     *    \param[in] reply the serialized peer reply object
+     *    \returns true if the request is successfully stored
+     */
+    bool PeerReplyCreate(
+        const Identifier& nym,
+        const Identifier& request,
+        const proto::PeerReply& reply);
+
+    /**   Rollback a PeerReplyCreate call
+     *
+     *    The original request is returned to IncomingPeerRequest box
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the identifier of the corresponding request
+     *    \param[in] reply the identifier of the peer reply object
+     *    \returns true if the rollback is successful
+     */
+    bool PeerReplyCreateRollback(
+        const Identifier& nym,
+        const Identifier& request,
+        const Identifier& reply);
+
+    /**   Obtain a list of incoming peer replies
+     *
+     *    \param[in] nym the identifier of the nym whose box is returned
+     */
+    ObjectList PeerReplyIncoming(const Identifier& nym) const;
+
+    /**   Store the senders's copy of a peer reply
+     *
+     *    The peer reply is stored in the IncomingPeerReply box for the
+     *    specified nym.
+     *
+     *    The corresponding request is moved from the nym's SentPeerRequest
+     *    box to the FinishedPeerRequest box.
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the identifier of the corresponding request
+     *    \param[in] reply the serialized peer reply object
+     *    \returns true if the request is successfully stored
+     */
+    bool PeerReplyReceive(
+        const Identifier& nym,
+        const Identifier& request,
+        const proto::PeerReply& reply);
+
+    /**   Load a peer reply object
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the identifier of the peer reply object
+     *    \param[in] box the box from which to retrive the peer object
+     *    \returns A smart pointer to the object. The smart pointer will not be
+     *             instantiated if the object does not exist or is invalid.
+     */
+    std::shared_ptr<proto::PeerRequest> PeerRequest(
+        const Identifier& nym,
+        const Identifier& request,
+        const StorageBox& box) const;
+
+    /**   Clean up the sender's copy of a peer reply
+     *
+     *    The peer reply is moved from the nym's IncomingPeerReply
+     *    box to the ProcessedPeerReply box.
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] reply the identifier of the peer reply object
+     *    \returns true if the request is successfully moved
+     */
+    bool PeerRequestComplete(
+        const Identifier& nym,
+        const Identifier& reply);
+
+    /**   Store the initiator's copy of a peer request
+     *
+     *    The peer request is stored in the SentPeerRequest box for the
+     *    specified nym.
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the serialized peer request object
+     *    \returns true if the request is successfully stored
+     */
+    bool PeerRequestCreate(
+        const Identifier& nym,
+        const proto::PeerRequest& request);
+
+    /**   Rollback a PeerRequestCreate call
+     *
+     *    The request is deleted from to SentPeerRequest box
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the identifier of the peer request
+     *    \returns true if the rollback is successful
+     */
+    bool PeerRequestCreateRollback(
+        const Identifier& nym,
+        const Identifier& request);
+
+    /**   Obtain a list of incoming peer requests
+     *
+     *    \param[in] nym the identifier of the nym whose box is returned
+     */
+    ObjectList PeerRequestIncoming(const Identifier& nym) const;
+
+    /**   Store the recipient's copy of a peer request
+     *
+     *    The peer request is stored in the IncomingPeerRequest box for the
+     *    specified nym.
+     *
+     *    \param[in] nym the identifier of the nym who owns the object
+     *    \param[in] request the serialized peer request object
+     *    \returns true if the request is successfully stored
+     */
+    bool PeerRequestReceive(
+        const Identifier& nym,
+        const proto::PeerRequest& request);
+
     /**   Unload and delete a server contract
      *
      *    This method destroys the contract object, removes it from the

--- a/include/opentxs/core/contract/peer/BailmentReply.hpp
+++ b/include/opentxs/core/contract/peer/BailmentReply.hpp
@@ -1,0 +1,75 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CONTRACT_PEER_BAILMENTREPLY_HPP
+#define OPENTXS_CORE_CONTRACT_PEER_BAILMENTREPLY_HPP
+
+#include "opentxs/core/contract/peer/PeerReply.hpp"
+
+#include "opentxs/core/Identifier.hpp"
+
+#include <string>
+
+namespace opentxs
+{
+
+class BailmentReply : public PeerReply
+{
+private:
+    typedef PeerReply ot_super;
+    friend class PeerReply;
+
+    proto::PeerReply IDVersion() const override;
+
+    BailmentReply(
+        const ConstNym& nym,
+        const proto::PeerReply& serialized);
+    BailmentReply(
+        const ConstNym& nym,
+        const Identifier& initiator,
+        const Identifier& request,
+        const std::string& terms);
+    BailmentReply() = delete;
+
+public:
+
+    ~BailmentReply() = default;
+};
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CONTRACT_PEER_BAILMENTREPLY_HPP

--- a/include/opentxs/core/contract/peer/BailmentRequest.hpp
+++ b/include/opentxs/core/contract/peer/BailmentRequest.hpp
@@ -1,0 +1,76 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CONTRACT_PEER_BAILMENTREQUEST_HPP
+#define OPENTXS_CORE_CONTRACT_PEER_BAILMENTREQUEST_HPP
+
+#include "opentxs/core/contract/peer/PeerRequest.hpp"
+
+#include "opentxs/core/Identifier.hpp"
+
+namespace opentxs
+{
+
+class BailmentRequest : public PeerRequest
+{
+private:
+    typedef PeerRequest ot_super;
+    friend class PeerRequest;
+
+    Identifier unit_;
+    Identifier server_;
+
+    proto::PeerRequest IDVersion() const override;
+
+    BailmentRequest(
+        const ConstNym& nym,
+        const proto::PeerRequest& serialized);
+    BailmentRequest(
+        const ConstNym& nym,
+        const Identifier& recipientID,
+        const Identifier& unitID,
+        const Identifier& serverID);
+    BailmentRequest() = delete;
+
+public:
+
+    ~BailmentRequest() = default;
+};
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CONTRACT_PEER_BAILMENTREQUEST_HPP

--- a/include/opentxs/core/contract/peer/OutBailmentReply.hpp
+++ b/include/opentxs/core/contract/peer/OutBailmentReply.hpp
@@ -1,0 +1,75 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CONTRACT_PEER_OUTBAILMENTREPLY_HPP
+#define OPENTXS_CORE_CONTRACT_PEER_OUTBAILMENTREPLY_HPP
+
+#include "opentxs/core/contract/peer/PeerReply.hpp"
+
+#include "opentxs/core/Identifier.hpp"
+
+#include <string>
+
+namespace opentxs
+{
+
+class OutBailmentReply : public PeerReply
+{
+private:
+    typedef PeerReply ot_super;
+    friend class PeerReply;
+
+    proto::PeerReply IDVersion() const override;
+
+    OutBailmentReply(
+        const ConstNym& nym,
+        const proto::PeerReply& serialized);
+    OutBailmentReply(
+        const ConstNym& nym,
+        const Identifier& initiator,
+        const Identifier& request,
+        const std::string& terms);
+    OutBailmentReply() = delete;
+
+public:
+
+    ~OutBailmentReply() = default;
+};
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CONTRACT_PEER_OUTBAILMENTREPLY_HPP

--- a/include/opentxs/core/contract/peer/OutBailmentRequest.hpp
+++ b/include/opentxs/core/contract/peer/OutBailmentRequest.hpp
@@ -1,0 +1,77 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CONTRACT_PEER_OUTBAILMENTREQUEST_HPP
+#define OPENTXS_CORE_CONTRACT_PEER_OUTBAILMENTREQUEST_HPP
+
+#include "opentxs/core/contract/peer/PeerRequest.hpp"
+
+#include "opentxs/core/Identifier.hpp"
+
+namespace opentxs
+{
+
+class OutBailmentRequest : public PeerRequest
+{
+private:
+    typedef PeerRequest ot_super;
+    friend class PeerRequest;
+
+    Identifier unit_;
+    Identifier server_;
+
+    proto::PeerRequest IDVersion() const override;
+
+    OutBailmentRequest(
+        const ConstNym& nym,
+        const proto::PeerRequest& serialized);
+    OutBailmentRequest(
+        const ConstNym& nym,
+        const Identifier& recipientID,
+        const Identifier& unitID,
+        const Identifier& serverID,
+        const std::string& terms);
+    OutBailmentRequest() = delete;
+
+public:
+
+    ~OutBailmentRequest() = default;
+};
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CONTRACT_PEER_OUTBAILMENTREQUEST_HPP

--- a/include/opentxs/core/contract/peer/PeerObject.hpp
+++ b/include/opentxs/core/contract/peer/PeerObject.hpp
@@ -60,8 +60,8 @@ private:
     std::unique_ptr<std::string> message_;
     std::unique_ptr<PeerReply> reply_;
     std::unique_ptr<PeerRequest> request_;
-    proto::PeerObjectType type_;
-    std::uint32_t version_;
+    proto::PeerObjectType type_{proto::PEEROBJECT_ERROR};
+    std::uint32_t version_{};
 
     PeerObject(const ConstNym& nym, const proto::PeerObject serialized);
     PeerObject(const std::string& message);

--- a/include/opentxs/core/contract/peer/PeerObject.hpp
+++ b/include/opentxs/core/contract/peer/PeerObject.hpp
@@ -41,6 +41,10 @@
 
 #include "opentxs/core/Proto.hpp"
 
+#include "opentxs/core/contract/Signable.hpp"
+#include "opentxs/core/contract/peer/PeerReply.hpp"
+#include "opentxs/core/contract/peer/PeerRequest.hpp"
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -54,15 +58,28 @@ class PeerObject
 {
 private:
     std::unique_ptr<std::string> message_;
+    std::unique_ptr<PeerReply> reply_;
+    std::unique_ptr<PeerRequest> request_;
     proto::PeerObjectType type_;
     std::uint32_t version_;
 
-    PeerObject(const proto::PeerObject serialized);
+    PeerObject(const ConstNym& nym, const proto::PeerObject serialized);
     PeerObject(const std::string& message);
+    PeerObject(
+        std::unique_ptr<PeerRequest>& request,
+        std::unique_ptr<PeerReply>& reply);
+    PeerObject(std::unique_ptr<PeerRequest>& request);
+    PeerObject() = delete;
 
 public:
     static std::unique_ptr<PeerObject> Create(const std::string& message);
+    static std::unique_ptr<PeerObject> Create(
+        std::unique_ptr<PeerRequest>& request,
+        std::unique_ptr<PeerReply>& reply);
+    static std::unique_ptr<PeerObject> Create(
+        std::unique_ptr<PeerRequest>& request);
     static std::unique_ptr<PeerObject> Factory(
+        const ConstNym& nym,
         const proto::PeerObject& serialized);
     static std::unique_ptr<PeerObject> Factory(
         const ConstNym& recipientNym,

--- a/include/opentxs/core/contract/peer/PeerObject.hpp
+++ b/include/opentxs/core/contract/peer/PeerObject.hpp
@@ -1,0 +1,81 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CONTRACT_PEER_PEEROBJECT_HPP
+#define OPENTXS_CORE_CONTRACT_PEER_PEEROBJECT_HPP
+
+#include "opentxs/core/Proto.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace opentxs
+{
+
+class OTASCIIArmor;
+
+class PeerObject
+{
+private:
+    std::unique_ptr<std::string> message_;
+    proto::PeerObjectType type_;
+    std::uint32_t version_;
+
+    PeerObject(const proto::PeerObject serialized);
+    PeerObject(const std::string& message);
+
+public:
+    static std::unique_ptr<PeerObject> Create(const std::string& message);
+    static std::unique_ptr<PeerObject> Factory(
+        const proto::PeerObject& serialized);
+    static std::unique_ptr<PeerObject> Factory(
+        const ConstNym& recipientNym,
+        const ConstNym& senderNym,
+        const OTASCIIArmor& encrypted);
+
+    std::unique_ptr<std::string>& Message() { return message_; }
+    proto::PeerObject Serialize() const;
+    proto::PeerObjectType Type() const { return type_; }
+    bool Validate() const;
+
+    ~PeerObject() = default;
+};
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CONTRACT_PEER_PEEROBJECT_HPP

--- a/include/opentxs/core/contract/peer/PeerReply.hpp
+++ b/include/opentxs/core/contract/peer/PeerReply.hpp
@@ -1,0 +1,105 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CONTRACT_PEER_PEERREPLY_HPP
+#define OPENTXS_CORE_CONTRACT_PEER_PEERREPLY_HPP
+
+#include "opentxs/core/Identifier.hpp"
+#include "opentxs/core/OTData.hpp"
+#include "opentxs/core/Proto.hpp"
+#include "opentxs/core/contract/Signable.hpp"
+
+#include <string>
+
+namespace opentxs
+{
+
+class PeerReply : public Signable
+{
+private:
+    typedef Signable ot_super;
+
+    Identifier initiator_;
+    Identifier recipient_;
+    Identifier cookie_;
+    proto::PeerRequestType type_;
+
+    static Identifier GetID(const proto::PeerReply& contract);
+    static bool FinalizeContract(PeerReply& contract);
+
+    Identifier GetID() const override;
+    proto::PeerReply SigVersion() const;
+
+    PeerReply() = delete;
+
+protected:
+
+    virtual proto::PeerReply IDVersion() const;
+
+    PeerReply(
+        const ConstNym& nym,
+        const proto::PeerReply& serialized);
+    PeerReply(
+        const ConstNym& nym,
+        const Identifier& initiator,
+        const proto::PeerRequestType& type,
+        const Identifier& request);
+
+public:
+    static PeerReply* Create(
+        const ConstNym& nym,
+        const proto::PeerRequestType& type,
+        const Identifier& request,
+        const std::string& terms);
+    static PeerReply* Factory(
+        const ConstNym& nym,
+        const proto::PeerReply& serialized);
+
+    std::string Alias() const override { return Name(); }
+    proto::PeerReply Contract() const;
+    std::string Name() const override;
+    OTData Serialize() const override;
+    const proto::PeerRequestType& Type() const { return type_; }
+    void SetAlias(__attribute__((unused)) std::string alias) override {}
+    bool Validate() const override;
+
+    ~PeerReply() = default;
+};
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CONTRACT_PEER_PEERREPLY_HPP

--- a/include/opentxs/core/contract/peer/PeerReply.hpp
+++ b/include/opentxs/core/contract/peer/PeerReply.hpp
@@ -57,7 +57,7 @@ private:
     Identifier initiator_;
     Identifier recipient_;
     Identifier cookie_;
-    proto::PeerRequestType type_;
+    proto::PeerRequestType type_{proto::PEERREQUEST_ERROR};
 
     static Identifier GetID(const proto::PeerReply& contract);
     static bool FinalizeContract(PeerReply& contract);

--- a/include/opentxs/core/contract/peer/PeerRequest.hpp
+++ b/include/opentxs/core/contract/peer/PeerRequest.hpp
@@ -1,0 +1,112 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CORE_CONTRACT_PEER_PEERREQUEST_HPP
+#define OPENTXS_CORE_CONTRACT_PEER_PEERREQUEST_HPP
+
+#include "opentxs/core/Identifier.hpp"
+#include "opentxs/core/OTData.hpp"
+#include "opentxs/core/Proto.hpp"
+#include "opentxs/core/contract/Signable.hpp"
+
+#include <string>
+
+namespace opentxs
+{
+
+class PeerRequest : public Signable
+{
+private:
+    typedef Signable ot_super;
+
+    Identifier initiator_;
+    Identifier recipient_;
+    Identifier cookie_;
+    proto::PeerRequestType type_;
+
+    static Identifier GetID(const proto::PeerRequest& contract);
+    static bool FinalizeContract(PeerRequest& contract);
+
+    Identifier GetID() const override;
+    proto::PeerRequest SigVersion() const;
+
+    PeerRequest() = delete;
+
+protected:
+
+    virtual proto::PeerRequest IDVersion() const;
+
+    PeerRequest(
+        const ConstNym& nym,
+        const proto::PeerRequest& serialized);
+    PeerRequest(
+        const ConstNym& nym,
+        const Identifier& recipient,
+        const proto::PeerRequestType& type);
+
+public:
+    static PeerRequest* Create(
+        const ConstNym& nym,
+        const proto::PeerRequestType& type,
+        const Identifier& unitID,
+        const Identifier& serverID);
+    static PeerRequest* Create(
+        const ConstNym& nym,
+        const proto::PeerRequestType& type,
+        const Identifier& unitID,
+        const Identifier& serverID,
+        const std::string& terms);
+    static PeerRequest* Factory(
+        const ConstNym& nym,
+        const proto::PeerRequest& serialized);
+
+    std::string Alias() const override { return Name(); }
+    proto::PeerRequest Contract() const;
+    const Identifier& Initiator() const { return initiator_; }
+    std::string Name() const override;
+    const Identifier& Recipient() const { return recipient_; }
+    OTData Serialize() const override;
+    const proto::PeerRequestType& Type() const { return type_; }
+    void SetAlias(__attribute__((unused)) std::string alias) override {}
+    bool Validate() const override;
+
+    ~PeerRequest() = default;
+};
+} // namespace opentxs
+
+#endif // OPENTXS_CORE_CONTRACT_PEER_PEERREQUEST_HPP

--- a/include/opentxs/core/contract/peer/PeerRequest.hpp
+++ b/include/opentxs/core/contract/peer/PeerRequest.hpp
@@ -57,7 +57,7 @@ private:
     Identifier initiator_;
     Identifier recipient_;
     Identifier cookie_;
-    proto::PeerRequestType type_;
+    proto::PeerRequestType type_{proto::PEERREQUEST_ERROR};
 
     static Identifier GetID(const proto::PeerRequest& contract);
     static bool FinalizeContract(PeerRequest& contract);

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -13,6 +13,8 @@ set(cxx-sources
   commands/CmdAcceptPayments.cpp
   commands/CmdAcceptReceipts.cpp
   commands/CmdAcceptTransfers.cpp
+  commands/CmdAcknowledgeBailment.cpp
+  commands/CmdAcknowledgeOutBailment.cpp
   commands/CmdAddAsset.cpp
   commands/CmdAddServer.cpp
   commands/CmdAddSignature.cpp
@@ -45,6 +47,8 @@ set(cxx-sources
   commands/CmdGetMarkets.cpp
   commands/CmdGetMyOffers.cpp
   commands/CmdGetOffers.cpp
+  commands/CmdGetPeerReplies.cpp
+  commands/CmdGetPeerRequests.cpp
   commands/CmdGetReceipt.cpp
   commands/CmdImportCash.cpp
   commands/CmdImportNym.cpp
@@ -61,6 +65,7 @@ set(cxx-sources
   commands/CmdNewNymECDSA.cpp
   commands/CmdNewNymLegacy.cpp
   commands/CmdNewOffer.cpp
+  commands/CmdRequestOutBailment.cpp
   commands/CmdOutbox.cpp
   commands/CmdOutmail.cpp
   commands/CmdOutpayment.cpp
@@ -73,6 +78,7 @@ set(cxx-sources
   commands/CmdRefreshAccount.cpp
   commands/CmdRefreshNym.cpp
   commands/CmdRegisterNym.cpp
+  commands/CmdRequestBailment.cpp
   commands/CmdSendCash.cpp
   commands/CmdSendCheque.cpp
   commands/CmdSendInvoice.cpp

--- a/src/client/OTAPI.cpp
+++ b/src/client/OTAPI.cpp
@@ -50,7 +50,11 @@
 #include "opentxs/core/util/Common.hpp"
 
 #include <stdint.h>
+#include <algorithm>
+#include <iostream>
+#include <iterator>
 #include <ostream>
+#include <sstream>
 #include <string>
 
 namespace opentxs
@@ -2167,6 +2171,120 @@ int32_t OTAPI_Wrap::sendNymMessage(const std::string& NOTARY_ID,
 {
     return Exec()->sendNymMessage(NOTARY_ID, NYM_ID, NYM_ID_RECIPIENT,
                                   THE_MESSAGE);
+}
+
+int32_t OTAPI_Wrap::initiateBailment(
+    const std::string& serverID,
+    const std::string& senderNymID,
+    const std::string& recipientNymID,
+    const std::string& unitID)
+{
+    return Exec()->
+        initiateBailment(serverID, senderNymID, recipientNymID, unitID);
+}
+
+int32_t OTAPI_Wrap::initiateOutBailment(
+    const std::string& serverID,
+    const std::string& senderNymID,
+    const std::string& recipientNymID,
+    const std::string& unitID,
+    const std::string& terms)
+{
+    return Exec()->initiateOutBailment
+        (serverID, senderNymID, recipientNymID, unitID, terms);
+}
+
+int32_t OTAPI_Wrap::acknowledgeBailment(
+    const std::string& serverID,
+    const std::string& senderNymID,
+    const std::string& recipientNymID,
+    const std::string& requestID,
+    const std::string& terms)
+{
+    return Exec()->acknowledgeBailment
+        (serverID, senderNymID, recipientNymID, requestID, terms);
+}
+
+int32_t OTAPI_Wrap::acknowledgeOutBailment(
+    const std::string& serverID,
+    const std::string& senderNymID,
+    const std::string& recipientNymID,
+    const std::string& requestID,
+    const std::string& terms)
+{
+    return Exec()->acknowledgeOutBailment
+        (serverID, senderNymID, recipientNymID, requestID, terms);
+}
+
+int32_t OTAPI_Wrap::completePeerReply(
+    const std::string& nymID,
+    const std::string& replyID)
+{
+    return Exec()->completePeerReply
+        (nymID, replyID);
+}
+
+int32_t OTAPI_Wrap::completePeerRequest(
+    const std::string& nymID,
+    const std::string& requestID)
+{
+    return Exec()->completePeerRequest
+        (nymID, requestID);
+}
+
+std::string OTAPI_Wrap::getIncomingRequests(const std::string& nymID)
+{
+    auto list = Exec()->getIncomingRequests(nymID);
+
+    std::ostringstream stream;
+
+    for (auto& item : list) {
+        stream << item;
+        stream << ",";
+    }
+
+    std::string output = stream.str();
+
+    if (0 < output.size()) {
+        output.erase(output.size()-1, 1);
+    }
+
+    return output;
+}
+
+std::string OTAPI_Wrap::getIncomingReplies(
+    const std::string& nymID)
+{
+    auto list = Exec()->getIncomingReplies(nymID);
+
+    std::ostringstream stream;
+
+    for (auto& item : list) {
+        stream << item;
+        stream << ",";
+    }
+
+    std::string output = stream.str();
+
+    if (0 < output.size()) {
+        output.erase(output.size()-1, 1);
+    }
+
+    return output;
+}
+
+std::string OTAPI_Wrap::getRequest(
+    const std::string& nymID,
+    const std::string& requestID)
+{
+    return Exec()->getRequest(nymID, requestID);
+}
+
+std::string OTAPI_Wrap::getReply(
+    const std::string& nymID,
+    const std::string& replyID)
+{
+    return Exec()->getRequest(nymID, replyID);
 }
 
 int32_t OTAPI_Wrap::sendNymInstrument(const std::string& NOTARY_ID,

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -14641,6 +14641,38 @@ std::list<std::string> OTAPI_Exec::getIncomingReplies(
     return output;
 }
 
+std::string OTAPI_Exec::getRequest(
+    const std::string& nymID,
+    const std::string& requestID) const
+{
+    auto request = App::Me().Contract().PeerRequest(
+        Identifier(nymID),
+        Identifier(requestID),
+        StorageBox::INCOMINGPEERREQUEST);
+
+    if (request) {
+        return proto::ProtoAsString(*request);
+    }
+
+    return "";
+}
+
+std::string OTAPI_Exec::getReply(
+    const std::string& nymID,
+    const std::string& replyID) const
+{
+    auto reply = App::Me().Contract().PeerReply(
+        Identifier(nymID),
+        Identifier(replyID),
+        StorageBox::INCOMINGPEERREPLY);
+
+    if (reply) {
+        return proto::ProtoAsString(*reply);
+    }
+
+    return "";
+}
+
 // Returns int32_t:
 // -1 means error; no message was sent.
 //  0 means NO error, but also: no message was sent.

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -4284,7 +4284,7 @@ std::string OTAPI_Exec::GetServer_ID(const int32_t& nIndex) const
     auto servers = App::Me().Contract().ServerList();
 
     if (index <= servers.size()) {
-        Storage::ObjectList::iterator it = servers.begin();
+        ObjectList::iterator it = servers.begin();
         std::advance(it, index);
         return it->first;
     }
@@ -4320,7 +4320,7 @@ std::string OTAPI_Exec::GetAssetType_ID(const int32_t& nIndex) const
     auto units = App::Me().Contract().UnitDefinitionList();
 
     if (index <= units.size()) {
-        Storage::ObjectList::iterator it = units.begin();
+        ObjectList::iterator it = units.begin();
         std::advance(it, index);
         return it->first;
     }

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -14327,7 +14327,7 @@ int32_t OTAPI_Exec::initiateBailment(
     const std::string& recipientNymID,
     const std::string& unitID) const
 {
-    int64_t notUsed;
+    int64_t notUsed = 0;
     int32_t output = -1;
     const Identifier sender(senderNymID);
     const Identifier recipient(recipientNymID);
@@ -14388,7 +14388,7 @@ int32_t OTAPI_Exec::initiateOutBailment(
     const std::string& unitID,
     const std::string& terms) const
 {
-    int64_t notUsed;
+    int64_t notUsed = 0;
     int32_t output = -1;
     const Identifier sender(senderNymID);
     const Identifier recipient(recipientNymID);
@@ -14450,7 +14450,7 @@ int32_t OTAPI_Exec::acknowledgeBailment(
     const std::string& requestID,
     const std::string& terms) const
 {
-    int64_t notUsed;
+    int64_t notUsed = 0;
     int32_t output = -1;
     const Identifier sender(senderNymID);
     const Identifier recipient(recipientNymID);
@@ -14525,7 +14525,7 @@ int32_t OTAPI_Exec::acknowledgeOutBailment(
     const std::string& requestID,
     const std::string& terms) const
 {
-    int64_t notUsed;
+    int64_t notUsed = 0;
     int32_t output = -1;
     const Identifier sender(senderNymID);
     const Identifier recipient(recipientNymID);

--- a/src/client/OTClient.cpp
+++ b/src/client/OTClient.cpp
@@ -65,6 +65,7 @@
 #include "opentxs/core/contract/Signable.hpp"
 #include "opentxs/core/contract/UnitDefinition.hpp"
 #include "opentxs/core/contract/basket/Basket.hpp"
+#include "opentxs/core/contract/peer/PeerObject.hpp"
 #include "opentxs/core/crypto/OTASCIIArmor.hpp"
 #include "opentxs/core/crypto/OTAsymmetricKey.hpp"
 #include "opentxs/core/crypto/OTNymOrSymmetricKey.hpp"
@@ -352,9 +353,9 @@ bool OTClient::AcceptEntireNymbox(Ledger& theNymbox,
             // always succeed and in the odd-event that it fails, I'll end up
             // with a duplicate message
             // in my mail. So what?
-            Message* pMessage = new Message;
+            std::unique_ptr<Message> pMessage(new Message);
 
-            OT_ASSERT(nullptr != pMessage);
+            OT_ASSERT(pMessage);
 
             // The original message that was sent to me (with an encrypted
             // envelope in the payload,
@@ -364,14 +365,34 @@ bool OTClient::AcceptEntireNymbox(Ledger& theNymbox,
             // and add it to pNym's mail.
             //
             if (pMessage->LoadContractFromString(strRespTo)) {
-                pNym->AddMail(*pMessage); // Now the Nym is responsible to
-                                          // delete it. It's in his "mail".
-                Nym* pSignerNym = pNym;
-                pNym->SaveSignedNymfile(*pSignerNym);
-            }
-            else {
-                delete pMessage; // Don't want to leak otherwise.
-                pMessage = nullptr;
+
+                auto recipientNym =
+                    App::Me().Contract().Nym(Identifier(pMessage->m_strNymID2));
+                auto senderNym =
+                    App::Me().Contract().Nym(Identifier(pMessage->m_strNymID));
+                auto peerObject = PeerObject::Factory(
+                    recipientNym,
+                    senderNym,
+                    pMessage->m_ascPayload);
+                proto::PeerObjectType type = proto::PEEROBJECT_ERROR;
+                proto::PeerObject serialized;
+
+                if (peerObject) {
+                    type = peerObject->Type();
+                    serialized = peerObject->Serialize();
+                }
+
+                switch (type) {
+                    case (proto::PEEROBJECT_MESSAGE) : {
+                        // Now the Nym is responsible to delete it. It's in
+                        // his "mail".
+                        pNym->AddMail(*(pMessage.release()));
+                        Nym* pSignerNym = pNym;
+                        pNym->SaveSignedNymfile(*pSignerNym);
+                        break;
+                    }
+                    default : {}
+                }
             }
         }
 

--- a/src/client/OTClient.cpp
+++ b/src/client/OTClient.cpp
@@ -391,6 +391,19 @@ bool OTClient::AcceptEntireNymbox(Ledger& theNymbox,
                         pNym->SaveSignedNymfile(*pSignerNym);
                         break;
                     }
+                    case (proto::PEEROBJECT_REQUEST) : {
+                        App::Me().Contract().PeerRequestReceive(
+                            recipientNym->ID(),
+                            serialized.otrequest());
+                        break;
+                    }
+                    case (proto::PEEROBJECT_RESPONSE) : {
+                        App::Me().Contract().PeerReplyReceive(
+                            recipientNym->ID(),
+                            Identifier(serialized.otreply().cookie()),
+                            serialized.otreply());
+                        break;
+                    }
                     default : {}
                 }
             }

--- a/src/client/OT_ME.cpp
+++ b/src/client/OT_ME.cpp
@@ -266,6 +266,120 @@ bool OT_ME::make_sure_enough_trans_nums(int32_t nNumberNeeded,
     return bReturnVal;
 }
 
+/** Request a deposit of some asset in exchange for an OT balance */
+std::string OT_ME::initiate_bailment(
+    const std::string& NOTARY_ID,
+    const std::string& NYM_ID,
+    const std::string& TARGET_NYM_ID,
+    const std::string& INSTRUMENT_DEFINITION_ID) const
+{
+    OTAPI_Func ot_Msg;
+
+    OTAPI_Func theRequest(
+        INITIATE_BAILMENT,
+        NOTARY_ID,
+        NYM_ID,
+        TARGET_NYM_ID,
+        INSTRUMENT_DEFINITION_ID);
+    std::string strResponse =
+        theRequest.SendRequest(theRequest, "INITIATE_BAILMENT");
+    int32_t nSuccess = VerifyMessageSuccess(strResponse);
+
+    if (1 != nSuccess) {
+        otOut << "Failed to " << __FUNCTION__ << "." << std::endl;
+        return "";
+    }
+
+    return strResponse;
+}
+
+/** Request a redemption of an OT balance for the underlying asset*/
+std::string OT_ME::initiate_outbailment(
+    const std::string& NOTARY_ID,
+    const std::string& NYM_ID,
+    const std::string& TARGET_NYM_ID,
+    const std::string& INSTRUMENT_DEFINITION_ID,
+    const std::string& THE_MESSAGE) const
+{
+    OTAPI_Func ot_Msg;
+
+    OTAPI_Func theRequest(
+        INITIATE_OUTBAILMENT,
+        NOTARY_ID,
+        NYM_ID,
+        TARGET_NYM_ID,
+        INSTRUMENT_DEFINITION_ID,
+        THE_MESSAGE);
+    std::string strResponse =
+        theRequest.SendRequest(theRequest, "INITIATE_OUTBAILMENT");
+    int32_t nSuccess = VerifyMessageSuccess(strResponse);
+
+    if (1 != nSuccess) {
+        otOut << "Failed to " << __FUNCTION__ << "." << std::endl;
+        return "";
+    }
+
+    return strResponse;
+}
+
+/** Respond to a bailment request with deposit instructions */
+std::string OT_ME::acknowledge_bailment(
+    const std::string& NOTARY_ID,
+    const std::string& NYM_ID,
+    const std::string& TARGET_NYM_ID,
+    const std::string& REQUEST_ID,
+    const std::string& THE_MESSAGE) const
+{
+    OTAPI_Func ot_Msg;
+
+    OTAPI_Func theRequest(
+        ACKNOWLEDGE_BAILMENT,
+        NOTARY_ID,
+        NYM_ID,
+        TARGET_NYM_ID,
+        REQUEST_ID,
+        THE_MESSAGE);
+    std::string strResponse =
+        theRequest.SendRequest(theRequest, "ACKNOWLEDGE_BAILMENT");
+    int32_t nSuccess = VerifyMessageSuccess(strResponse);
+
+    if (1 != nSuccess) {
+        otOut << "Failed to " << __FUNCTION__ << "." << std::endl;
+        return "";
+    }
+
+    return strResponse;
+}
+
+/** Respond to an outbailment request with withdrawal instructions */
+std::string OT_ME::acknowledge_outbailment(
+    const std::string& NOTARY_ID,
+    const std::string& NYM_ID,
+    const std::string& TARGET_NYM_ID,
+    const std::string& REQUEST_ID,
+    const std::string& THE_MESSAGE) const
+{
+    OTAPI_Func ot_Msg;
+
+    OTAPI_Func theRequest(
+        ACKNOWLEDGE_OUTBAILMENT,
+        NOTARY_ID,
+        NYM_ID,
+        TARGET_NYM_ID,
+        REQUEST_ID,
+        THE_MESSAGE);
+    std::string strResponse =
+        theRequest.SendRequest(theRequest, "ACKNOWLEDGE_OUTBAILMENT");
+    int32_t nSuccess = VerifyMessageSuccess(strResponse);
+
+    if (1 != nSuccess) {
+        otOut << "Failed to " << __FUNCTION__ << "." << std::endl;
+        return "";
+    }
+
+    return strResponse;
+}
+
 // REGISTER NYM AT SERVER (or download nymfile, if nym already registered.)
 //
 std::string OT_ME::register_nym(const std::string& NOTARY_ID,

--- a/src/client/commands/CmdAcknowledgeBailment.cpp
+++ b/src/client/commands/CmdAcknowledgeBailment.cpp
@@ -1,0 +1,97 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/client/commands/CmdAcknowledgeBailment.hpp"
+
+#include "opentxs/client/OT_ME.hpp"
+
+namespace opentxs {
+
+CmdAcknowledgeBailment::CmdAcknowledgeBailment()
+{
+    command = "acknowledgebailment";
+    args[0] = "--server <server>";
+    args[1] = "--mynym <nym>";
+    args[2] = "--hisnym <nym>";
+    args[3] = "--mypurse ID for the request being acknowledged";
+    category = catOtherUsers;
+    help = "Respond to a bailment request with deposit instructions";
+}
+
+CmdAcknowledgeBailment::~CmdAcknowledgeBailment()
+{
+}
+
+std::int32_t CmdAcknowledgeBailment::runWithOptions()
+{
+    return run(
+        getOption("server"),
+        getOption("mynym"),
+        getOption("hisnym"),
+        getOption("mypurse"));
+}
+
+std::int32_t CmdAcknowledgeBailment::run(
+    std::string server,
+    std::string mynym,
+    std::string hisnym,
+    std::string mypurse)
+{
+    if (!checkServer("server", server)) {
+        return -1;
+    }
+
+    if (!checkNym("mynym", mynym)) {
+        return -1;
+    }
+
+    if (!checkNym("hisnym", hisnym)) {
+        return -1;
+    }
+
+    std::string terms = inputText("Deposit instructions");
+    if (0 == terms.size()) {
+        return -1;
+    }
+
+    OT_ME ot_me;
+    std::string response = ot_me.acknowledge_bailment(
+        server, mynym, hisnym, mypurse, terms);
+    return processResponse(response, "acknowledge bailment");
+}
+} // namespace opentxs

--- a/src/client/commands/CmdAcknowledgeOutBailment.cpp
+++ b/src/client/commands/CmdAcknowledgeOutBailment.cpp
@@ -1,0 +1,97 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/client/commands/CmdAcknowledgeOutBailment.hpp"
+
+#include "opentxs/client/OT_ME.hpp"
+
+namespace opentxs {
+
+CmdAcknowledgeOutBailment::CmdAcknowledgeOutBailment()
+{
+    command = "acknowledgeoutbailment";
+    args[0] = "--server <server>";
+    args[1] = "--mynym <nym>";
+    args[2] = "--hisnym <nym>";
+    args[3] = "--mypurse ID for the request being acknowledged";
+    category = catOtherUsers;
+    help = "Respond to an out bailment request with withdrawal instructions";
+}
+
+CmdAcknowledgeOutBailment::~CmdAcknowledgeOutBailment()
+{
+}
+
+std::int32_t CmdAcknowledgeOutBailment::runWithOptions()
+{
+    return run(
+        getOption("server"),
+        getOption("mynym"),
+        getOption("hisnym"),
+        getOption("mypurse"));
+}
+
+std::int32_t CmdAcknowledgeOutBailment::run(
+    std::string server,
+    std::string mynym,
+    std::string hisnym,
+    std::string mypurse)
+{
+    if (!checkServer("server", server)) {
+        return -1;
+    }
+
+    if (!checkNym("mynym", mynym)) {
+        return -1;
+    }
+
+    if (!checkNym("hisnym", hisnym)) {
+        return -1;
+    }
+
+    std::string terms = inputText("Withdrawal instructions");
+    if (0 == terms.size()) {
+        return -1;
+    }
+
+    OT_ME ot_me;
+    std::string response = ot_me.acknowledge_outbailment(
+        server, mynym, hisnym, mypurse, terms);
+    return processResponse(response, "acknowledge outbailment");
+}
+} // namespace opentxs

--- a/src/client/commands/CmdGetPeerReplies.cpp
+++ b/src/client/commands/CmdGetPeerReplies.cpp
@@ -1,0 +1,75 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/client/commands/CmdGetPeerReplies.hpp"
+
+#include "opentxs/client/OTAPI.hpp"
+#include "opentxs/core/Log.hpp"
+
+namespace opentxs {
+
+CmdGetPeerReplies::CmdGetPeerReplies()
+{
+    command = "getpeerreplies";
+    args[0] = "--mynym <nym>";
+    category = catOtherUsers;
+    help = "Get a list of incoming peer reply IDs";
+}
+
+CmdGetPeerReplies::~CmdGetPeerReplies()
+{
+}
+
+std::int32_t CmdGetPeerReplies::runWithOptions()
+{
+    return run(getOption("mynym"));
+}
+
+std::int32_t CmdGetPeerReplies::run(std::string mynym)
+{
+    if (!checkNym("mynym", mynym)) {
+        return -1;
+    }
+
+    auto output = OTAPI_Wrap::getIncomingReplies(mynym);
+
+    otOut << output << std::endl;
+
+    return 1;
+}
+} // namespace opentxs

--- a/src/client/commands/CmdGetPeerRequests.cpp
+++ b/src/client/commands/CmdGetPeerRequests.cpp
@@ -1,0 +1,75 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/client/commands/CmdGetPeerRequests.hpp"
+
+#include "opentxs/client/OTAPI.hpp"
+#include "opentxs/core/Log.hpp"
+
+namespace opentxs {
+
+CmdGetPeerRequests::CmdGetPeerRequests()
+{
+    command = "getpeerrequests";
+    args[0] = "--mynym <nym>";
+    category = catOtherUsers;
+    help = "Get a list of incoming peer request IDs";
+}
+
+CmdGetPeerRequests::~CmdGetPeerRequests()
+{
+}
+
+std::int32_t CmdGetPeerRequests::runWithOptions()
+{
+    return run(getOption("mynym"));
+}
+
+std::int32_t CmdGetPeerRequests::run(std::string mynym)
+{
+    if (!checkNym("mynym", mynym)) {
+        return -1;
+    }
+
+    auto output = OTAPI_Wrap::getIncomingRequests(mynym);
+
+    otOut << output << std::endl;
+
+    return 1;
+}
+} // namespace opentxs

--- a/src/client/commands/CmdRequestBailment.cpp
+++ b/src/client/commands/CmdRequestBailment.cpp
@@ -1,0 +1,96 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/client/commands/CmdRequestBailment.hpp"
+
+#include "opentxs/client/OT_ME.hpp"
+
+namespace opentxs {
+
+CmdRequestBailment::CmdRequestBailment()
+{
+    command = "requestbailment";
+    args[0] = "--server <server>";
+    args[1] = "--mynym <nym>";
+    args[2] = "--hisnym <nym>";
+    args[3] = "--mypurse <purse>";
+    category = catOtherUsers;
+    help = "Ask the issuer of a unit to accept a deposit";
+}
+
+CmdRequestBailment::~CmdRequestBailment()
+{
+}
+
+std::int32_t CmdRequestBailment::runWithOptions()
+{
+    return run(
+        getOption("server"),
+        getOption("mynym"),
+        getOption("hisnym"),
+        getOption("mypurse"));
+}
+
+std::int32_t CmdRequestBailment::run(
+    std::string server,
+    std::string mynym,
+    std::string hisnym,
+    std::string mypurse)
+{
+    if (!checkServer("server", server)) {
+        return -1;
+    }
+
+    if (!checkNym("mynym", mynym)) {
+        return -1;
+    }
+
+    if (!checkNym("hisnym", hisnym)) {
+        return -1;
+    }
+
+    if (!checkPurse("mypurse", mypurse)) {
+        return -1;
+    }
+
+    OT_ME ot_me;
+    std::string response = ot_me.initiate_bailment(
+        server, mynym, hisnym, mypurse);
+    return processResponse(response, "request bailment");
+}
+} // namespace opentxs

--- a/src/client/commands/CmdRequestOutBailment.cpp
+++ b/src/client/commands/CmdRequestOutBailment.cpp
@@ -1,0 +1,101 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/client/commands/CmdRequestOutBailment.hpp"
+
+#include "opentxs/client/OT_ME.hpp"
+
+namespace opentxs {
+
+CmdRequestOutBailment::CmdRequestOutBailment()
+{
+    command = "requestoutbailment";
+    args[0] = "--server <server>";
+    args[1] = "--mynym <nym>";
+    args[2] = "--hisnym <nym>";
+    args[3] = "--mypurse <purse>";
+    category = catOtherUsers;
+    help = "Ask the issuer of a unit to process a withdrawal";
+}
+
+CmdRequestOutBailment::~CmdRequestOutBailment()
+{
+}
+
+std::int32_t CmdRequestOutBailment::runWithOptions()
+{
+    return run(
+        getOption("server"),
+        getOption("mynym"),
+        getOption("hisnym"),
+        getOption("mypurse"));
+}
+
+std::int32_t CmdRequestOutBailment::run(
+    std::string server,
+    std::string mynym,
+    std::string hisnym,
+    std::string mypurse)
+{
+    if (!checkServer("server", server)) {
+        return -1;
+    }
+
+    if (!checkNym("mynym", mynym)) {
+        return -1;
+    }
+
+    if (!checkNym("hisnym", hisnym)) {
+        return -1;
+    }
+
+    if (!checkPurse("mypurse", mypurse)) {
+        return -1;
+    }
+
+    std::string terms = inputText("Withdrawal instructions");
+    if (0 == terms.size()) {
+        return -1;
+    }
+
+    OT_ME ot_me;
+    std::string response = ot_me.initiate_outbailment(
+        server, mynym, hisnym, mypurse, terms);
+    return processResponse(response, "request outbailment");
+}
+} // namespace opentxs

--- a/src/client/ot_otapi_ot.cpp
+++ b/src/client/ot_otapi_ot.cpp
@@ -237,6 +237,10 @@ OTAPI_Func::OTAPI_Func(OTAPI_Func_Type theType, const string& p_notaryID,
         instrumentDefinitionID = p_strParam;
         strData = p_strData;
     }
+    else if (theType == INITIATE_BAILMENT) {
+        nymID2 = p_strParam;
+        instrumentDefinitionID = p_strData;
+    }
     else {
         otOut << "ERROR! WRONG TYPE passed to OTAPI_Func.OTAPI_Func()\n";
     }
@@ -345,6 +349,21 @@ OTAPI_Func::OTAPI_Func(OTAPI_Func_Type theType, const string& p_notaryID,
                               // passed here.;
         nData = stol(p_strData);
         strData = p_strData2; // transaction number passed here as string;
+    }
+    else if (theType == INITIATE_OUTBAILMENT) {
+        nymID2 = p_nymID2;
+        instrumentDefinitionID = p_strData;
+        strData = p_strData2;
+    }
+    else if (theType == ACKNOWLEDGE_BAILMENT) {
+        nymID2 = p_nymID2;
+        strData = p_strData;
+        strData2 = p_strData2;
+    }
+    else if (theType == ACKNOWLEDGE_OUTBAILMENT) {
+        nymID2 = p_nymID2;
+        strData = p_strData;
+        strData2 = p_strData2;
     }
     else {
         otOut << "ERROR! WRONG TYPE passed to OTAPI_Func.OTAPI_Func() "
@@ -696,6 +715,18 @@ OT_OTAPI_OT int32_t OTAPI_Func::Run() const
     case ADJUST_USAGE_CREDITS:
         return OTAPI_Wrap::usageCredits(notaryID, nymID, nymID2,
                                         stoll(strData));
+    case INITIATE_BAILMENT:
+        return OTAPI_Wrap::initiateBailment(
+            notaryID, nymID, nymID2, instrumentDefinitionID);
+    case INITIATE_OUTBAILMENT:
+        return OTAPI_Wrap::initiateOutBailment(
+            notaryID, nymID, nymID2, instrumentDefinitionID, strData);
+    case ACKNOWLEDGE_BAILMENT:
+        return OTAPI_Wrap::acknowledgeBailment(
+            notaryID, nymID, nymID2, strData, strData2);
+    case ACKNOWLEDGE_OUTBAILMENT:
+        return OTAPI_Wrap::acknowledgeOutBailment(
+            notaryID, nymID, nymID2, strData, strData2);
     default:
         break;
     }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -52,6 +52,7 @@ set(cxx-sources
   contract/basket/Basket.cpp
   contract/basket/BasketContract.cpp
   contract/basket/BasketItem.cpp
+  contract/peer/PeerObject.cpp
   crypto/BitcoinCrypto.cpp
   crypto/OTAsymmetricKey.cpp
   crypto/OTAsymmetricKeyOpenSSL.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -52,7 +52,13 @@ set(cxx-sources
   contract/basket/Basket.cpp
   contract/basket/BasketContract.cpp
   contract/basket/BasketItem.cpp
+  contract/peer/BailmentReply.cpp
+  contract/peer/BailmentRequest.cpp
+  contract/peer/OutBailmentReply.cpp
+  contract/peer/OutBailmentRequest.cpp
   contract/peer/PeerObject.cpp
+  contract/peer/PeerReply.cpp
+  contract/peer/PeerRequest.cpp
   crypto/BitcoinCrypto.cpp
   crypto/OTAsymmetricKey.cpp
   crypto/OTAsymmetricKeyOpenSSL.cpp

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -5104,6 +5104,52 @@ bool Nym::Sign(const proto::UnitDefinition& contract, proto::Signature& sig)
     return haveSig;
 }
 
+bool Nym::Sign(const proto::PeerRequest& contract, proto::Signature& sig) const
+{
+    bool haveSig = false;
+
+    for (auto& it : m_mapCredentialSets) {
+        if (nullptr != it.second) {
+            bool success = it.second->Sign(
+                proto::ProtoAsData(contract),
+                sig,
+                nullptr,
+                nullptr,
+                proto::SIGROLE_PEERREQUEST);
+
+            if (success) {
+                haveSig = true;
+                break;
+            }
+        }
+    }
+
+    return haveSig;
+}
+
+bool Nym::Sign(const proto::PeerReply& contract, proto::Signature& sig) const
+{
+    bool haveSig = false;
+
+    for (auto& it : m_mapCredentialSets) {
+        if (nullptr != it.second) {
+            bool success = it.second->Sign(
+                proto::ProtoAsData(contract),
+                sig,
+                nullptr,
+                nullptr,
+                proto::SIGROLE_PEERREPLY);
+
+            if (success) {
+                haveSig = true;
+                break;
+            }
+        }
+    }
+
+    return haveSig;
+}
+
 bool Nym::Verify(const OTData& plaintext, const proto::Signature& sig) const
 {
     for (auto& it : m_mapCredentialSets) {

--- a/src/core/app/Wallet.cpp
+++ b/src/core/app/Wallet.cpp
@@ -148,6 +148,230 @@ ConstNym Wallet::Nym(const proto::CredentialIndex& publicNym)
     return Nym(Identifier(nym));
 }
 
+std::shared_ptr<proto::PeerReply> Wallet::PeerReply(
+    const Identifier& nym,
+    const Identifier& reply,
+    const StorageBox& box) const
+{
+    std::shared_ptr<proto::PeerReply> output;
+
+    App::Me().DB().Load(
+        String(nym).Get(),
+        String(reply).Get(),
+        box,
+        output);
+
+    return output;
+}
+
+bool Wallet::PeerReplyComplete(
+    const Identifier& nym,
+    const Identifier& replyID)
+{
+    const std::string nymID = String(nym).Get();
+    std::shared_ptr<proto::PeerReply> reply;
+    const bool haveReply =
+        App::Me().DB().Load(
+            nymID,
+            String(replyID).Get(),
+            StorageBox::SENTPEERREPLY,
+            reply,
+            false);
+
+    if (!haveReply) { return false; }
+
+    if (App::Me().DB().Store(*reply, nymID, StorageBox::FINISHEDPEERREPLY)) {
+        return App::Me().DB().RemoveNymBoxItem(
+            nymID,
+            StorageBox::SENTPEERREPLY,
+            String(replyID).Get());
+    }
+
+    return false;
+}
+
+bool Wallet::PeerReplyCreate(
+    const Identifier& nym,
+    const Identifier& requestID,
+    const proto::PeerReply& reply)
+{
+    const std::string nymID = String(nym).Get();
+    std::shared_ptr<proto::PeerRequest> request;
+    const bool haveRequest =
+        App::Me().DB().Load(
+            nymID,
+            String(requestID).Get(),
+            StorageBox::INCOMINGPEERREQUEST,
+            request,
+            false);
+
+    if (!haveRequest) { return false; }
+
+    if (reply.cookie() != request->id()) {
+        otErr << __FUNCTION__ << ": reply cookie does not match request id."
+              << std::endl;
+
+        return false;
+    }
+
+    if (reply.type() != request->type()) {
+        otErr << __FUNCTION__ << ": reply type does not match request type."
+              << std::endl;
+
+        return false;
+    }
+
+    const bool createdReply = App::Me().DB().Store(
+        reply, nymID, StorageBox::SENTPEERREPLY);
+
+    if (!createdReply) { return false; }
+
+    const bool processedRequest = App::Me().DB().Store(
+        *request, nymID, StorageBox::PROCESSEDPEERREQUEST);
+
+    if (!processedRequest) { return false; }
+
+    return App::Me().DB().RemoveNymBoxItem(
+        nymID, StorageBox::INCOMINGPEERREQUEST, String(requestID).Get());
+}
+
+bool Wallet::PeerReplyCreateRollback(
+    const Identifier& nym,
+    const Identifier& request,
+    const Identifier& reply)
+{
+    const std::string nymID = String(nym).Get();
+    const std::string requestID = String(request).Get();
+    const std::string replyID = String(reply).Get();
+    std::shared_ptr<proto::PeerRequest> requestItem;
+    const bool loadedRequest = App::Me().DB().Load(
+        nymID, requestID, StorageBox::PROCESSEDPEERREQUEST, requestItem);
+
+    if (!loadedRequest) { return false; }
+
+    const bool requestRolledBack = App::Me().DB().Store(
+       *requestItem, nymID, StorageBox::INCOMINGPEERREQUEST);
+
+    if (!requestRolledBack) { return false; }
+
+    const bool purgedRequest = App::Me().DB().RemoveNymBoxItem(
+        nymID, StorageBox::PROCESSEDPEERREQUEST, requestID);
+
+    if (!purgedRequest) { return false; }
+
+    return App::Me().DB().RemoveNymBoxItem(
+        nymID, StorageBox::SENTPEERREPLY, replyID);;
+}
+
+ObjectList Wallet::PeerReplyIncoming(const Identifier& nym) const
+{
+    return App::Me().DB().NymBoxList(
+        String(nym).Get(), StorageBox::INCOMINGPEERREPLY);
+}
+
+bool Wallet::PeerReplyReceive(
+    const Identifier& nym,
+    const Identifier& requestID,
+    const proto::PeerReply& reply)
+{
+    const std::string nymID = String(nym).Get();
+    std::shared_ptr<proto::PeerRequest> request;
+    const bool haveRequest =
+        App::Me().DB().Load(
+            nymID,
+            String(requestID).Get(),
+            StorageBox::SENTPEERREQUEST,
+            request,
+            false);
+
+    if (!haveRequest) { return false; }
+
+    const bool receivedReply = App::Me().DB().Store(
+        reply, nymID, StorageBox::INCOMINGPEERREPLY);
+
+    if (!receivedReply) { return false; }
+
+    const bool finishedRequest = App::Me().DB().Store(
+        *request, nymID, StorageBox::FINISHEDPEERREQUEST);
+
+    if (!finishedRequest) { return false; }
+
+    return App::Me().DB().RemoveNymBoxItem(
+        nymID, StorageBox::SENTPEERREQUEST, String(requestID).Get());
+}
+
+std::shared_ptr<proto::PeerRequest> Wallet::PeerRequest(
+    const Identifier& nym,
+    const Identifier& request,
+    const StorageBox& box) const
+{
+    std::shared_ptr<proto::PeerRequest> output;
+
+    App::Me().DB().Load(
+        String(nym).Get(),
+        String(request).Get(),
+        box,
+        output);
+
+    return output;
+}
+
+bool Wallet::PeerRequestComplete(
+    const Identifier& nym,
+    const Identifier& replyID)
+{
+    const std::string nymID = String(nym).Get();
+    std::shared_ptr<proto::PeerReply> reply;
+    const bool haveReply =
+        App::Me().DB().Load(
+            nymID,
+            String(replyID).Get(),
+            StorageBox::INCOMINGPEERREPLY,
+            reply,
+            false);
+
+    if (!haveReply) { return false; }
+
+    if (App::Me().DB().Store(*reply, nymID, StorageBox::PROCESSEDPEERREPLY)) {
+        return App::Me().DB().RemoveNymBoxItem(
+            nymID,
+            StorageBox::INCOMINGPEERREPLY,
+            String(replyID).Get());
+    }
+
+    return false;
+
+}
+
+bool Wallet::PeerRequestCreate(
+    const Identifier& nym,
+    const proto::PeerRequest& request)
+{
+    return App::Me().DB().Store(
+        request, String(nym).Get(), StorageBox::SENTPEERREQUEST);
+}
+
+bool Wallet::PeerRequestCreateRollback(
+    const Identifier& nym,
+    const Identifier& request)
+{
+    return App::Me().DB().RemoveNymBoxItem(
+        String(nym).Get(), StorageBox::SENTPEERREQUEST, String(request).Get());
+}
+
+ObjectList Wallet::PeerRequestIncoming(const Identifier& nym) const
+{
+    return App::Me().DB().NymBoxList(
+        String(nym).Get(), StorageBox::INCOMINGPEERREQUEST);
+}
+bool Wallet::PeerRequestReceive(
+    const Identifier& nym,
+    const proto::PeerRequest& request)
+{
+    return App::Me().DB().Store(
+        request, String(nym).Get(), StorageBox::INCOMINGPEERREQUEST);
+}
+
 bool Wallet::RemoveServer(const Identifier& id)
 {
     std::string server(String(id).Get());

--- a/src/core/app/Wallet.cpp
+++ b/src/core/app/Wallet.cpp
@@ -319,7 +319,7 @@ ConstServerContract Wallet::Server(
     return Server(Identifier(server));
 }
 
-Storage::ObjectList Wallet::ServerList() { return App::Me().DB().ServerList(); }
+ObjectList Wallet::ServerList() { return App::Me().DB().ServerList(); }
 
 bool Wallet::SetNymAlias(const Identifier& id, const std::string alias)
 {
@@ -338,7 +338,7 @@ bool Wallet::SetUnitDefinitionAlias(
     return App::Me().DB().SetUnitDefinitionAlias(String(id).Get(), alias);
 }
 
-Storage::ObjectList Wallet::UnitDefinitionList()
+ObjectList Wallet::UnitDefinitionList()
 {
     return App::Me().DB().UnitDefinitionList();
 }

--- a/src/core/contract/UnitDefinition.cpp
+++ b/src/core/contract/UnitDefinition.cpp
@@ -660,26 +660,21 @@ UnitDefinition* UnitDefinition::Create(
         new CurrencyContract(
             nym, shortname, name, symbol, terms, tla, power, fraction));
 
-    if (!contract) {
-        return nullptr;
-    }
+    if (!contract) { return nullptr; }
 
-    if (!contract->CalculateID()) {
-        return nullptr;
-    }
+    if (!contract->CalculateID()) { return nullptr; }
 
     if (contract->nym_) {
-        proto::UnitDefinition serialized = contract->SigVersion();
+        auto serialized = contract->SigVersion();
         std::shared_ptr<proto::Signature> sig =
             std::make_shared<proto::Signature>();
+
         if (contract->nym_->Sign(serialized, *sig)) {
             contract->signatures_.push_front(sig);
         }
     }
 
-    if (!contract->Validate()) {
-        return nullptr;
-    }
+    if (!contract->Validate()) { return nullptr; }
 
     contract->alias_ = contract->short_name_;
 

--- a/src/core/contract/peer/BailmentReply.cpp
+++ b/src/core/contract/peer/BailmentReply.cpp
@@ -1,0 +1,71 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/core/contract/peer/BailmentReply.hpp"
+
+namespace opentxs
+{
+BailmentReply::BailmentReply(
+    const ConstNym& nym,
+    const proto::PeerReply& serialized)
+      : ot_super(nym, serialized)
+{
+    conditions_ = serialized.bailment().instructions();
+}
+
+BailmentReply::BailmentReply(
+    const ConstNym& nym,
+    const Identifier& initiator,
+    const Identifier& request,
+    const std::string& terms)
+      : ot_super(nym, initiator, proto::PEERREQUEST_BAILMENT, request)
+{
+    conditions_ = terms;
+}
+
+proto::PeerReply BailmentReply::IDVersion() const
+{
+    auto contract = ot_super::IDVersion();
+
+    auto& bailment = *contract.mutable_bailment();
+    bailment.set_version(version_);
+    bailment.set_instructions(conditions_);
+
+    return contract;
+}
+} // namespace opentxs

--- a/src/core/contract/peer/BailmentRequest.cpp
+++ b/src/core/contract/peer/BailmentRequest.cpp
@@ -1,0 +1,76 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/core/contract/peer/BailmentRequest.hpp"
+
+#include "opentxs/core/String.hpp"
+
+namespace opentxs
+{
+BailmentRequest::BailmentRequest(
+    const ConstNym& nym,
+    const proto::PeerRequest& serialized)
+      : ot_super(nym, serialized)
+      , unit_(serialized.bailment().unitid())
+      , server_(serialized.bailment().serverid())
+{
+}
+
+BailmentRequest::BailmentRequest(
+    const ConstNym& nym,
+    const Identifier& recipientID,
+    const Identifier& unitID,
+    const Identifier& serverID)
+      : ot_super(nym, recipientID, proto::PEERREQUEST_BAILMENT)
+      , unit_(unitID)
+      , server_(serverID)
+{
+}
+
+proto::PeerRequest BailmentRequest::IDVersion() const
+{
+    auto contract = ot_super::IDVersion();
+
+    auto& bailment = *contract.mutable_bailment();
+    bailment.set_version(version_);
+    bailment.set_unitid(String(unit_).Get());
+    bailment.set_serverid(String(server_).Get());
+
+    return contract;
+}
+} // namespace opentxs

--- a/src/core/contract/peer/OutBailmentReply.cpp
+++ b/src/core/contract/peer/OutBailmentReply.cpp
@@ -1,0 +1,71 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/core/contract/peer/OutBailmentReply.hpp"
+
+namespace opentxs
+{
+OutBailmentReply::OutBailmentReply(
+    const ConstNym& nym,
+    const proto::PeerReply& serialized)
+      : ot_super(nym, serialized)
+{
+    conditions_ = serialized.outbailment().instructions();
+}
+
+OutBailmentReply::OutBailmentReply(
+    const ConstNym& nym,
+    const Identifier& initiator,
+    const Identifier& request,
+    const std::string& terms)
+      : ot_super(nym, initiator, proto::PEERREQUEST_OUTBAILMENT, request)
+{
+    conditions_ = terms;
+}
+
+proto::PeerReply OutBailmentReply::IDVersion() const
+{
+    auto contract = ot_super::IDVersion();
+
+    auto& bailment = *contract.mutable_outbailment();
+    bailment.set_version(version_);
+    bailment.set_instructions(conditions_);
+
+    return contract;
+}
+} // namespace opentxs

--- a/src/core/contract/peer/OutBailmentRequest.cpp
+++ b/src/core/contract/peer/OutBailmentRequest.cpp
@@ -1,0 +1,80 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/core/contract/peer/OutBailmentRequest.hpp"
+
+#include "opentxs/core/String.hpp"
+
+namespace opentxs
+{
+OutBailmentRequest::OutBailmentRequest(
+    const ConstNym& nym,
+    const proto::PeerRequest& serialized)
+      : ot_super(nym, serialized)
+      , unit_(serialized.outbailment().unitid())
+      , server_(serialized.outbailment().serverid())
+{
+    conditions_ = serialized.outbailment().instructions();
+}
+
+OutBailmentRequest::OutBailmentRequest(
+    const ConstNym& nym,
+    const Identifier& recipientID,
+    const Identifier& unitID,
+    const Identifier& serverID,
+    const std::string& terms)
+      : ot_super(nym, recipientID, proto::PEERREQUEST_OUTBAILMENT)
+      , unit_(unitID)
+      , server_(serverID)
+{
+    conditions_ = terms;
+}
+
+proto::PeerRequest OutBailmentRequest::IDVersion() const
+{
+    auto contract = ot_super::IDVersion();
+
+    auto& outbailment = *contract.mutable_outbailment();
+    outbailment.set_version(version_);
+    outbailment.set_unitid(String(unit_).Get());
+    outbailment.set_serverid(String(server_).Get());
+    outbailment.set_instructions(conditions_);
+
+    return contract;
+}
+} // namespace opentxs

--- a/src/core/contract/peer/PeerObject.cpp
+++ b/src/core/contract/peer/PeerObject.cpp
@@ -54,21 +54,15 @@ PeerObject::PeerObject(const ConstNym& nym, const proto::PeerObject serialized)
         case (proto::PEEROBJECT_MESSAGE) : {
             message_.reset(new std::string(serialized.otmessage()));
 
-            OT_ASSERT(message_);
-
             break;
         }
         case (proto::PEEROBJECT_REQUEST) : {
             request_.reset(PeerRequest::Factory(nym, serialized.otrequest()));
 
-            OT_ASSERT(request_);
-
             break;
         }
         case (proto::PEEROBJECT_RESPONSE) : {
             reply_.reset(PeerReply::Factory(nym, serialized.otreply()));
-
-            OT_ASSERT(reply_);
 
             break;
         }
@@ -106,8 +100,6 @@ std::unique_ptr<PeerObject> PeerObject::Create(const std::string& message)
 {
     std::unique_ptr<PeerObject> output(new PeerObject(message));
 
-    OT_ASSERT(output);
-
     if (!output->Validate()) {
         output.reset();
     }
@@ -121,8 +113,6 @@ std::unique_ptr<PeerObject> PeerObject::Create(
 {
     std::unique_ptr<PeerObject> output(new PeerObject(request, reply));
 
-    OT_ASSERT(output);
-
     if (!output->Validate()) {
         output.reset();
     }
@@ -134,8 +124,6 @@ std::unique_ptr<PeerObject> PeerObject::Create(
     std::unique_ptr<PeerRequest>& request)
 {
     std::unique_ptr<PeerObject> output(new PeerObject(request));
-
-    OT_ASSERT(output);
 
     if (!output->Validate()) {
         output.reset();

--- a/src/core/contract/peer/PeerObject.cpp
+++ b/src/core/contract/peer/PeerObject.cpp
@@ -1,0 +1,148 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/core/contract/peer/PeerObject.hpp"
+
+#include "opentxs/core/Log.hpp"
+#include "opentxs/core/String.hpp"
+#include "opentxs/core/crypto/OTASCIIArmor.hpp"
+#include "opentxs/core/crypto/OTEnvelope.hpp"
+#include "opentxs/core/util/Assert.hpp"
+
+namespace opentxs
+{
+PeerObject::PeerObject(
+    const proto::PeerObject serialized)
+      : type_(serialized.type())
+      , version_(serialized.version())
+{
+    switch (serialized.type()) {
+        case (proto::PEEROBJECT_MESSAGE) : {
+            message_.reset(new std::string(serialized.otmessage()));
+
+            OT_ASSERT(message_);
+
+        }
+        default : {
+            otErr << __FUNCTION__ << ": Unknown type" << std::endl;
+        }
+    }
+}
+
+PeerObject::PeerObject(const std::string& message)
+    : type_(proto::PEEROBJECT_MESSAGE)
+    , version_(1)
+{
+    message_.reset(new std::string(message));
+
+    OT_ASSERT(message_);
+}
+
+std::unique_ptr<PeerObject> PeerObject::Create(const std::string& message)
+{
+    std::unique_ptr<PeerObject> output(new PeerObject(message));
+
+    OT_ASSERT(output);
+
+    if (!output->Validate()) {
+        output.reset();
+    }
+
+    return output;
+}
+
+std::unique_ptr<PeerObject> PeerObject::Factory(
+    const proto::PeerObject& serialized)
+{
+    const bool valid = proto::Check(
+        serialized, serialized.version(), serialized.version());
+    std::unique_ptr<PeerObject> output;
+
+    if (valid) {
+        output.reset(new PeerObject(serialized));
+    }
+
+    return output;
+}
+
+std::unique_ptr<PeerObject> PeerObject::Factory(
+    const ConstNym& recipientNym,
+    const ConstNym& senderNym,
+    const OTASCIIArmor& encrypted)
+{
+    std::unique_ptr<PeerObject> output;
+    OTEnvelope input;
+
+    if (!input.SetAsciiArmoredData(encrypted)) { return output; }
+
+    String contents;
+
+    if (!input.Open(*recipientNym, contents)) { return output; }
+
+    auto serialized = proto::StringToProto<proto::PeerObject>(contents);
+
+    output = Factory(senderNym, serialized);
+
+    return output;
+}
+
+proto::PeerObject PeerObject::Serialize() const
+{
+    proto::PeerObject output;
+    output.set_version(version_);
+    output.set_type(type_);
+
+    switch (type_) {
+        case (proto::PEEROBJECT_MESSAGE) : {
+            output.set_otmessage(String(*message_).Get());
+        }
+        default : {
+            otErr << __FUNCTION__ << ": Unknown type" << std::endl;
+        }
+    }
+
+    return output;
+}
+
+bool PeerObject::Validate() const
+{
+    const auto serialized = Serialize();
+
+    return proto::Check(serialized, version_, version_);
+}
+} // namespace opentxs

--- a/src/core/contract/peer/PeerReply.cpp
+++ b/src/core/contract/peer/PeerReply.cpp
@@ -1,0 +1,276 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/core/contract/peer/PeerReply.hpp"
+
+#include "opentxs/core/Log.hpp"
+#include "opentxs/core/Nym.hpp"
+#include "opentxs/core/String.hpp"
+#include "opentxs/core/app/App.hpp"
+#include "opentxs/core/contract/peer/BailmentReply.hpp"
+#include "opentxs/core/contract/peer/OutBailmentReply.hpp"
+
+namespace opentxs
+{
+PeerReply::PeerReply(
+    const ConstNym& nym,
+    const proto::PeerReply& serialized)
+      : ot_super(nym)
+      , initiator_(serialized.initiator())
+      , recipient_(serialized.recipient())
+      , cookie_(serialized.cookie())
+      , type_(serialized.type())
+{
+    id_ = Identifier(serialized.id());
+    signatures_.push_front(
+        SerializedSignature(
+            std::make_shared<proto::Signature>(serialized.signature())));
+    version_ = serialized.version();
+}
+
+PeerReply::PeerReply(
+    const ConstNym& nym,
+    const Identifier& initiator,
+    const proto::PeerRequestType& type,
+    const Identifier& request)
+        : ot_super(nym)
+        , initiator_(initiator)
+        , recipient_(nym->ID())
+        , cookie_(request)
+        , type_(type)
+{
+    version_ = 1;
+}
+
+proto::PeerReply PeerReply::Contract() const
+{
+    auto contract = SigVersion();
+    *(contract.mutable_signature()) = *(signatures_.front());
+
+    return contract;
+}
+
+PeerReply* PeerReply::Create(
+    const ConstNym& nym,
+    const proto::PeerRequestType& type,
+    const Identifier& requestID,
+    const std::string& terms)
+{
+    auto peerRequest = App::Me().Contract().PeerRequest(
+            nym->ID(), requestID, StorageBox::INCOMINGPEERREQUEST);
+
+    if (!peerRequest) {
+        otErr << __FUNCTION__ << ": failed to load request."
+              << std::endl;
+
+        return nullptr;
+    }
+
+    std::unique_ptr<PeerReply> contract;
+
+    switch (type) {
+        case (proto::PEERREQUEST_BAILMENT) : {
+            contract.reset(new BailmentReply(
+                nym, Identifier(peerRequest->initiator()), requestID, terms));
+            break;
+        }
+        case (proto::PEERREQUEST_OUTBAILMENT) : {
+            contract.reset(new OutBailmentReply(
+                nym, Identifier(peerRequest->initiator()), requestID, terms));
+            break;
+        }
+        default: {
+            otErr << __FUNCTION__ << ": invalid request type." << std::endl;
+
+            return nullptr;
+        }
+    }
+
+    if (!contract) {
+        otErr << __FUNCTION__ << ": failed to instantiate reply."
+              << std::endl;
+
+        return nullptr;
+    }
+
+    if (FinalizeContract(*contract)) {
+        return contract.release();
+    } else {
+        otErr << __FUNCTION__ << ": failed to finalize contract." << std::endl;
+
+        return nullptr;
+    }
+}
+
+PeerReply* PeerReply::Factory(
+    const ConstNym& nym,
+    const proto::PeerReply& serialized)
+{
+    if (!proto::Check(serialized, 0, 0xFFFFFFFF)) { return nullptr; }
+
+    std::unique_ptr<PeerReply> contract;
+
+    switch (serialized.type()) {
+        case (proto::PEERREQUEST_BAILMENT) : {
+            contract.reset(new BailmentReply(nym, serialized));
+            break;
+        }
+        case (proto::PEERREQUEST_OUTBAILMENT) : {
+            contract.reset(new OutBailmentReply(nym, serialized));
+            break;
+        }
+        default : {
+            otErr << __FUNCTION__ << ": invalid reply type." << std::endl;
+
+            return nullptr;
+        }
+    }
+
+    if (!contract) {
+        otErr << __FUNCTION__ << ": failed to instantiate reply."
+              << std::endl;
+
+        return nullptr;
+    }
+    if (!contract->Validate()) {
+        otErr << __FUNCTION__ << ": invalid reply." << std::endl;
+
+        return nullptr;
+    }
+
+    return contract.release();
+}
+
+bool PeerReply::FinalizeContract(PeerReply& contract)
+{
+    if (!contract.CalculateID()) {
+        otErr << __FUNCTION__ << ": failed to calculate ID." << std::endl;
+
+        return false;
+    }
+
+    if (contract.nym_) {
+        auto serialized = contract.SigVersion();
+        std::shared_ptr<proto::Signature> sig =
+            std::make_shared<proto::Signature>();
+
+        if (contract.nym_->Sign(serialized, *sig)) {
+            contract.signatures_.push_front(sig);
+        }
+    }
+
+    return contract.Validate();
+}
+
+Identifier PeerReply::GetID() const
+{
+    return GetID(IDVersion());
+}
+
+Identifier PeerReply::GetID(const proto::PeerReply& contract)
+{
+    Identifier id;
+    id.CalculateDigest(proto::ProtoAsData(contract));
+    return id;
+}
+
+proto::PeerReply PeerReply::IDVersion() const
+{
+    proto::PeerReply contract;
+
+    contract.set_version(version_);
+    contract.clear_id();         // reinforcing that this field must be blank.
+    contract.set_initiator(String(initiator_).Get());
+    contract.set_recipient(String(recipient_).Get());
+    contract.set_type(type_);
+    contract.set_cookie(String(cookie_).Get());
+    contract.clear_signature();  // reinforcing that this field must be blank.
+
+    return contract;
+}
+
+std::string PeerReply::Name() const
+{
+    return String(id_).Get();
+}
+
+OTData PeerReply::Serialize() const
+{
+
+    return proto::ProtoAsData(Contract());
+}
+
+proto::PeerReply PeerReply::SigVersion() const
+{
+    auto contract = IDVersion();
+    contract.set_id(String(ID()).Get());
+
+    return contract;
+}
+
+bool PeerReply::Validate() const
+{
+    bool validNym = false;
+
+    if (nym_) {
+        validNym = nym_->VerifyPseudonym();
+    } else {
+        otErr << __FUNCTION__ << ": invalid nym." << std::endl;
+    }
+
+    bool validSyntax = proto::Check(Contract(), 0, 0xFFFFFFFF);
+
+    if (!validSyntax) {
+        otErr << __FUNCTION__ << ": invalid syntax." << std::endl;
+    }
+
+    bool validSig = false;
+
+    if (nym_) {
+        validSig = nym_->Verify(
+            proto::ProtoAsData(SigVersion()),
+            *(signatures_.front()));
+    }
+
+    if (!validSig) {
+        otErr << __FUNCTION__ << ": invalid signature." << std::endl;
+    }
+
+    return (validNym && validSyntax && validSig);
+}
+} // namespace opentxs

--- a/src/core/contract/peer/PeerRequest.cpp
+++ b/src/core/contract/peer/PeerRequest.cpp
@@ -1,0 +1,323 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#include "opentxs/core/contract/peer/PeerRequest.hpp"
+
+#include "opentxs/core/Log.hpp"
+#include "opentxs/core/Nym.hpp"
+#include "opentxs/core/String.hpp"
+#include "opentxs/core/app/App.hpp"
+#include "opentxs/core/contract/peer/BailmentRequest.hpp"
+#include "opentxs/core/contract/peer/OutBailmentRequest.hpp"
+
+namespace opentxs
+{
+PeerRequest::PeerRequest(
+    const ConstNym& nym,
+    const proto::PeerRequest& serialized)
+      : ot_super(nym)
+      , initiator_(serialized.initiator())
+      , recipient_(serialized.recipient())
+      , cookie_(serialized.cookie())
+      , type_(serialized.type())
+{
+    id_ = Identifier(serialized.id());
+    signatures_.push_front(
+        SerializedSignature(
+            std::make_shared<proto::Signature>(serialized.signature())));
+    version_ = serialized.version();
+}
+
+PeerRequest::PeerRequest(
+    const ConstNym& nym,
+    const Identifier& recipient,
+    const proto::PeerRequestType& type)
+        : ot_super(nym)
+        , initiator_(nym->ID())
+        , recipient_(String(recipient).Get())
+        , type_(type)
+{
+    version_ = 1;
+    auto random = App::Me().Crypto().AES().InstantiateBinarySecretSP();
+    random->randomizeMemory(32);
+    cookie_.CalculateDigest(
+        OTData(random->getMemory(), random->getMemorySize()));
+}
+
+proto::PeerRequest PeerRequest::Contract() const
+{
+    auto contract = SigVersion();
+    *(contract.mutable_signature()) = *(signatures_.front());
+
+    return contract;
+}
+
+PeerRequest* PeerRequest::Create(
+    const ConstNym& nym,
+    const proto::PeerRequestType& type,
+    const Identifier& unitID,
+    const Identifier& serverID)
+{
+    auto unit = App::Me().Contract().UnitDefinition(unitID);
+
+    if (!unit) {
+        otErr << __FUNCTION__ << ": failed to load unit definition."
+              << std::endl;
+
+        return nullptr;
+    }
+
+    std::unique_ptr<PeerRequest> contract;
+
+    switch (type) {
+        case (proto::PEERREQUEST_BAILMENT) : {
+            contract.reset(
+                new BailmentRequest(nym, unit->Nym()->ID(), unitID, serverID));
+            break;
+        }
+        default: {
+            otErr << __FUNCTION__ << ": invalid request type." << std::endl;
+
+            return nullptr;
+        }
+    }
+
+    if (!contract) {
+        otErr << __FUNCTION__ << ": failed to instantiate request."
+              << std::endl;
+
+        return nullptr;
+    }
+
+    if (FinalizeContract(*contract)) {
+        return contract.release();
+    } else {
+        otErr << __FUNCTION__ << ": failed to finalize contract." << std::endl;
+
+        return nullptr;
+    }
+}
+
+PeerRequest* PeerRequest::Create(
+    const ConstNym& nym,
+    const proto::PeerRequestType& type,
+    const Identifier& unitID,
+    const Identifier& serverID,
+    const std::string& terms)
+{
+    auto unit = App::Me().Contract().UnitDefinition(unitID);
+
+    if (!unit) {
+        otErr << __FUNCTION__ << ": failed to load unit definition."
+              << std::endl;
+
+        return nullptr;
+    }
+
+    std::unique_ptr<PeerRequest> contract;
+
+    switch (type) {
+        case (proto::PEERREQUEST_OUTBAILMENT) : {
+            contract.reset(
+                new OutBailmentRequest(
+                    nym, unit->Nym()->ID(), unitID, serverID, terms));
+            break;
+        }
+        default: {
+            otErr << __FUNCTION__ << ": invalid request type." << std::endl;
+
+            return nullptr;
+        }
+    }
+
+    if (!contract) {
+        otErr << __FUNCTION__ << ": failed to instantiate request."
+              << std::endl;
+
+        return nullptr;
+    }
+
+    if (FinalizeContract(*contract)) {
+        return contract.release();
+    } else {
+        otErr << __FUNCTION__ << ": failed to finalize contract." << std::endl;
+
+        return nullptr;
+    }
+}
+
+PeerRequest* PeerRequest::Factory(
+    const ConstNym& nym,
+    const proto::PeerRequest& serialized)
+{
+    if (!proto::Check(serialized, 0, 0xFFFFFFFF)) {
+        otErr << __FUNCTION__ << ": invalid protobuf." << std::endl;
+        return nullptr;
+    }
+
+    std::unique_ptr<PeerRequest> contract;
+
+    switch (serialized.type()) {
+        case (proto::PEERREQUEST_BAILMENT) : {
+            contract.reset(new BailmentRequest(nym, serialized));
+            break;
+        }
+        case (proto::PEERREQUEST_OUTBAILMENT) : {
+            contract.reset(new OutBailmentRequest(nym, serialized));
+            break;
+        }
+        default : {
+            otErr << __FUNCTION__ << ": invalid request type." << std::endl;
+
+            return nullptr;
+        }
+    }
+
+    if (!contract) {
+        otErr << __FUNCTION__ << ": failed to instantiate request."
+              << std::endl;
+
+        return nullptr;
+    }
+    if (!contract->Validate()) {
+        otErr << __FUNCTION__ << ": invalid request." << std::endl;
+
+        return nullptr;
+    }
+
+    return contract.release();
+}
+
+bool PeerRequest::FinalizeContract(PeerRequest& contract)
+{
+    if (!contract.CalculateID()) {
+        otErr << __FUNCTION__ << ": failed to calculate ID." << std::endl;
+
+        return false;
+    }
+
+    if (contract.nym_) {
+        auto serialized = contract.SigVersion();
+        std::shared_ptr<proto::Signature> sig =
+            std::make_shared<proto::Signature>();
+
+        if (contract.nym_->Sign(serialized, *sig)) {
+            contract.signatures_.push_front(sig);
+        }
+    }
+
+    return contract.Validate();
+}
+
+Identifier PeerRequest::GetID() const
+{
+    return GetID(IDVersion());
+}
+
+Identifier PeerRequest::GetID(const proto::PeerRequest& contract)
+{
+    Identifier id;
+    id.CalculateDigest(proto::ProtoAsData(contract));
+    return id;
+}
+
+proto::PeerRequest PeerRequest::IDVersion() const
+{
+    proto::PeerRequest contract;
+
+    contract.set_version(version_);
+    contract.clear_id();         // reinforcing that this field must be blank.
+    contract.set_initiator(String(initiator_).Get());
+    contract.set_recipient(String(recipient_).Get());
+    contract.set_type(type_);
+    contract.set_cookie(String(cookie_).Get());
+    contract.clear_signature();  // reinforcing that this field must be blank.
+
+    return contract;
+}
+
+std::string PeerRequest::Name() const
+{
+    return String(id_).Get();
+}
+
+OTData PeerRequest::Serialize() const
+{
+
+    return proto::ProtoAsData(Contract());
+}
+
+proto::PeerRequest PeerRequest::SigVersion() const
+{
+    auto contract = IDVersion();
+    contract.set_id(String(ID()).Get());
+
+    return contract;
+}
+
+bool PeerRequest::Validate() const
+{
+    bool validNym = false;
+
+    if (nym_) {
+        validNym = nym_->VerifyPseudonym();
+    } else {
+        otErr << __FUNCTION__ << ": invalid nym." << std::endl;
+    }
+
+    bool validSyntax = proto::Check(Contract(), 0, 0xFFFFFFFF);
+
+    if (!validSyntax) {
+        otErr << __FUNCTION__ << ": invalid syntax." << std::endl;
+    }
+
+    bool validSig = false;
+
+    if (nym_) {
+        validSig = nym_->Verify(
+            proto::ProtoAsData(SigVersion()),
+            *(signatures_.front()));
+    }
+
+    if (!validSig) {
+        otErr << __FUNCTION__ << ": invalid signature." << std::endl;
+    }
+
+    return (validNym && validSyntax && validSig);
+}
+} // namespace opentxs

--- a/src/opentxs/opentxs.cpp
+++ b/src/opentxs/opentxs.cpp
@@ -47,6 +47,8 @@
 #include "opentxs/client/commands/CmdAcceptPayments.hpp"
 #include "opentxs/client/commands/CmdAcceptReceipts.hpp"
 #include "opentxs/client/commands/CmdAcceptTransfers.hpp"
+#include "opentxs/client/commands/CmdAcknowledgeBailment.hpp"
+#include "opentxs/client/commands/CmdAcknowledgeOutBailment.hpp"
 #include "opentxs/client/commands/CmdAddAsset.hpp"
 #include "opentxs/client/commands/CmdAddServer.hpp"
 #include "opentxs/client/commands/CmdAddSignature.hpp"
@@ -76,6 +78,8 @@
 #include "opentxs/client/commands/CmdGetMarkets.hpp"
 #include "opentxs/client/commands/CmdGetMyOffers.hpp"
 #include "opentxs/client/commands/CmdGetOffers.hpp"
+#include "opentxs/client/commands/CmdGetPeerReplies.hpp"
+#include "opentxs/client/commands/CmdGetPeerRequests.hpp"
 #include "opentxs/client/commands/CmdGetReceipt.hpp"
 #include "opentxs/client/commands/CmdImportCash.hpp"
 #include "opentxs/client/commands/CmdImportNym.hpp"
@@ -104,6 +108,8 @@
 #include "opentxs/client/commands/CmdRefreshAccount.hpp"
 #include "opentxs/client/commands/CmdRefreshNym.hpp"
 #include "opentxs/client/commands/CmdRegisterNym.hpp"
+#include "opentxs/client/commands/CmdRequestBailment.hpp"
+#include "opentxs/client/commands/CmdRequestOutBailment.hpp"
 #include "opentxs/client/commands/CmdSendCash.hpp"
 #include "opentxs/client/commands/CmdSendCheque.hpp"
 #include "opentxs/client/commands/CmdSendInvoice.hpp"
@@ -177,7 +183,9 @@ const char* categoryName[] = {
 CmdBase* cmds[] = {new CmdAcceptAll,       new CmdAcceptInbox,
                    new CmdAcceptInvoices,  new CmdAcceptMoney,
                    new CmdAcceptPayments,  new CmdAcceptReceipts,
-                   new CmdAcceptTransfers, new CmdAddAsset,
+                   new CmdAcceptTransfers, new CmdAcknowledgeBailment,
+                   new CmdAcknowledgeOutBailment,
+                   new CmdAddAsset,
                    new CmdAddServer,       new CmdAddSignature,
                    new CmdCancel,          new CmdChangePw,
                    new CmdCheckNym,        new CmdClearExpired,
@@ -191,7 +199,8 @@ CmdBase* cmds[] = {new CmdAcceptAll,       new CmdAcceptInbox,
                    new CmdExchangeBasket,  new CmdExportCash,
                    new CmdExportNym,       new CmdGetInstrumentDefinition,
                    new CmdGetMarkets,      new CmdGetMyOffers,
-                   new CmdGetOffers,       new CmdGetReceipt,
+                   new CmdGetOffers,       new CmdGetPeerRequests,
+                   new CmdGetPeerReplies,  new CmdGetReceipt,
                    new CmdImportCash,      new CmdImportNym,
                    new CmdInbox,           new CmdInmail,
                    new CmdInpayments,      new CmdIssueAsset,
@@ -206,6 +215,7 @@ CmdBase* cmds[] = {new CmdAcceptAll,       new CmdAcceptInbox,
                    new CmdPayDividend,     new CmdPayInvoice,
                    new CmdProposePlan,     new CmdRefresh,
                    new CmdRefreshAccount,  new CmdRefreshNym,
+                   new CmdRequestBailment, new CmdRequestOutBailment,
                    new CmdRegisterNym,     new CmdSendCash,
                    new CmdSendCheque,      new CmdSendInvoice,
                    new CmdSendMessage,     new CmdSendVoucher,

--- a/src/server/OTServer.cpp
+++ b/src/server/OTServer.cpp
@@ -384,10 +384,10 @@ void OTServer::CreateMainFile(
     OTASCIIArmor ascContract(signedContract);
     opentxs::String strBookended;
     ascContract.WriteArmoredString(strBookended, "SERVER CONTRACT");
-    OTDB::StorePlainString(strBookended.Get(), "NEW_SERVER_CONTRACT.txt");
+    OTDB::StorePlainString(strBookended.Get(), "NEW_SERVER_CONTRACT.otc");
 
     otOut << "Your server contract has been saved as " << std::endl
-          << " NEW_SERVER_CONTRACT.txt in the server data directory."
+          << " NEW_SERVER_CONTRACT.otc in the server data directory."
           << std::endl;
 
     mainFileExists = mainFile_.CreateMainFile(


### PR DESCRIPTION
Create a new protobuf wrapper for user messages: PeerObject

A PeerObject can contain a message (intended to be read by a human), or a PeerRequest or PeerReply which are intended to be parsed by a script.

Two peer workflows are implemented: bailment and outbailment. They allow a user to coordinate with an issuer to deposit or withdraw the underlying assets.