### PR TITLE
Implement keep alive for server connections

### DIFF
--- a/include/opentxs/client/OTAPI_Exec.hpp
+++ b/include/opentxs/client/OTAPI_Exec.hpp
@@ -4377,6 +4377,8 @@ public:
         const std::string& words,
         const std::string& passphrase) const;
 
+    EXPORT void SetZMQKeepAlive(const std::uint64_t seconds) const;
+
 protected:
     static bool bInitOTApp;
     static bool bCleanupOTApp;

--- a/include/opentxs/client/OTAPI_Wrap.hpp
+++ b/include/opentxs/client/OTAPI_Wrap.hpp
@@ -4302,13 +4302,12 @@ public:
         const std::string& words,
         const std::string& passphrase);
 
+    EXPORT static void SetZMQKeepAlive(const std::uint64_t seconds);
+
 private:
     OTAPI_Wrap();
-    ~OTAPI_Wrap()
-    {
-    }
+    ~OTAPI_Wrap() = default;
 };
-
 } // namespace opentxs
 
 #endif // OPENTXS_CLIENT_OTAPI_HPP

--- a/include/opentxs/network/ServerConnection.hpp
+++ b/include/opentxs/network/ServerConnection.hpp
@@ -42,9 +42,12 @@
 #include "opentxs/core/Types.hpp"
 #include "opentxs/network/ZMQ.hpp"
 
+#include <atomic>
+#include <ctime>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 
 namespace opentxs
 {
@@ -58,12 +61,12 @@ private:
     friend class ZMQ;
 
     std::shared_ptr<const ServerContract> remote_contract_;
-
     const std::string remote_endpoint_;
-
     zsock_t* request_socket_{nullptr};
-
     std::unique_ptr<std::mutex> lock_;
+    std::unique_ptr<std::thread> thread_;
+    std::atomic<std::time_t> last_activity_;
+    std::atomic<bool> shutdown_;
 
     static std::string GetRemoteEndpoint(
         const std::string& server,
@@ -71,10 +74,12 @@ private:
 
     void Init();
     bool Receive(std::string& reply);
-    void Reset();
+    void ResetSocket();
+    void ResetTimer();
     void SetRemoteKey();
     void SetProxy();
     void SetTimeouts();
+    void Thread();
 
     ServerConnection() = delete;
     ServerConnection(const std::string& server);

--- a/include/opentxs/network/ZMQ.hpp
+++ b/include/opentxs/network/ZMQ.hpp
@@ -51,6 +51,7 @@ extern "C" {
 }
 // IWYU pragma: end_exports
 
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -78,6 +79,7 @@ private:
     std::chrono::seconds linger_;
     std::chrono::seconds receive_timeout_;
     std::chrono::seconds send_timeout_;
+    mutable std::atomic<std::chrono::seconds> keep_alive_;
 
     std::string socks_proxy_;
 
@@ -93,6 +95,8 @@ private:
     ZMQ& operator=(const ZMQ&&) = delete;
 
 public:
+    std::chrono::seconds KeepAlive() const;
+    void KeepAlive(const std::chrono::seconds duration) const;
     std::chrono::seconds Linger();
     std::chrono::seconds ReceiveTimeout();
     std::chrono::seconds SendTimeout();

--- a/src/client/OTAPI_Exec.cpp
+++ b/src/client/OTAPI_Exec.cpp
@@ -17377,4 +17377,9 @@ bool OTAPI_Exec::AddClaim(
 
     return SetClaim(nymID, section,  proto::ProtoAsString(*claim));
 }
+
+void OTAPI_Exec::SetZMQKeepAlive(const std::uint64_t seconds) const
+{
+    App::Me().ZMQ().KeepAlive(std::chrono::seconds(seconds));
+}
 }  // namespace opentxs

--- a/src/client/OTAPI_Wrap.cpp
+++ b/src/client/OTAPI_Wrap.cpp
@@ -2930,4 +2930,9 @@ std::string OTAPI_Wrap::Wallet_ImportSeed(
 {
     return Exec()->Wallet_ImportSeed(words, passphrase);
 }
+
+void OTAPI_Wrap::SetZMQKeepAlive(const std::uint64_t seconds)
+{
+    Exec()->SetZMQKeepAlive(seconds);
+}
 } // namespace opentxs

--- a/src/network/ZMQ.cpp
+++ b/src/network/ZMQ.cpp
@@ -45,6 +45,7 @@
 #define CLIENT_SOCKET_LINGER 1000
 #define CLIENT_SEND_TIMEOUT 1000
 #define CLIENT_RECV_TIMEOUT 10000
+#define KEEP_ALIVE 30
 
 namespace opentxs
 {
@@ -98,9 +99,28 @@ void ZMQ::Init()
         socks,
         haveSocksConfig);
 
+    int64_t keepAlive;
+    config_.CheckSet_long(
+        "Connection",
+        "keep_alive",
+        KEEP_ALIVE,
+        keepAlive,
+        notUsed);
+    keep_alive_.store(std::chrono::seconds(keepAlive));
+
     if (configChecked && haveSocksConfig && socks.Exists()) {
         socks_proxy_ = socks.Get();
     }
+}
+
+std::chrono::seconds ZMQ::KeepAlive() const
+{
+    return keep_alive_.load();
+}
+
+void ZMQ::KeepAlive(const std::chrono::seconds duration) const
+{
+    keep_alive_.store(duration);
 }
 
 std::chrono::seconds ZMQ::Linger()


### PR DESCRIPTION
All server connections monitor time since last activity in a seperate thread.

When more than a configurable interval (default: 30 seconds) has elapsed, an empty message is sent to the server.