### PR TITLE
Bip47 DesignatedPubKey

### DIFF
--- a/include/opentxs/core/Data.hpp
+++ b/include/opentxs/core/Data.hpp
@@ -72,6 +72,8 @@ public:
     EXPORT Data& operator=(const Data& rhs);
     EXPORT Data& operator=(Data&& rhs);
 
+    EXPORT static Data fromHex(const std::string&);
+
     EXPORT bool operator==(const Data& rhs) const;
     EXPORT bool operator!=(const Data& rhs) const;
     EXPORT Data& operator+=(const Data& rhs);

--- a/include/opentxs/core/crypto/Bip47.hpp
+++ b/include/opentxs/core/crypto/Bip47.hpp
@@ -1,0 +1,94 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler\opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#ifndef OPENTXS_CRYPTO_BIP47_HPP
+#define OPENTXS_CRYPTO_BIP47_HPP
+
+#if OT_CRYPTO_USING_LIBBITCOIN
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <bitcoin/bitcoin/utility/data.hpp>
+
+namespace opentxs
+{
+class Data;
+
+/** Extract the designated public key from a BIP-47 notification transaction.
+ *
+ *  This function parses the inputs of the input transaction in index order
+ *  for an eligible input script.
+ *
+ *  An eligible input contains an input script (scriptSig) which spends a
+ *  previous output script (scriptPubKey) of one of the following
+ *  [standard
+ * forms](https://bitcoin.org/en/developer-guide#standard-transactions):
+ *
+ *      - Pubkey
+ *      - Pay to pubkey hash (P2PKH)
+ *      - Multisig
+ *      - P2SH redeeming a pubkey script
+ *      - P2SH redeeming a P2PKH script
+ *      - P2SH redeeming a multisig script
+ *
+ *  The public key (first public key for a multisig script) from the eligible
+ *  input is extracted from the transaction and returned.
+ *
+ *  \param[in] transaction A serialized bitcoin (or equivalent) transaction
+ *
+ *  \returns A smart pointer to the extracted public key. The smart pointer
+ *           is initialized to nullptr if the input transaction does not contain
+ *           a valid input.
+ *           If instantiated, the output will be 33 bytes for a compressed
+ *           pubkey, or 64 bytes for an uncompressed pubkey.
+ */
+std::unique_ptr<Data> DesignatedPubkey(
+    const Data& transaction,
+    const std::vector<Data>& previous_transactions);
+
+namespace bip47
+{
+const libbitcoin::data_chunk ReadData(const Data& d);
+}
+
+}  // namespace opentxs
+
+#endif  // OT_CRYPTO_USING_LIBBITCOIN
+#endif  // OPENTXS_CRYPTO_BIP47_HPP

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -32,6 +32,7 @@ set(cxx-sources
   crypto/AsymmetricKeySecp256k1.cpp
   crypto/Bip32.cpp
   crypto/Bip39.cpp
+  crypto/Bip47.cpp
   crypto/ChildKeyCredential.cpp
   crypto/ContactCredential.cpp
   crypto/Credential.cpp

--- a/src/core/Data.cpp
+++ b/src/core/Data.cpp
@@ -47,6 +47,7 @@
 #include <cstdio>
 #include <iomanip>
 #include <sstream>
+#include <boost/algorithm/hex.hpp>
 
 namespace opentxs
 {
@@ -105,6 +106,20 @@ Data& Data::operator+=(const Data& rhs)
     concatenate(rhs.data_);
 
     return *this;
+}
+
+Data Data::fromHex(const std::string& in)
+{
+    std::vector<std::uint8_t> v;
+
+    for (unsigned int i = 0; i < in.length(); i += 2) {
+        std::string byteString = in.substr(i, 2);
+        std::uint8_t byte =
+            static_cast<std::uint8_t>(strtol(byteString.c_str(), NULL, 16));
+        v.push_back(byte);
+    }
+
+    return Data(v);
 }
 
 std::string Data::asHex() const

--- a/src/core/crypto/Bip47.cpp
+++ b/src/core/crypto/Bip47.cpp
@@ -1,0 +1,349 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#if OT_CRYPTO_USING_LIBBITCOIN
+
+#include <string>
+#include <boost/algorithm/hex.hpp>
+
+#include <bitcoin/bitcoin/chain/script.hpp>
+#include <bitcoin/bitcoin/chain/transaction.hpp>
+#include <bitcoin/bitcoin/chain/output.hpp>
+#include <bitcoin/bitcoin/machine/operation.hpp>
+#include <bitcoin/bitcoin/math/elliptic_curve.hpp>
+
+#include "opentxs/core/stdafx.hpp"
+
+#include "opentxs/core/crypto/Bip47.hpp"
+
+#include "opentxs/core/Data.hpp"
+
+namespace libbitcoin
+{
+
+namespace machine
+{
+
+bool is_public_key_pattern(const operation::list& ops);
+bool is_key_hash_pattern(const operation::list& ops);
+bool is_multisig_script_hash_pattern(
+    unsigned int& middle,
+    const machine::operation::list& ops);
+
+bool is_public_key_pattern(const operation::list& ops)
+{
+    return ops.size() == 3 && is_public_key(ops[1].data()) &&
+           ops[2].code() == machine::opcode::checksig;
+}
+
+bool is_key_hash_pattern(const operation::list& ops)
+{
+    return ops.size() == 7 && is_public_key(ops[1].data()) &&
+           ops[2].code() == opcode::dup && ops[3].code() == opcode::hash160 &&
+           ops[4].data().size() == short_hash_size &&
+           ops[5].code() == opcode::equalverify &&
+           ops[6].code() == opcode::checksig;
+}
+
+bool is_multisig_script_hash_pattern(
+    unsigned int& middle,
+    const machine::operation::list& ops)
+{
+    static constexpr auto op_1 = static_cast<uint8_t>(opcode::push_positive_1);
+    static constexpr auto op_16 =
+        static_cast<uint8_t>(opcode::push_positive_16);
+
+    const auto op_count = ops.size();
+
+    if (op_count < 6 || ops[0].code() != opcode::push_size_0 ||
+        ops[op_count - 1].code() != opcode::checkmultisig)
+        return false;
+
+    const auto op_n = static_cast<uint8_t>(ops[op_count - 2].code());
+
+    int num_signatures = 0;
+    middle = 1;
+    while (true) {
+        if (middle >= op_count) {
+            return false;
+        }
+
+        // The first numeric op we encounter is the middle of the script.
+        if (machine::operation::is_numeric(ops[middle].code())) {
+            break;
+        }
+
+        // check for push data
+        if (!machine::operation::is_push(ops[middle].code())) {
+            return false;
+        }
+
+        num_signatures++;
+        middle++;
+    }
+
+    const auto op_m = static_cast<uint8_t>(ops[middle].code());
+
+    if (op_m < op_1 || op_m > op_n || op_n < op_1 || op_n > op_16) return false;
+
+    const int number = op_n - op_1 + 1u;
+    const int points = op_count - 3u - num_signatures - 1;
+
+    if (number != points) return false;
+
+    for (auto op = ops.begin() + num_signatures + 3; op != ops.end() - 2; ++op)
+        if (!is_public_key(op->data())) return false;
+
+    return true;
+}
+
+}  // machine
+
+}  // libbitcoin
+
+namespace opentxs
+{
+
+bool extract_designated_pubkey(
+    libbitcoin::data_chunk& out,
+    const libbitcoin::machine::operation::list& input,
+    const libbitcoin::machine::operation::list& prevout_script);
+Data* designated_pubkey(
+    const libbitcoin::data_chunk& transaction,
+    const std::vector<Data>& previous_transactions);
+
+bool extract_designated_pubkey(
+    libbitcoin::data_chunk& out,
+    const libbitcoin::machine::operation::list& input,
+    const libbitcoin::machine::operation::list& prevout_script)
+{
+    if (libbitcoin::chain::script::is_pay_public_key_pattern(prevout_script)) {
+        if (libbitcoin::chain::script::is_sign_public_key_pattern(input)) {
+            out = prevout_script[0].data();
+            return true;
+        }
+
+        return false;
+    }
+
+    if (libbitcoin::chain::script::is_pay_key_hash_pattern(prevout_script)) {
+        if (libbitcoin::chain::script::is_sign_key_hash_pattern(input)) {
+            out = input[1].data();
+            return true;
+        }
+
+        return false;
+    }
+
+    if (libbitcoin::chain::script::is_pay_multisig_pattern(prevout_script)) {
+        if (libbitcoin::chain::script::is_sign_multisig_pattern(input)) {
+            out = prevout_script[1].data();
+            return true;
+        }
+
+        return false;
+    }
+
+    if (!libbitcoin::chain::script::is_pay_script_hash_pattern(
+            prevout_script)) {
+        return false;
+    }
+
+    if (is_public_key_pattern(input)) {
+        out = input[1].data();
+        return true;
+    }
+
+    if (is_key_hash_pattern(input)) {
+        out = input[1].data();
+        return true;
+    }
+
+    unsigned int middle;
+    if (is_multisig_script_hash_pattern(middle, input)) {
+        out = input[middle + 1].data();
+        return true;
+    }
+
+    return false;
+}
+
+const libbitcoin::data_chunk bip47::ReadData(const Data& d)
+{
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(d.GetPointer());
+    return std::vector<std::uint8_t>(p, p + d.GetSize());
+}
+
+// The previous transactions are not necessarily given in order.
+Data* designated_pubkey(
+    const libbitcoin::data_chunk& transaction,
+    const std::vector<Data>& previous_transactions)
+{
+    // Deserialize tx
+    libbitcoin::chain::transaction tx =
+        libbitcoin::chain::transaction::factory(transaction);
+    if (!tx.is_valid()) {
+        return nullptr;
+    }
+
+    auto inputs = tx.inputs();
+    const unsigned int size = inputs.size();
+    if (size < 1 || size != previous_transactions.size()) {
+        return nullptr;
+    }
+
+    // A type used to iterate over the previous transactions, which might be out
+    // of order.
+    class matcher
+    {
+    public:
+        const unsigned int size;
+        const std::vector<Data>& previous_transactions;
+
+        // Keep track of which txs have been matched.
+        std::vector<bool> matched;
+
+        // Keep track of which txs have been seen;
+        std::vector<bool> seen;
+
+        std::vector<libbitcoin::chain::transaction> txs;
+        std::vector<libbitcoin::hash_digest> hashes;
+
+        libbitcoin::chain::output get(
+            libbitcoin::chain::output_point previous_output)
+        {
+            for (unsigned int i = 0; i < size; i++) {
+                // skip txs that have already been matched.
+                if (matched[i]) continue;
+
+                // The previous tx corresponding to this index.
+                libbitcoin::chain::transaction prev;
+
+                // The hash of the previous tx corresponding to this index.
+                libbitcoin::hash_digest id;
+
+                if (seen[i]) {
+                    prev = txs[i];
+                    id = hashes[i];
+                } else {
+                    prev = libbitcoin::chain::transaction::factory(
+                        bip47::ReadData(previous_transactions[i]));
+                    id = prev.hash();
+
+                    // libbitcoin::reverse_hash(id);
+                }
+
+                // If the hashes don't match, save these and try the next one.
+                if (id != previous_output.hash()) {
+                    txs[i] = prev;
+                    hashes[i] = id;
+                    seen[i] = true;
+
+                    continue;
+                }
+
+                matched[i] = true;
+
+                auto outputs = prev.outputs();
+                if (previous_output.index() < outputs.size()) {
+                    return prev.outputs()[previous_output.index()];
+                }
+
+                // Error case if the input doesn't correspond to an output.
+                return libbitcoin::chain::output();
+            }
+
+            // Invalid output if we go through the whole list and don't find
+            // what we're looking for.
+            return libbitcoin::chain::output();
+        }
+
+        matcher(int z, const std::vector<Data>& p)
+            : size(z)
+            , previous_transactions(p)
+            , matched(std::vector<bool>(size))
+            , seen(std::vector<bool>(size))
+            , txs(std::vector<libbitcoin::chain::transaction>(size))
+            , hashes(std::vector<libbitcoin::hash_digest>(size))
+        {
+            for (int i = 0; i < z; i++) {
+                matched[i] = false;
+                seen[i] = false;
+            }
+        }
+    };
+
+    matcher m(size, previous_transactions);
+
+    libbitcoin::data_chunk out;
+
+    // Go through inputs of this transaction.
+    for (std::vector<libbitcoin::chain::input>::iterator input = inputs.begin();
+         input != inputs.end();
+         ++input) {
+
+        // Get the previous output corresponding to this input.
+        libbitcoin::chain::output output = m.get(input->previous_output());
+
+        // if the output is invalid, something went wrong.
+        if (!output.is_valid()) {
+            return nullptr;
+        }
+
+        if (extract_designated_pubkey(
+                out,
+                input->script().operations(),
+                output.script().operations())) {
+            return new Data(out);
+        }
+    }
+
+    return nullptr;
+}
+
+std::unique_ptr<Data> DesignatedPubkey(
+    const Data& transaction,
+    const std::vector<Data>& previous_transactions)
+{
+    return std::unique_ptr<Data>(
+        designated_pubkey(bip47::ReadData(transaction), previous_transactions));
+}
+
+}  // opentxs
+
+#endif  // OT_CRYPTO_USING_LIBBITCOIN

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -4,6 +4,7 @@ set(name unittests-opentxs)
 
 set(cxx-sources
   Test_Data.cpp
+  crypto/Bip47.cpp
 )
 
 include_directories(
@@ -12,6 +13,12 @@ include_directories(
 )
 
 add_executable(${name} ${cxx-sources})
+
+if (LIBBITCOIN_EXPORT)
+  target_link_libraries(${name} ${LIBBITCOIN_LIBRARIES})
+  target_link_libraries(${name} ${Boost_SYSTEM_LIBRARIES})
+endif()
+
 target_link_libraries(${name} opentxs ${GTEST_BOTH_LIBRARIES})
 set_target_properties(${name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 add_test(${name} ${PROJECT_BINARY_DIR}/tests/${name} --gtest_output=xml:gtestresults.xml)

--- a/tests/core/crypto/Bip47.cpp
+++ b/tests/core/crypto/Bip47.cpp
@@ -1,0 +1,374 @@
+/************************************************************
+ *
+ *                 OPEN TRANSACTIONS
+ *
+ *       Financial Cryptography and Digital Cash
+ *       Library, Protocol, API, Server, CLI, GUI
+ *
+ *       -- Anonymous Numbered Accounts.
+ *       -- Untraceable Digital Cash.
+ *       -- Triple-Signed Receipts.
+ *       -- Cheques, Vouchers, Transfers, Inboxes.
+ *       -- Basket Currencies, Markets, Payment Plans.
+ *       -- Signed, XML, Ricardian-style Contracts.
+ *       -- Scripted smart contracts.
+ *
+ *  EMAIL:
+ *  fellowtraveler@opentransactions.org
+ *
+ *  WEBSITE:
+ *  http://www.opentransactions.org/
+ *
+ *  -----------------------------------------------------
+ *
+ *   LICENSE:
+ *   This Source Code Form is subject to the terms of the
+ *   Mozilla Public License, v. 2.0. If a copy of the MPL
+ *   was not distributed with this file, You can obtain one
+ *   at http://mozilla.org/MPL/2.0/.
+ *
+ *   DISCLAIMER:
+ *   This program is distributed in the hope that it will
+ *   be useful, but WITHOUT ANY WARRANTY; without even the
+ *   implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *   PARTICULAR PURPOSE.  See the Mozilla Public License
+ *   for more details.
+ *
+ ************************************************************/
+
+#if OT_CRYPTO_USING_LIBBITCOIN
+
+#include <gtest/gtest.h>
+#include <bitcoin/bitcoin/chain/script.hpp>
+#include <bitcoin/bitcoin/chain/input.hpp>
+#include <bitcoin/bitcoin/chain/output.hpp>
+#include <bitcoin/bitcoin/chain/transaction.hpp>
+#include <bitcoin/bitcoin/wallet/payment_address.hpp>
+#include <bitcoin/bitcoin/wallet/ec_private.hpp>
+#include <bitcoin/bitcoin/wallet/ec_public.hpp>
+
+#include "opentxs/core/crypto/Bip47.hpp"
+#include "opentxs/core/Data.hpp"
+
+// Some randomly generated private keys that we use to make test scripts. 
+std::vector<libbitcoin::wallet::ec_private> pks = {
+    libbitcoin::wallet::ec_private(std::string("92jzWxyfpnFWWQSuGL2mTAizDg5BFpqrC8K6StMzoXxEdfXHqz5")),
+    libbitcoin::wallet::ec_private(std::string("924REJHf9dqNWT28bhxhKj5fF37hHY1WepBwwhgAX1KkKeRfQCu")), 
+    libbitcoin::wallet::ec_private(std::string("92C1QQ2bx9x69CVsYG1WzGsVVMkpB3CY7GNGBKMtG8vqauV2TNo"))};
+
+std::vector<libbitcoin::wallet::ec_private> extra_pks = {
+    libbitcoin::wallet::ec_private(std::string("L4P4wKfq2uhtFvx9p58SxJmLKDQA6BAxCZGdvUkF79JZtve9Qwgg")),
+    libbitcoin::wallet::ec_private(std::string("L1D4M3eHGXBmiScJp8utABLXX2vhn7t1FP34Z5iZd65KvfTj73Us")), 
+    libbitcoin::wallet::ec_private(std::string("L3Qk2VeASwyYmJEAJmynYhYwREBHJbnEsmE7GSVt26zPf996gtVP")), 
+    libbitcoin::wallet::ec_private(std::string("KwY3d3uNTDNjZmi5KbH1ZZVawszUNsRRsDon6opqhBaiCJ7DP88F")), 
+    libbitcoin::wallet::ec_private(std::string("KwdEDagQ5LuDpa8bgvzWDitEHsjYDxipSyrWQfZe7CJiLEvYMVDa")), 
+    libbitcoin::wallet::ec_private(std::string("L4T85i7xeUTFmU2pEbkyq5Mduo2qPkkJANpwtswN21ezq11L88w1"))};
+
+libbitcoin::wallet::ec_public test_key();
+
+libbitcoin::wallet::ec_public test_key() {
+    static int i = 0;
+    i++;
+    if (i == extra_pks.size()) i = 0;
+    return extra_pks[i].to_public();
+}
+
+libbitcoin::machine::operation push(libbitcoin::data_chunk chunk) {
+    return libbitcoin::machine::operation(chunk);
+}
+
+libbitcoin::machine::operation push(std::string str) {
+    libbitcoin::data_chunk in;
+    libbitcoin::decode_base16(in, str);
+    uint8_t size = in.size();
+    if (size < 1 || size > 75) {
+        // error state
+    }
+    in.insert(in.begin(), &size, &size + 1);
+    return push(in);
+}
+
+namespace opentxs
+{
+
+struct test_script {
+    libbitcoin::machine::operation::list input_script, output_script;
+    
+    // the pay to script hash version of this script. 
+    test_script p2sh() {
+        libbitcoin::machine::operation::list new_input = input_script;
+        new_input.insert(new_input.end(), output_script.begin(), output_script.end());
+        return {new_input, 
+            libbitcoin::chain::script::to_pay_script_hash_pattern(libbitcoin::wallet::payment_address(new_input))};
+    };
+    
+    // test this script to see that the value read matches the given expected value.
+    bool test(libbitcoin::wallet::ec_public expected,
+              unsigned int p, // The index of the redeemed tx in the unsorted list of previous txs.
+              unsigned int q  // The index of the output which is redeemed by the notification tx.
+             ) {
+        std::vector<libbitcoin::chain::output> prev_outputs(q + 1);
+        for (int i = 0; i < q; i ++) {
+            libbitcoin::data_chunk r;
+            libbitcoin::decode_base16(r, "random stuff");
+            prev_outputs[i] = libbitcoin::chain::output(1, libbitcoin::chain::script::to_null_data_pattern(r));
+        }
+        prev_outputs[q] = libbitcoin::chain::output(1, output_script);
+        
+        // Construct a test transaction for the previous output that will be redeemed to 
+        // make the notification tx. 
+        const libbitcoin::chain::transaction prev(0, 0, std::vector<libbitcoin::chain::input>(), prev_outputs);
+        
+        if (!prev.is_valid()) return false;
+        
+        const libbitcoin::hash_digest prev_hash = prev.hash();
+        
+        // The keys that will be used 
+        std::vector<libbitcoin::wallet::ec_public> prev_keys(p);
+        for (int i = 0; i < p; i ++) {
+            prev_keys[i] = test_key();
+        }
+        
+        // The set of input txs as a list of data. The correct one is always last.
+        std::vector<Data> prev_list(p + 1);
+        prev_list[p] = Data(prev.to_data());
+        
+        // The list of input txs that are not the main one we're looking for. 
+        std::vector<libbitcoin::chain::transaction> prev_txs(p);
+        std::vector<libbitcoin::hash_digest> prev_hashes(p);
+        for (int i = 0; i < p; i++) {
+            prev_txs[i] = libbitcoin::chain::transaction(0, 0,
+                std::vector<libbitcoin::chain::input>(),
+                {libbitcoin::chain::output(1,
+                    libbitcoin::chain::script::to_pay_key_hash_pattern(libbitcoin::wallet::payment_address(prev_keys[i], libbitcoin::wallet::payment_address::testnet_p2kh)))});
+            
+            if (!prev_txs[i].is_valid()) return false;
+            
+            prev_hashes[i] = prev_txs[i].hash();
+            prev_list[i] = Data(prev_txs[i].to_data());
+        }
+        
+        // Create the inputs to the test tx. The correct one is always the first one. 
+        std::vector<libbitcoin::chain::input> inputs(p + 1);
+        inputs[0] = libbitcoin::chain::input(libbitcoin::chain::output_point(prev_hash, q), input_script, 0);
+        for (int i = 0; i < p; i ++) {
+            libbitcoin::data_chunk pk;
+            prev_keys[i].to_data(pk);
+            libbitcoin::machine::operation::list alt_input_script = {push("abdcef"), push(pk)};
+            inputs[i + 1] = libbitcoin::chain::input(libbitcoin::chain::output_point(prev_hashes[i], 0), 
+                alt_input_script, 0);
+        }
+        
+        // Construct a test transaction for the inputs. 
+        const libbitcoin::chain::transaction tx(0, 0, 
+            inputs, std::vector<libbitcoin::chain::output>());
+        
+        if (!tx.is_valid()) return false;
+        
+        std::unique_ptr<Data> extracted = DesignatedPubkey(Data(tx.to_data()), prev_list);
+        
+        return extracted != nullptr && expected.encoded() == 
+            libbitcoin::wallet::ec_public(bip47::ReadData(*extracted)).encoded();
+    }
+    
+    // test this script to see that the value read matches the given expected value.
+    bool test(libbitcoin::wallet::ec_public expected) {
+        return test(expected, 0, 0);
+    }
+
+    // Generate standard test scripts. 
+    static test_script p2pk(libbitcoin::wallet::ec_public key, std::string signature) {
+        libbitcoin::data_chunk pk;
+        key.to_data(pk);
+        return {{push(signature)}, libbitcoin::chain::script::to_pay_public_key_pattern(pk)};
+    }
+
+    static test_script p2pkh(libbitcoin::wallet::ec_public key, std::string signature) {
+        libbitcoin::data_chunk pk;
+        key.to_data(pk);
+        return {{push(signature), push(pk)}, libbitcoin::chain::script::to_pay_key_hash_pattern(libbitcoin::wallet::payment_address(key, libbitcoin::wallet::payment_address::testnet_p2kh))};
+    }
+
+    static test_script p2multi(std::queue<std::string> signatures, int minimum, std::queue<libbitcoin::ec_compressed> pubkeys) {
+        std::vector<libbitcoin::ec_compressed> pubs(pubkeys.size());
+        int i = 0;
+        while(!pubkeys.empty()) {
+            pubs[i] = pubkeys.front();
+            pubkeys.pop();
+            i++;
+        }
+        
+        auto multisig = libbitcoin::chain::script::to_pay_multisig_pattern(minimum, pubs);
+        
+        test_script z = {{libbitcoin::machine::operation(libbitcoin::machine::opcode::push_size_0)}, multisig};
+        while (!signatures.empty()) {
+            z.input_script.push_back(push(signatures.front()));
+            signatures.pop();
+        }
+        return z;
+    }
+};
+
+struct test_case {
+    libbitcoin::wallet::ec_public expected;
+    test_script script;
+    
+    bool test() {
+        return script.test(expected);
+    }
+    
+    bool test_p2sh() {
+        return script.p2sh().test(expected);
+    }
+    
+    std::string to_string() {
+        return "{" + libbitcoin::chain::script(script.input_script).to_string(1) + ", " + libbitcoin::chain::script(script.output_script).to_string(1) + "}";
+    }
+};
+
+// Generate a set of multisig test cases. 
+std::queue<test_case> multisig_test_cases() {
+    std::vector<std::string> signatures = {"abcd", "0123", "4567"};
+    std::queue<test_case> test_cases;
+    
+    std::vector<libbitcoin::ec_compressed> pub(pks.size());
+    
+    for (int i = 0; i < pks.size(); i++) {
+        pub[i] = pks[i].to_public();
+    }
+    
+    for (int size = 2; size <= 3; size++) {
+        for (int of = 2; of <= size; of++) {
+            std::queue<std::string> sig;
+                
+            for (int i = 0; i < of; i ++) {
+                sig.push(signatures.at(i));
+            }
+                
+            for(int order = 0; order < pks.size(); order ++) {
+                std::queue<libbitcoin::ec_compressed> keys;
+            
+                libbitcoin::ec_compressed expected = pub.at(order);
+                keys.push(expected);
+                
+                for (int i = 1; i < size; i++) {
+                    keys.push(pub.at((order + i)%pub.size()));
+                }
+                
+                test_cases.push({
+                    expected,
+                    test_script::p2multi(sig, of, keys)});
+            }
+        }
+    }
+    
+    return test_cases;
+}
+
+class raw_test_case {
+public:
+    opentxs::Data tx;
+    std::vector<opentxs::Data> prev;
+    
+    raw_test_case(std::string hex, std::vector<std::string> prev_hex):tx(Data::fromHex(hex)),prev(prev_hex.size()) {
+        auto rtx = libbitcoin::chain::transaction::factory(bip47::ReadData(tx));
+        if (!rtx.is_valid()) {
+            throw "not valid";
+        }
+        
+        for (int i = 0; i < prev_hex.size(); i ++) {
+            prev[i] = Data::fromHex(prev_hex[i]);
+            
+            auto ztx = libbitcoin::chain::transaction::factory(bip47::ReadData(prev[i]));
+            if (!ztx.is_valid()) {
+                throw "not valid";
+            }
+        }
+    }
+};
+    
+// Raw txs that we use as test cases. 
+    std::vector<raw_test_case> raw_test_cases = {raw_test_case( std::string("010000000134d3a0b2a82327028c0ef4de18e08b947b20efde8fa62ef8cf6c5acdfd3371b3000000006a473044022045cf89a6b050746c1178a4a4872f09c6e742cfd7f137a9c928dcb43ed86815c5022070e7f68c4948bfa0d51811ecdac68926f263ddcae3c80bec960b36ca8e3f6b20012102a0a11c882e89165e4965924754b28ae77c02c96feec96fe9372e9a977a331b7cffffffff030000000000000000536a4c5001000318bdb4978d27893924f950659527b35acbb9c8f61a758bcee1605e768035e391c8d631d02b337be070c9c4131c6df0d37646ebee474c877bc55d0a073b32e20e000000000000000000000000002a41bf07000000001976a9141b7f45dd59c8bb33bc0af532f8aefbfe2196b19288acaa0a0000000000001976a91477c40baad31493ac9d6f087831aaffa92617f90988ac00000000"), 
+        {std::string("010000000138ee971d51266752189aea453867a9a4017e8fc494bbc53946032a40490ce8f60100000017160014c069d3bcd52b811ccf677cf850e919075b8d649dffffffff0280a4bf07000000001976a914785babbf897aafb2fd1129d03c6663e44e3ffcc488ac141f9f507400000017a914b192e9c9465fa4b2e67250bcf9adbe5cf45578378700000000")})};
+
+// Test that a basic pay to pubkey tx is recognized and has the correct pubkey returned. 
+TEST(bip47_extract_designated_pubkey, pay_to_pubkey)
+{
+   for (std::vector<libbitcoin::wallet::ec_private>::iterator it = pks.begin(); it != pks.end(); ++it) {
+       auto pub = it->to_public();
+       ASSERT_TRUE(test_script::p2pk(pub, "abcd").test(pub));
+   }
+}
+
+TEST(bip47_extract_designated_pubkey, out_of_order)
+{
+    auto key = pks[0].to_public();
+    for (int i = 1; i < 3; i++) {
+        for (int j = 1; j < 3; j++) {
+            ASSERT_NO_FATAL_FAILURE(test_script::p2pk(key, "abcd").test(key, i, j));
+        }
+    }
+}
+
+TEST(bip47_extract_designated_pubkey, pay_to_pubkey_hash)
+{
+   for (std::vector<libbitcoin::wallet::ec_private>::iterator it = pks.begin(); it != pks.end(); ++it) {
+       auto pub = it->to_public();
+       ASSERT_TRUE(test_script::p2pkh(pub, "abcd").test(pub));
+   }
+}
+
+TEST(bip47_extract_designated_pubkey, pay_to_pubkey_p2sh)
+{
+   for (std::vector<libbitcoin::wallet::ec_private>::iterator it = pks.begin(); it != pks.end(); ++it) {
+       auto pub = it->to_public();
+       ASSERT_TRUE(test_script::p2pk(pub, "abcd").p2sh().test(pub));
+   }
+}
+
+TEST(bip47_extract_designated_pubkey, pay_to_pubkey_hash_p2sh)
+{
+   for (std::vector<libbitcoin::wallet::ec_private>::iterator it = pks.begin(); it != pks.end(); ++it) {
+       auto pub = it->to_public();
+       ASSERT_TRUE(test_script::p2pkh(pub, "abcd").p2sh().test(pub));
+   }
+}
+
+TEST(bip47_extract_designated_pubkey, multisig)
+{
+    std::queue<test_case> test_cases;
+    ASSERT_NO_THROW(test_cases = multisig_test_cases());
+    int i = 0;
+    while (!test_cases.empty()) {
+        ASSERT_TRUE(test_cases.front().test());
+        test_cases.pop();
+        i++;
+    }
+}
+
+TEST(bip47_extract_designated_pubkey, multisig_p2sh)
+{
+    std::queue<test_case> test_cases;
+    ASSERT_NO_THROW(test_cases = multisig_test_cases());
+    int i = 0;
+    while (!test_cases.empty()) {
+        ASSERT_TRUE(test_cases.front().test_p2sh());
+        test_cases.pop();
+        i++;
+    }
+}
+
+// Tests with raw txs. The raw test cases are all valid and we simply tests that nullptr is not returned. 
+// The other tests should have sufficiently demonstrated that the correct pubkey is returned. 
+TEST(bip47_extract_designated_pubkey, raw)
+{
+    for (raw_test_case c : raw_test_cases) {
+        std::unique_ptr<Data> z;
+        ASSERT_NO_THROW(z = DesignatedPubkey(c.tx, c.prev));
+        ASSERT_TRUE(z != nullptr);
+    } 
+}
+
+} // opentxs
+
+#endif  // OT_CRYPTO_USING_LIBBITCOIN


### PR DESCRIPTION
Add bip47 support to extract the pubkey from a notification tx. There are a lot of tests and there is also a new constructor in Data that reads in a hex string. 

I found a bug in is_pay_multisig_pattern and I have a pending pr in libbitcoin to fix it but for now we rely on a version of the function that I just copied into opentxs. 