### PR TITLE
New format for signed protobufs

### DIFF
--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -43,6 +43,7 @@
 #include "opentxs/core/NymIDSource.hpp"
 #include "opentxs/core/Proto.hpp"
 #include "opentxs/core/Types.hpp"
+#include "opentxs/core/crypto/CredentialSet.hpp"
 #include "opentxs/core/crypto/NymParameters.hpp"
 #include "opentxs/core/crypto/OTASCIIArmor.hpp"
 
@@ -57,7 +58,6 @@ namespace opentxs
 {
 
 class OTAsymmetricKey;
-class CredentialSet;
 class Item;
 class OTKeypair;
 class Ledger;
@@ -932,6 +932,45 @@ public:
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;
     bool Verify(const proto::Verification& item) const;
     zcert_t* TransportKey() const;
+
+    template<class T>
+    bool SignProto(
+        T& input,
+        proto::Signature& signature,
+        const OTPasswordData* pPWData = nullptr) const {
+            bool haveSig = false;
+            signature.set_hashtype(proto::HASHTYPE_SHA256);
+
+            for (auto& it: m_mapCredentialSets) {
+                if (nullptr != it.second) {
+                    bool success = it.second->SignProto(
+                        input,
+                        signature,
+                        pPWData);
+
+                    if (success) {
+                        haveSig = true;
+                        break;
+                    } else {
+                        otErr << __FUNCTION__ << ": Credential set "
+                              << it.second->GetMasterCredID() << " could not "
+                              << "sign protobuf." << std::endl;
+                    }
+                }
+                otErr << __FUNCTION__ << ": Did not find any credential sets "
+                        << "capable of signing on this nym." << std::endl;
+            }
+
+            return haveSig;
+    }
+
+    template<class T>
+    bool VerifyProto(T& input, proto::Signature& signature) const {
+        proto::Signature signatureCopy;
+        signatureCopy.CopyFrom(signature);
+        signature.clear_signature();
+        return Verify(proto::ProtoAsData<T>(input), signatureCopy);
+    }
 };
 
 }  // namespace opentxs

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -924,7 +924,6 @@ public:
         const int64_t start = 0,
         const int64_t end = 0,
         const OTPasswordData* pPWData = nullptr) const;
-    bool Sign(const proto::PeerReply& contract, proto::Signature& sig) const;
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;
     bool Verify(const proto::Verification& item) const;
     zcert_t* TransportKey() const;

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -915,17 +915,7 @@ public:
     std::unique_ptr<proto::VerificationSet> VerificationSet() const;
     bool SetVerificationSet(const proto::VerificationSet& data);
 
-    bool Sign(
-        proto::Verification& verification,
-        const OTPasswordData* pPWData = nullptr) const;
-    proto::Verification Sign(
-        const std::string& claim,
-        const bool polarity,
-        const int64_t start = 0,
-        const int64_t end = 0,
-        const OTPasswordData* pPWData = nullptr) const;
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;
-    bool Verify(const proto::Verification& item) const;
     zcert_t* TransportKey() const;
 
     template<class T>

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -924,7 +924,6 @@ public:
         const int64_t start = 0,
         const int64_t end = 0,
         const OTPasswordData* pPWData = nullptr) const;
-    bool Sign(const proto::PeerRequest& contract, proto::Signature& sig) const;
     bool Sign(const proto::PeerReply& contract, proto::Signature& sig) const;
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;
     bool Verify(const proto::Verification& item) const;

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -924,8 +924,6 @@ public:
         const int64_t start = 0,
         const int64_t end = 0,
         const OTPasswordData* pPWData = nullptr) const;
-    bool Sign(const proto::UnitDefinition& contract, proto::Signature& sig)
-        const;
     bool Sign(const proto::PeerRequest& contract, proto::Signature& sig) const;
     bool Sign(const proto::PeerReply& contract, proto::Signature& sig) const;
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -924,7 +924,6 @@ public:
         const int64_t start = 0,
         const int64_t end = 0,
         const OTPasswordData* pPWData = nullptr) const;
-    bool Sign(proto::ServerContract& contract) const;
     bool Sign(const proto::UnitDefinition& contract, proto::Signature& sig)
         const;
     bool Sign(const proto::PeerRequest& contract, proto::Signature& sig) const;

--- a/include/opentxs/core/Proto.hpp
+++ b/include/opentxs/core/Proto.hpp
@@ -51,6 +51,8 @@
 #include "opentxs/core/crypto/OTASCIIArmor.hpp"
 #include "opentxs/core/util/Assert.hpp"
 
+#include <iostream>
+
 namespace opentxs
 {
 namespace proto

--- a/include/opentxs/core/Types.hpp
+++ b/include/opentxs/core/Types.hpp
@@ -36,8 +36,8 @@
  *
  ************************************************************/
 
-#ifndef OPENTXS_CORE_TYPES
-#define OPENTXS_CORE_TYPES
+#ifndef OPENTXS_CORE_TYPES_HPP
+#define OPENTXS_CORE_TYPES_HPP
 
 #include <cstdint>
 #include <set>
@@ -46,6 +46,10 @@
 
 namespace opentxs
 {
+typedef bool CredentialIndexModeFlag;
+static const CredentialIndexModeFlag CREDENTIAL_INDEX_MODE_ONLY_IDS = true;
+static const CredentialIndexModeFlag CREDENTIAL_INDEX_MODE_FULL_CREDS = false;
+
 /** C++11 representation of a claim. This version is more useful than the
  *  protobuf version, since it contains the claim ID.
  */
@@ -88,4 +92,4 @@ enum class StorageBox : std::uint8_t {
 };
 
 } // namespace opentxs
-#endif // OPENTXS_CORE_TYPES
+#endif // OPENTXS_CORE_TYPES_HPP

--- a/include/opentxs/core/app/Identity.hpp
+++ b/include/opentxs/core/app/Identity.hpp
@@ -141,6 +141,10 @@ private:
     void SetAttributesOnClaim(
         proto::ContactItem& item,
         const Claim& claim) const;
+    bool Sign(
+        proto::Verification& plaintext,
+        const Nym& nym,
+        const OTPasswordData* pPWData = nullptr) const;
 
 public:
     /**  Translate an claim attribute enum value to human-readable text

--- a/include/opentxs/core/contract/ServerContract.hpp
+++ b/include/opentxs/core/contract/ServerContract.hpp
@@ -106,7 +106,9 @@ public:
 
     std::string Name() const override { return name_; }
     OTData Serialize() const override;
+    bool UpdateSignature() override;
     bool Validate() const override;
+    bool VerifySignature(const proto::Signature& signature) const override;
 
     EXPORT ~ServerContract() = default;
 };

--- a/include/opentxs/core/contract/Signable.hpp
+++ b/include/opentxs/core/contract/Signable.hpp
@@ -89,6 +89,8 @@ public:
     virtual std::string Terms() const { return conditions_; }
 
     virtual void SetAlias(std::string alias) { alias_ = alias; }
+    virtual bool UpdateSignature();
+    virtual bool VerifySignature(const proto::Signature& signature) const;
 
     virtual std::string Name() const = 0;
     virtual OTData Serialize() const = 0;
@@ -96,7 +98,5 @@ public:
 
     virtual ~Signable() = default;
 };
-
 }  // namespace opentxs
-
 #endif  // OPENTXS_CORE_SIGNABLE_HPP

--- a/include/opentxs/core/contract/UnitDefinition.hpp
+++ b/include/opentxs/core/contract/UnitDefinition.hpp
@@ -164,7 +164,10 @@ public:
     EXPORT OTData Serialize() const override;
     EXPORT bool Validate() const override;
     EXPORT std::string Name() const override { return short_name_; }
+    EXPORT bool UpdateSignature() override;
     EXPORT const proto::UnitDefinition PublicContract() const;
+    EXPORT bool VerifySignature(const proto::Signature& signature) const
+        override;
 
     EXPORT virtual int32_t DecimalPower() const { return 0; }
     EXPORT virtual std::string FractionalUnitName() const { return ""; }

--- a/include/opentxs/core/contract/peer/PeerReply.hpp
+++ b/include/opentxs/core/contract/peer/PeerReply.hpp
@@ -96,7 +96,9 @@ public:
     OTData Serialize() const override;
     const proto::PeerRequestType& Type() const { return type_; }
     void SetAlias(__attribute__((unused)) std::string alias) override {}
+    bool UpdateSignature() override;
     bool Validate() const override;
+    bool VerifySignature(const proto::Signature& signature) const override;
 
     ~PeerReply() = default;
 };

--- a/include/opentxs/core/contract/peer/PeerRequest.hpp
+++ b/include/opentxs/core/contract/peer/PeerRequest.hpp
@@ -103,7 +103,9 @@ public:
     OTData Serialize() const override;
     const proto::PeerRequestType& Type() const { return type_; }
     void SetAlias(__attribute__((unused)) std::string alias) override {}
+    bool UpdateSignature() override;
     bool Validate() const override;
+    bool VerifySignature(const proto::Signature& signature) const override;
 
     ~PeerRequest() = default;
 };

--- a/include/opentxs/core/crypto/Credential.hpp
+++ b/include/opentxs/core/crypto/Credential.hpp
@@ -180,16 +180,6 @@ public:
     virtual bool GetVerificationSet(
         std::unique_ptr<proto::VerificationSet>& verificationSet) const;
 
-    virtual bool Sign(
-        Contract& theContract,
-        const OTPasswordData* pPWData = nullptr) const;
-    virtual bool Sign(
-        const OTData& plaintext,
-        proto::Signature& sig,
-        const OTPasswordData* pPWData = nullptr,
-        const OTPassword* exportPassword = nullptr,
-        const proto::SignatureRole role = proto::SIGROLE_ERROR,
-        proto::KeyRole key = proto::KEYROLE_SIGN) const;
     virtual bool Verify(
         const OTData& plaintext,
         const proto::Signature& sig,

--- a/include/opentxs/core/crypto/CredentialSet.hpp
+++ b/include/opentxs/core/crypto/CredentialSet.hpp
@@ -251,19 +251,6 @@ public:
         const proto::VerificationSet& verificationSet);
 
     bool Sign(
-        const OTData& plaintext,
-        proto::Signature& sig,
-        const OTPasswordData* pPWData = nullptr,
-        const OTPassword* exportPassword = nullptr,
-        const proto::SignatureRole role = proto::SIGROLE_ERROR,
-        proto::KeyRole key = proto::KEYROLE_SIGN) const;
-    bool Sign(
-        const Credential& plaintext,
-        proto::Signature& sig,
-        const OTPasswordData* pPWData = nullptr,
-        const OTPassword* exportPassword = nullptr,
-        const proto::SignatureRole role = proto::SIGROLE_PUBCREDENTIAL) const;
-    bool Sign(
         const MasterCredential& credential,
         const NymParameters& nymParameters,
         proto::Signature& sig,

--- a/include/opentxs/core/crypto/KeyCredential.hpp
+++ b/include/opentxs/core/crypto/KeyCredential.hpp
@@ -168,6 +168,39 @@ public:
         unsigned char* privateKey) const override;
 
     virtual ~KeyCredential();
+
+    template<class C>
+    bool SignProto(
+        C& serialized,
+        proto::Signature& signature,
+        proto::KeyRole key = proto::KEYROLE_SIGN,
+        const OTPasswordData* pPWData = nullptr) const
+            {
+                const OTKeypair* keyToUse = nullptr;
+
+                switch (key) {
+                    case (proto::KEYROLE_AUTH) :
+                        keyToUse = m_AuthentKey.get();
+                        break;
+                    case (proto::KEYROLE_SIGN) :
+                        keyToUse = m_SigningKey.get();
+                        break;
+                    default :
+                        otErr << __FUNCTION__ << ": Can not sign with the "
+                              << "specified key." << std::endl;
+                        return false;
+                }
+
+                if (nullptr != keyToUse) {
+                    return keyToUse->SignProto<C>(
+                        serialized,
+                        signature,
+                        String(ID()),
+                        pPWData);
+                }
+
+                return false;
+            }
 };
 
 } // namespace opentxs

--- a/include/opentxs/core/crypto/KeyCredential.hpp
+++ b/include/opentxs/core/crypto/KeyCredential.hpp
@@ -143,17 +143,6 @@ public:
 
     bool canSign() const override { return hasPrivateData(); }
 
-    using ot_super::Sign;
-    bool Sign(
-        const OTData& plaintext,
-        proto::Signature& sig,
-        const OTPasswordData* pPWData = nullptr,
-        const OTPassword* exportPassword = nullptr,
-        const proto::SignatureRole role = proto::SIGROLE_ERROR,
-        proto::KeyRole key = proto::KEYROLE_SIGN) const override;
-    bool Sign(
-        Contract& theContract,
-        const OTPasswordData* pPWData = nullptr) const override;
     using ot_super::Verify;
     bool Verify(
         const OTData& plaintext,
@@ -161,7 +150,6 @@ public:
         const proto::KeyRole key = proto::KEYROLE_SIGN) const override;
     EXPORT virtual bool VerifySig(
         const proto::Signature& sig,
-        const OTAsymmetricKey& theKey,
         const CredentialModeFlag asPrivate = Credential::PRIVATE_VERSION) const;
     bool TransportKey(
         unsigned char* publicKey,

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -314,6 +314,11 @@ public:
                 signature.set_version(1);
                 signature.set_credentialid(credID.Get());
 
+                if ((proto::HASHTYPE_ERROR == signature.hashtype()) ||
+                    !signature.has_hashtype()) {
+                    signature.set_hashtype(proto::HASHTYPE_SHA256);
+                }
+
                 OTData sig;
                 bool goodSig = engine().Sign(
                     proto::ProtoAsData<C>(serialized),

--- a/include/opentxs/core/crypto/OTAsymmetricKey.hpp
+++ b/include/opentxs/core/crypto/OTAsymmetricKey.hpp
@@ -39,6 +39,7 @@
 #ifndef OPENTXS_CORE_CRYPTO_OTASYMMETRICKEY_HPP
 #define OPENTXS_CORE_CRYPTO_OTASYMMETRICKEY_HPP
 
+#include "opentxs/core/Log.hpp"
 #include "opentxs/core/OTData.hpp"
 #include "opentxs/core/Proto.hpp"
 #include "opentxs/core/String.hpp"
@@ -295,6 +296,39 @@ public:
     virtual bool TransportKey(
         unsigned char* publicKey,
         unsigned char* privateKey) const = 0;
+
+    template<class C>
+    bool SignProto(
+        C& serialized,
+        proto::Signature& signature,
+        const String credID = "",
+        const OTPasswordData* pPWData = nullptr) const
+            {
+                if (IsPublic()) {
+                    otErr << "You must use private keys to create signatures."
+                          << std::endl;
+
+                    return false;
+                }
+
+                signature.set_version(1);
+                signature.set_credentialid(credID.Get());
+
+                OTData sig;
+                bool goodSig = engine().Sign(
+                    proto::ProtoAsData<C>(serialized),
+                    *this,
+                    static_cast<CryptoHash::HashType>(signature.hashtype()),
+                    sig,
+                    pPWData,
+                    nullptr);
+
+                if (goodSig) {
+                    signature.set_signature(sig.GetPointer(), sig.GetSize());
+                }
+
+                return goodSig;
+            }
 };
 
 }  // namespace opentxs

--- a/include/opentxs/core/crypto/OTKeypair.hpp
+++ b/include/opentxs/core/crypto/OTKeypair.hpp
@@ -97,11 +97,6 @@ public:
     // of a self-signed MasterCredential
     EXPORT bool GetPublicKey(String& strKey) const;
 
-    // Only works if a private key is present.
-    //
-    EXPORT bool SignContract(
-        Contract& theContract,
-        const OTPasswordData* pPWData = nullptr);
     // TODO this violates encapsulation and should be deprecated
     EXPORT int32_t GetPublicKeyBySignature(
         listOfAsymmetricKeys& listOutput,  // inclusive means, return keys when
@@ -118,13 +113,6 @@ public:
     EXPORT ~OTKeypair();
 
     serializedAsymmetricKey Serialize(bool privateKey = false) const;
-    bool Sign(
-        const OTData& plaintext,
-        const String& credID,
-        proto::Signature& sig,
-        const OTPasswordData* pPWData = nullptr,
-        const OTPassword* exportPassword = nullptr,
-        const proto::SignatureRole role = proto::SIGROLE_ERROR) const;
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;
     bool TransportKey(unsigned char* publicKey, unsigned char* privateKey)
         const;

--- a/include/opentxs/core/crypto/OTKeypair.hpp
+++ b/include/opentxs/core/crypto/OTKeypair.hpp
@@ -128,6 +128,27 @@ public:
     bool Verify(const OTData& plaintext, const proto::Signature& sig) const;
     bool TransportKey(unsigned char* publicKey, unsigned char* privateKey)
         const;
+
+    template<class C>
+    bool SignProto(
+        C& serialized,
+        proto::Signature& signature,
+        const String credID = "",
+        const OTPasswordData* pPWData = nullptr) const
+            {
+                if (!m_pkeyPrivate) {
+                    otErr << __FUNCTION__ << ": Missing private key. Can not "
+                          << "sign." << std::endl;
+
+                    return false;
+                }
+
+                return m_pkeyPrivate->SignProto<C>(
+                    serialized,
+                    signature,
+                    credID,
+                    pPWData);
+            }
 };
 
 }  // namespace opentxs

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -53,7 +53,6 @@
 #include "opentxs/core/String.hpp"
 #include "opentxs/core/app/App.hpp"
 #include "opentxs/core/crypto/Credential.hpp"
-#include "opentxs/core/crypto/CredentialSet.hpp"
 #include "opentxs/core/crypto/NymParameters.hpp"
 #include "opentxs/core/crypto/OTASCIIArmor.hpp"
 #include "opentxs/core/crypto/OTPasswordData.hpp"
@@ -2851,7 +2850,7 @@ bool Nym::ReEncryptPrivateCredentials(
 
 const serializedCredentialIndex Nym::asPublicNym() const
 {
-    return SerializeCredentialIndex(Nym::FULL_CREDS);
+    return SerializeCredentialIndex(CREDENTIAL_INDEX_MODE_FULL_CREDS);
 }
 
 void Nym::GetPrivateCredentials(String& strCredList, String::Map* pmapCredFiles)

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -4977,98 +4977,11 @@ bool Nym::SetVerificationSet(const proto::VerificationSet& data)
     return false;
 }
 
-bool Nym::Sign(proto::Verification& verification, const OTPasswordData* pPWData)
-    const
-{
-    std::unique_ptr<proto::Signature> sig;
-    sig.reset(new proto::Signature());
-
-    bool haveSig = false;
-
-    for (auto& it : m_mapCredentialSets) {
-        if (nullptr != it.second) {
-            bool success = it.second->Sign(
-                proto::ProtoAsData<proto::Verification>(verification),
-                *sig,
-                pPWData,
-                nullptr,
-                proto::SIGROLE_CLAIM);
-
-            if (success) {
-                haveSig = true;
-                break;
-            }
-        }
-    }
-
-    if (haveSig) {
-        verification.clear_sig();
-        verification.set_allocated_sig(sig.release());
-    }
-
-    return haveSig;
-}
-
-proto::Verification Nym::Sign(
-    const std::string& claim,
-    const bool polarity,
-    const int64_t start,
-    const int64_t end,
-    const OTPasswordData* pPWData) const
-{
-    proto::Verification output;
-    output.set_version(1);
-    output.set_claim(claim);
-    output.set_valid(polarity);
-    output.set_start(start);
-    output.set_end(end);
-
-    std::unique_ptr<proto::Signature> sig;
-    sig.reset(new proto::Signature());
-
-    bool haveSig = false;
-
-    for (auto& it : m_mapCredentialSets) {
-        if (nullptr != it.second) {
-            bool success = it.second->Sign(
-                proto::ProtoAsData<proto::Verification>(output),
-                *sig,
-                pPWData,
-                nullptr,
-                proto::SIGROLE_CLAIM);
-
-            if (success) {
-                haveSig = true;
-                break;
-            }
-        }
-    }
-
-    if (haveSig) {
-        output.set_allocated_sig(sig.release());
-    }
-
-    return output;
-}
-
 bool Nym::Verify(const OTData& plaintext, const proto::Signature& sig) const
 {
     for (auto& it : m_mapCredentialSets) {
         if (nullptr != it.second) {
             if (it.second->Verify(plaintext, sig)) {
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
-bool Nym::Verify(const proto::Verification& item) const
-{
-    for (auto& it : m_mapCredentialSets) {
-        if (nullptr != it.second) {
-            if (it.second->Verify(item)) {
                 return true;
             }
         }

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -5051,34 +5051,6 @@ proto::Verification Nym::Sign(
     return output;
 }
 
-bool Nym::Sign(proto::ServerContract& contract) const
-{
-    std::unique_ptr<proto::Signature> sig(new proto::Signature());
-    bool haveSig = false;
-
-    for (auto& it : m_mapCredentialSets) {
-        if (nullptr != it.second) {
-            bool success = it.second->Sign(
-                proto::ProtoAsData<proto::ServerContract>(contract),
-                *sig,
-                nullptr,
-                nullptr,
-                proto::SIGROLE_SERVERCONTRACT);
-
-            if (success) {
-                haveSig = true;
-                break;
-            }
-        }
-    }
-
-    if (haveSig) {
-        contract.set_allocated_signature(sig.release());
-    }
-
-    return haveSig;
-}
-
 bool Nym::Sign(const proto::UnitDefinition& contract, proto::Signature& sig)
     const
 {

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -5051,29 +5051,6 @@ proto::Verification Nym::Sign(
     return output;
 }
 
-bool Nym::Sign(const proto::PeerRequest& contract, proto::Signature& sig) const
-{
-    bool haveSig = false;
-
-    for (auto& it : m_mapCredentialSets) {
-        if (nullptr != it.second) {
-            bool success = it.second->Sign(
-                proto::ProtoAsData(contract),
-                sig,
-                nullptr,
-                nullptr,
-                proto::SIGROLE_PEERREQUEST);
-
-            if (success) {
-                haveSig = true;
-                break;
-            }
-        }
-    }
-
-    return haveSig;
-}
-
 bool Nym::Sign(const proto::PeerReply& contract, proto::Signature& sig) const
 {
     bool haveSig = false;

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -5051,29 +5051,6 @@ proto::Verification Nym::Sign(
     return output;
 }
 
-bool Nym::Sign(const proto::PeerReply& contract, proto::Signature& sig) const
-{
-    bool haveSig = false;
-
-    for (auto& it : m_mapCredentialSets) {
-        if (nullptr != it.second) {
-            bool success = it.second->Sign(
-                proto::ProtoAsData(contract),
-                sig,
-                nullptr,
-                nullptr,
-                proto::SIGROLE_PEERREPLY);
-
-            if (success) {
-                haveSig = true;
-                break;
-            }
-        }
-    }
-
-    return haveSig;
-}
-
 bool Nym::Verify(const OTData& plaintext, const proto::Signature& sig) const
 {
     for (auto& it : m_mapCredentialSets) {

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -5051,30 +5051,6 @@ proto::Verification Nym::Sign(
     return output;
 }
 
-bool Nym::Sign(const proto::UnitDefinition& contract, proto::Signature& sig)
-    const
-{
-    bool haveSig = false;
-
-    for (auto& it : m_mapCredentialSets) {
-        if (nullptr != it.second) {
-            bool success = it.second->Sign(
-                proto::ProtoAsData<proto::UnitDefinition>(contract),
-                sig,
-                nullptr,
-                nullptr,
-                proto::SIGROLE_UNITDEFINITION);
-
-            if (success) {
-                haveSig = true;
-                break;
-            }
-        }
-    }
-
-    return haveSig;
-}
-
 bool Nym::Sign(const proto::PeerRequest& contract, proto::Signature& sig) const
 {
     bool haveSig = false;

--- a/src/core/app/Identity.cpp
+++ b/src/core/app/Identity.cpp
@@ -195,7 +195,7 @@ bool Identity::AddInternalVerification(
 
         changed = true;
 
-        return onNym.Sign(newVerification, pPWData);
+        return Sign(newVerification, onNym, pPWData);
     }
 
     return true;
@@ -572,6 +572,18 @@ void Identity::SetAttributesOnClaim(
     for (auto& attribute : std::get<6>(claim)) {
         item.add_attribute(static_cast<proto::ContactItemAttribute>(attribute));
     }
+}
+
+bool Identity::Sign(
+    proto::Verification& plaintext,
+    const Nym& nym,
+    const OTPasswordData* pPWData) const
+{
+    plaintext.clear_sig();
+    auto& signature = *plaintext.mutable_sig();
+    signature.set_role(proto::SIGROLE_CLAIM);
+
+    return nym.SignProto(plaintext, signature, pPWData);
 }
 
 std::unique_ptr<proto::VerificationSet> Identity::Verifications(

--- a/src/core/contract/Signable.cpp
+++ b/src/core/contract/Signable.cpp
@@ -37,6 +37,7 @@
  ************************************************************/
 
 #include "opentxs/core/contract/Signable.hpp"
+#include "opentxs/core/Log.hpp"
 
 namespace opentxs
 {
@@ -46,4 +47,26 @@ Signable::Signable(const ConstNym& nym)
 {
 }
 
+bool Signable::UpdateSignature()
+{
+    if (!nym_) {
+        otErr << __FUNCTION__ << ": Missing nym." << std::endl;
+
+        return false;
+    }
+
+    return true;
+}
+
+bool Signable::VerifySignature(
+    __attribute__((unused)) const proto::Signature& signature) const
+{
+    if (!nym_) {
+        otErr << __FUNCTION__ << ": Missing nym." << std::endl;
+
+        return false;
+    }
+
+    return true;
+}
 } // namespace opentxs

--- a/src/core/contract/basket/BasketContract.cpp
+++ b/src/core/contract/basket/BasketContract.cpp
@@ -79,8 +79,7 @@ bool BasketContract::FinalizeTemplate(
         proto::UnitDefinition basket = contract->SigVersion();
         std::shared_ptr<proto::Signature> sig =
             std::make_shared<proto::Signature>();
-        if (contract->nym_->Sign(basket, *sig)) {
-            contract->signatures_.push_front(sig);
+        if (contract->UpdateSignature()) {
             serialized = contract->PublicContract();
 
             return proto::Check(serialized, 0, 0xFFFFFFFF, false);

--- a/src/core/crypto/Credential.cpp
+++ b/src/core/crypto/Credential.cpp
@@ -548,16 +548,22 @@ bool Credential::AddMasterSignature()
 
     SerializedSignature serializedMasterSignature =
         std::make_shared<proto::Signature>();
+    auto serialized = asSerialized(
+        Credential::AS_PUBLIC, Credential::WITHOUT_SIGNATURES);
+    auto& signature = *serialized->add_signature();
+    signature.set_role(proto::SIGROLE_PUBCREDENTIAL);
 
     bool havePublicSig =
-        owner_backlink_->Sign(*this, *serializedMasterSignature);
+        owner_backlink_->SignProto(
+            *serialized,
+            signature);
 
     if (!havePublicSig) {
         otErr << __FUNCTION__
               << ": Failed to obtain signature from master credential.\n";
         return false;
     }
-
+    serializedMasterSignature->CopyFrom(signature);
     signatures_.push_back(serializedMasterSignature);
 
     return true;
@@ -578,32 +584,6 @@ bool Credential::GetContactData(
 bool Credential::GetVerificationSet(
     __attribute__((unused))
     std::unique_ptr<proto::VerificationSet>& verificationSet) const
-{
-    OT_ASSERT_MSG(false, "This method was called on the wrong credential.\n");
-
-    return false;
-}
-
-/** Override this method for credentials capable of signing Contracts and
- * producing xml signatures. */
-bool Credential::Sign(
-    __attribute__((unused)) Contract& theContract,
-    __attribute__((unused)) const OTPasswordData* pPWData) const
-{
-    OT_ASSERT_MSG(false, "This method was called on the wrong credential.\n");
-
-    return false;
-}
-
-/** Override this method for credentials capable of signing binary data and
- * producing protobuf signatures. */
-bool Credential::Sign(
-    __attribute__((unused)) const OTData& plaintext,
-    __attribute__((unused)) proto::Signature& sig,
-    __attribute__((unused)) const OTPasswordData* pPWData,
-    __attribute__((unused)) const OTPassword* exportPassword,
-    __attribute__((unused)) const proto::SignatureRole role,
-    __attribute__((unused)) proto::KeyRole key) const
 {
     OT_ASSERT_MSG(false, "This method was called on the wrong credential.\n");
 

--- a/src/core/crypto/CredentialSet.cpp
+++ b/src/core/crypto/CredentialSet.cpp
@@ -1234,10 +1234,13 @@ bool CredentialSet::Verify(
 
 bool CredentialSet::Verify(const proto::Verification& item) const
 {
-    proto::Signature sig = item.sig();
-    proto::Verification signingForm = VerificationCredential::SigningForm(item);
+    auto serialized = VerificationCredential::SigningForm(item);
+    auto& signature = *serialized.mutable_sig();
+    proto::Signature signatureCopy;
+    signatureCopy.CopyFrom(signature);
+    signature.clear_signature();
 
-    return Verify(proto::ProtoAsData<proto::Verification>(signingForm), sig);
+    return Verify(proto::ProtoAsData(serialized), signatureCopy);
 }
 
 bool CredentialSet::TransportKey(

--- a/src/core/crypto/CredentialSet.cpp
+++ b/src/core/crypto/CredentialSet.cpp
@@ -985,7 +985,7 @@ SerializedCredentialSet CredentialSet::Serialize(
     credSet->set_nymid(m_strNymID.Get());
     credSet->set_masterid(GetMasterCredID().Get());
 
-    if (Nym::ONLY_IDS == mode) {
+    if (CREDENTIAL_INDEX_MODE_ONLY_IDS == mode) {
         credSet->set_mode(proto::CREDSETMODE_INDEX);
 
         for (auto& it : m_mapCredentials) {

--- a/src/core/crypto/CredentialSet.cpp
+++ b/src/core/crypto/CredentialSet.cpp
@@ -1141,69 +1141,12 @@ bool CredentialSet::AddVerificationCredential(
 }
 
 bool CredentialSet::Sign(
-    const OTData& plaintext,
-    proto::Signature& sig,
-    const OTPasswordData* pPWData,
-    const OTPassword* exportPassword,
-    const proto::SignatureRole role,
-    proto::KeyRole key) const
-{
-    switch (role) {
-        case (proto::SIGROLE_PUBCREDENTIAL):
-            return m_MasterCredential->Sign(
-                plaintext, sig, pPWData, exportPassword, role, key);
-
-            break;
-        case (proto::SIGROLE_NYMIDSOURCE):
-            otErr << __FUNCTION__ << ": Credentials to be signed with a nym"
-                  << " source can not use this method.\n";
-
-            return false;
-        case (proto::SIGROLE_PRIVCREDENTIAL):
-            otErr << __FUNCTION__ << ": Private credential can not use this "
-                  << "method.\n";
-
-            return false;
-        default:
-            // Find the first private child credential, and use it to sign
-            for (auto& it : m_mapCredentials) {
-                if (nullptr != it.second) {
-                    if (it.second->canSign()) {
-                        return it.second->Sign(
-                            plaintext, sig, pPWData, exportPassword, role, key);
-                    }
-                }
-            }
-    }
-
-    return false;
-}
-
-bool CredentialSet::Sign(
     const MasterCredential& credential,
     const NymParameters& nymParameters,
     proto::Signature& sig,
     const OTPasswordData* pPWData) const
 {
     return nym_id_source_->Sign(nymParameters, credential, sig, pPWData);
-}
-
-bool CredentialSet::Sign(
-    const Credential& plaintext,
-    proto::Signature& sig,
-    const OTPasswordData* pPWData,
-    const OTPassword* exportPassword,
-    const proto::SignatureRole role) const
-{
-    serializedCredential serialized = plaintext.asSerialized(
-        Credential::AS_PUBLIC, Credential::WITHOUT_SIGNATURES);
-
-    return Sign(
-        proto::ProtoAsData<proto::Credential>(*serialized),
-        sig,
-        pPWData,
-        exportPassword,
-        role);
 }
 
 bool CredentialSet::Verify(

--- a/src/core/crypto/MasterCredential.cpp
+++ b/src/core/crypto/MasterCredential.cpp
@@ -232,12 +232,11 @@ bool MasterCredential::Verify(const Credential& credential) const
         return false;
     }
 
-    if (!m_SigningKey) {
-        otErr << __FUNCTION__ << ": Master is missing signing keypair.\n";
-        return false;
-    }
+    auto& signature = *serializedCred->add_signature();
+    signature.CopyFrom(*masterSig);
+    signature.clear_signature();
 
-    return m_SigningKey->Verify(
+    return Verify(
         proto::ProtoAsData<proto::Credential>(*serializedCred), *masterSig);
 }
 

--- a/src/core/crypto/OTAsymmetricKey.cpp
+++ b/src/core/crypto/OTAsymmetricKey.cpp
@@ -39,7 +39,6 @@
 #include "opentxs/core/crypto/OTAsymmetricKey.hpp"
 
 #include "opentxs/core/Identifier.hpp"
-#include "opentxs/core/Log.hpp"
 #include "opentxs/core/OTData.hpp"
 #include "opentxs/core/String.hpp"
 #include "opentxs/core/app/App.hpp"

--- a/src/core/crypto/OTKeypair.cpp
+++ b/src/core/crypto/OTKeypair.cpp
@@ -193,14 +193,6 @@ bool OTKeypair::MakeNewKeypair(const NymParameters& nymParameters)
     // set.
 }
 
-bool OTKeypair::SignContract(Contract& theContract,
-                             const OTPasswordData* pPWData)
-{
-    OT_ASSERT(m_pkeyPrivate);
-
-    return theContract.SignWithKey(*m_pkeyPrivate, pPWData);
-}
-
 // PUBLIC KEY
 
 // Get a public key as an opentxs::String.
@@ -339,29 +331,6 @@ serializedAsymmetricKey OTKeypair::Serialize(bool privateKey) const
     } else {
         return m_pkeyPublic->Serialize();
     }
-}
-
-bool OTKeypair::Sign(
-    const OTData& plaintext,
-    const String& credID,
-    proto::Signature& sig,
-    const OTPasswordData* pPWData,
-    const OTPassword* exportPassword,
-    const proto::SignatureRole role) const
-{
-    if (!m_pkeyPrivate) {
-        otErr << __FUNCTION__ << ": Missing private key. Can not sign.\n";
-
-        return false;
-    }
-
-    return m_pkeyPrivate->Sign(
-        plaintext,
-        sig,
-        pPWData,
-        exportPassword,
-        credID,
-        role);
 }
 
 bool OTKeypair::Verify(


### PR DESCRIPTION
Previously the metadata fields in Signature protobuf messages were not covered by the signature since the message to be signed was serialized without the embedded Signature message.

Now every time a protobuf is serialized for signing, it's serialized with fully-instantiated embedded Signature message except that the byte field for holding the signature itself is blank.