### PR TITLE
Only create one child credential during nym creation

### DIFF
--- a/include/opentxs/client/OTAPI_Exec.hpp
+++ b/include/opentxs/client/OTAPI_Exec.hpp
@@ -4399,6 +4399,19 @@ public:
 
     EXPORT bool CheckConnection(const std::string& server) const;
 
+    EXPORT std::string AddChildEd25519Credential(
+        const Identifier& nymID,
+        const Identifier& masterID) const;
+
+    EXPORT std::string AddChildSecp256k1Credential(
+        const Identifier& nymID,
+        const Identifier& masterID) const;
+
+    EXPORT std::string AddChildRSACredential(
+        const Identifier& nymID,
+        const Identifier& masterID,
+        const std::uint32_t keysize) const;
+
 protected:
     static bool bInitOTApp;
     static bool bCleanupOTApp;

--- a/include/opentxs/client/OTAPI_Wrap.hpp
+++ b/include/opentxs/client/OTAPI_Wrap.hpp
@@ -4325,6 +4325,19 @@ public:
 
     EXPORT static bool CheckConnection(const std::string& server);
 
+    EXPORT static std::string AddChildEd25519Credential(
+        const std::string& nymID,
+        const std::string& masterID);
+
+    EXPORT static std::string AddChildSecp256k1Credential(
+        const std::string& nymID,
+        const std::string& masterID);
+
+    EXPORT static std::string AddChildRSACredential(
+        const std::string& nymID,
+        const std::string& masterID,
+        const std::uint32_t keysize);
+
 private:
     OTAPI_Wrap();
     ~OTAPI_Wrap() = default;

--- a/include/opentxs/client/OT_API.hpp
+++ b/include/opentxs/client/OT_API.hpp
@@ -1148,6 +1148,11 @@ public:
 
     EXPORT ConnectionState CheckConnection(const std::string& server) const;
 
+    EXPORT std::string AddChildKeyCredential(
+        const Identifier& nymID,
+        const Identifier& masterID,
+        const NymParameters& nymParameters) const;
+
 private:
     bool LoadConfigFile();
 };

--- a/include/opentxs/core/Nym.hpp
+++ b/include/opentxs/core/Nym.hpp
@@ -904,6 +904,11 @@ public:
 
     EXPORT void ClearOutpayments();  // called by the destructor. (Not intended
                                      // to erase messages from local storage.)
+
+    std::string AddChildKeyCredential(
+        const Identifier& strMasterID,
+        const NymParameters& nymParameters);
+
     void ClearCredentials();
     void ClearAll();
     EXPORT void DisplayStatistics(String& strOutput);

--- a/include/opentxs/core/crypto/CredentialSet.hpp
+++ b/include/opentxs/core/crypto/CredentialSet.hpp
@@ -128,7 +128,6 @@ private:
     std::uint32_t index_{};
     proto::KeyMode mode_{proto::KEYMODE_ERROR};
 
-    bool AddChildKeyCredential(const NymParameters& nymParameters);
     bool CreateMasterCredential(const NymParameters& nymParameters);
 
     CredentialSet();
@@ -246,6 +245,7 @@ public:
     EXPORT ~CredentialSet();
     EXPORT bool WriteCredentials() const;
 
+    std::string AddChildKeyCredential(const NymParameters& nymParameters);
     bool GetContactData(std::unique_ptr<proto::ContactData>& contactData) const;
     void RevokeContactCredentials(std::list<std::string>& contactCredentialIDs);
     bool AddContactCredential(const proto::ContactData& contactData);

--- a/src/client/OTAPI_Wrap.cpp
+++ b/src/client/OTAPI_Wrap.cpp
@@ -2787,7 +2787,7 @@ std::string OTAPI_Wrap::GetContactData_Base64(const std::string nymID)
 {
     return Exec()->GetContactData_Base64(nymID);
 }
-    
+
 bool OTAPI_Wrap::SetContactData(
     const std::string nymID,
     const std::string data)
@@ -2985,5 +2985,30 @@ void OTAPI_Wrap::SetZMQKeepAlive(const std::uint64_t seconds)
 bool OTAPI_Wrap::CheckConnection(const std::string& server)
 {
     return Exec()->CheckConnection(server);
+}
+
+std::string OTAPI_Wrap::AddChildEd25519Credential(
+    const std::string& nymID,
+    const std::string& masterID)
+{
+    return Exec()->AddChildEd25519Credential(
+        Identifier(nymID), Identifier(masterID));
+}
+
+std::string OTAPI_Wrap::AddChildSecp256k1Credential(
+    const std::string& nymID,
+    const std::string& masterID)
+{
+    return Exec()->AddChildSecp256k1Credential(
+        Identifier(nymID), Identifier(masterID));
+}
+
+std::string OTAPI_Wrap::AddChildRSACredential(
+    const std::string& nymID,
+    const std::string& masterID,
+    const std::uint32_t keysize)
+{
+    return Exec()->AddChildRSACredential(
+        Identifier(nymID), Identifier(masterID), keysize);
 }
 } // namespace opentxs

--- a/src/client/OT_API.cpp
+++ b/src/client/OT_API.cpp
@@ -14085,4 +14085,19 @@ ConnectionState OT_API::CheckConnection(const std::string& server) const
 {
     return App::Me().ZMQ().Status(server);
 }
+
+std::string OT_API::AddChildKeyCredential(
+    const Identifier& nymID,
+    const Identifier& masterID,
+    const NymParameters& nymParameters) const
+{
+    std::string output;
+    Nym* nym = GetOrLoadPrivateNym(nymID, false, __FUNCTION__);
+
+    if (nullptr == nym) { return output; }
+
+    output = nym->AddChildKeyCredential(masterID, nymParameters);
+
+    return output;
+}
 }  // namespace opentxs

--- a/src/core/Nym.cpp
+++ b/src/core/Nym.cpp
@@ -5057,4 +5057,26 @@ bool Nym::hasCapability(const NymCapability& capability) const
 
     return false;
 }
+
+std::string Nym::AddChildKeyCredential(
+    const Identifier& masterID,
+    const NymParameters& nymParameters)
+{
+    std::string output;
+    std::string master = String(masterID).Get();
+    auto it = m_mapCredentialSets.find(master);
+    const bool noMaster = (it == m_mapCredentialSets.end());
+
+    if (noMaster) {
+        otErr << __FUNCTION__ << ": master ID not found." << std::endl;
+
+        return output;
+    }
+
+    if (it->second) {
+        output = it->second->AddChildKeyCredential(nymParameters);
+    }
+
+    return output;
+}
 }  // namespace opentxs


### PR DESCRIPTION
Speeds up nym creation. New API commands available for adding new child key credentials.