### PR TITLE
password fixes.

### DIFF
--- a/include/opentxs/server/MessageProcessor.hpp
+++ b/include/opentxs/server/MessageProcessor.hpp
@@ -81,7 +81,7 @@ public:
 private:
     Server& server_;
     std::atomic<bool>& shutdown_;
-    const network::zeromq::Context& context_;
+    const network::zeromq::Context& context_[[maybe_unused]];
     std::shared_ptr<network::zeromq::ReplySocket> reply_socket_;
     std::unique_ptr<std::thread> thread_{nullptr};
 

--- a/src/api/crypto/Crypto.cpp
+++ b/src/api/crypto/Crypto.cpp
@@ -131,6 +131,9 @@ const OTCachedKey& Crypto::CachedKey(const Identifier& id) const
     auto& output = cached_keys_[id];
 
     if (false == bool(output)) {
+        OT_FAIL_MSG("This function is broken, this never should have "
+                    "happened.");
+
         output.reset(new OTCachedKey(OT_MASTER_KEY_TIMEOUT));
     }
 
@@ -182,8 +185,8 @@ Editor<OTCachedKey> Crypto::mutable_DefaultKey() const
 {
     OT_ASSERT(primary_key_);
 
-    std::function<void(OTCachedKey*, Lock&)> callback =
-        [&](OTCachedKey*, Lock&) -> void {};
+    std::function<void(OTCachedKey*, Lock&)> callback = [&](OTCachedKey*,
+                                                            Lock&) -> void {};
 
     return Editor<OTCachedKey>(cached_key_lock_, primary_key_.get(), callback);
 }

--- a/src/api/crypto/Util.cpp
+++ b/src/api/crypto/Util.cpp
@@ -51,10 +51,10 @@ bool Util::GetPasswordFromConsole(OTPassword& theOutput, bool bRepeat) const
 {
     std::int32_t nAttempts = 0;
 
-    for (;;) {
+    for (int i = 0; i < 5; i++) {
         theOutput.zeroMemory();
 
-        if (GetPasswordFromConsole(theOutput, "(OT) passphrase: ")) {
+        if (get_password(theOutput, "(OT) passphrase: ")) {
             if (!bRepeat) {
                 std::cout << std::endl;
                 return true;
@@ -66,8 +66,7 @@ bool Util::GetPasswordFromConsole(OTPassword& theOutput, bool bRepeat) const
 
         OTPassword tempPassword;
 
-        if (!GetPasswordFromConsole(
-                tempPassword, "(Verifying) passphrase again: ")) {
+        if (!get_password(tempPassword, "(Verifying) passphrase again: ")) {
             std::cout << "Sorry." << std::endl;
             return false;
         }

--- a/src/client/SwigWrap.cpp
+++ b/src/client/SwigWrap.cpp
@@ -118,8 +118,9 @@ extern "C" int32_t default_pass_cb(
     //    otWarn << "OPENSSL_CALLBACK: (Password callback hasn't been set
     // yet...) Using 'test' pass phrase for \"%s\"\n", (char *)u);
 
-    otWarn << __FUNCTION__ << ": Using DEFAULT TEST PASSWORD: "
-                              "'test' (for \""
+    otWarn << __FUNCTION__
+           << ": Using DEFAULT TEST PASSWORD: "
+              "'test' (for \""
            << str_userdata << "\")\n";
 
     // get pass phrase, length 'len' into 'tmp'
@@ -168,6 +169,7 @@ extern "C" int32_t souped_up_pass_cb(
 {
     //  OT_ASSERT(nullptr != buf); // apparently it CAN be nullptr sometimes.
     OT_ASSERT(nullptr != userdata);
+
     const OTPasswordData* pPWData =
         static_cast<const OTPasswordData*>(userdata);
     const std::string str_userdata = pPWData->GetDisplayString();
@@ -177,6 +179,7 @@ extern "C" int32_t souped_up_pass_cb(
 
     // Sometimes it's passed in, otherwise we use the global one.
     const auto providedKey = pPWData->GetCachedKey();
+
     auto& cachedKey = (nullptr == providedKey) ? OT::App().Crypto().DefaultKey()
                                                : *providedKey;
 
@@ -222,7 +225,6 @@ extern "C" int32_t souped_up_pass_cb(
              // which case they do NOT look up the master
              // password...
     {
-
         // Therefore we need to provide the password from an OTSymmetricKey
         // stored here.
         // (the "actual key" in the OTSymmetricKey IS the password that we are
@@ -270,17 +272,15 @@ extern "C" int32_t souped_up_pass_cb(
 
         OTCaller* pCaller =
             SwigWrap::GetPasswordCaller();  // See if the developer
-                                            // registered one via the OT
-                                            // API.
+                                            // registered one via the OT API.
 
-        //      if (nullptr == pCaller)
-        //      {
-        //          otErr << "OPENSSL_CALLBACK (souped_up_pass_cb): OTCaller is
-        // nullptr. Try calling OT_API_Set_PasswordCallback() first.\n";
-        //          OT_ASSERT(0); // This will never actually happen, since
-        // SetPasswordCaller() and souped_up_pass_cb are activated in same
-        // place.
-        //      }
+        // This will never actually happen, since SetPasswordCaller() and
+        // souped_up_pass_cb are activated in same place.
+        OT_ASSERT_MSG(
+            (nullptr != pCaller),
+            "OPENSSL_CALLBACK (souped_up_pass_cb): "
+            "OTCaller is nullptr. "
+            "Try calling OT_API_Set_PasswordCallback() first.");
 
         if (nullptr == pCaller)  // We'll just grab it from the console then.
         {
@@ -337,7 +337,6 @@ extern "C" int32_t souped_up_pass_cb(
             bGotPassword = pCaller->GetPassword(thePassword);
         }
     }
-
     if (!bGotPassword) {
         otOut << __FUNCTION__
               << ": Failure: (false == bGotPassword.) (Returning 0.)\n";
@@ -354,9 +353,10 @@ extern "C" int32_t souped_up_pass_cb(
                                            : thePassword.getMemorySize();
 
     if (len < 0) {
-        otOut << __FUNCTION__ << ": <0 length password was "
-                                 "returned from the API password callback. "
-                                 "Returning 0.\n";
+        otOut << __FUNCTION__
+              << ": <0 length password was "
+                 "returned from the API password callback. "
+                 "Returning 0.\n";
         return 0;
     }
     // --------------------------------------
@@ -408,7 +408,6 @@ extern "C" int32_t souped_up_pass_cb(
         len = thePassword.isPassword() ? thePassword.getPasswordSize()
                                        : thePassword.getMemorySize();
     }
-
     OTPassword* pMasterPW = pPWData->GetMasterPW();
 
     if (pPWData->isForCachedKey() && (nullptr != pMasterPW)) {
@@ -468,12 +467,13 @@ bool OT_API_Set_PasswordCallback(OTCaller& theCaller)  // Caller must have
                                                        // already.
 {
     if (!theCaller.isCallbackSet()) {
-        otErr << __FUNCTION__ << ": ERROR:\nOTCaller::setCallback() "
-                                 "MUST be called first, with an "
-                                 "OTCallback-extended class passed to it,\n"
-                                 "before then invoking this function (and "
-                                 "passing that OTCaller as a parameter "
-                                 "into this function.)\n";
+        otErr << __FUNCTION__
+              << ": ERROR:\nOTCaller::setCallback() "
+                 "MUST be called first, with an "
+                 "OTCallback-extended class passed to it,\n"
+                 "before then invoking this function (and "
+                 "passing that OTCaller as a parameter "
+                 "into this function.)\n";
         return false;
     }
 
@@ -506,11 +506,13 @@ void SwigWrap::SetPasswordCallback(OT_OPENSSL_CALLBACK* pCallback)
     const char* szFunc = "SwigWrap::SetPasswordCallback";
 
     if (nullptr != s_pwCallback)
-        otOut << szFunc << ": WARNING: re-setting the password callback (one "
-                           "was already there)...\n";
+        otOut << szFunc
+              << ": WARNING: re-setting the password callback (one "
+                 "was already there)...\n";
     else
-        otWarn << szFunc << ": FYI, setting the password callback to a "
-                            "non-nullptr pointer (which is what we want.)\n";
+        otWarn << szFunc
+               << ": FYI, setting the password callback to a "
+                  "non-nullptr pointer (which is what we want.)\n";
 
     if (nullptr == pCallback)
         otErr << szFunc
@@ -530,13 +532,14 @@ OT_OPENSSL_CALLBACK* SwigWrap::GetPasswordCallback()
     const char* szFunc = "SwigWrap::GetPasswordCallback";
 
 #if defined OT_TEST_PASSWORD
-    otInfo << szFunc << ": WARNING, OT_TEST_PASSWORD *is* defined. The "
-                        "internal 'C'-based password callback was just "
-                        "requested by OT (to pass to OpenSSL). So, returning "
-                        "the default_pass_cb password callback, which will "
-                        "automatically return "
-                        "the 'test' password to OpenSSL, if/when it calls that "
-                        "callback function.\n";
+    otInfo << szFunc
+           << ": WARNING, OT_TEST_PASSWORD *is* defined. The "
+              "internal 'C'-based password callback was just "
+              "requested by OT (to pass to OpenSSL). So, returning "
+              "the default_pass_cb password callback, which will "
+              "automatically return "
+              "the 'test' password to OpenSSL, if/when it calls that "
+              "callback function.\n";
     return &default_pass_cb;
 #else
     if (IsPasswordCallbackSet()) {
@@ -550,24 +553,16 @@ OT_OPENSSL_CALLBACK* SwigWrap::GetPasswordCallback()
                   "by the (probably Java) OTAPI client.)\n";
         return s_pwCallback;
     } else {
-        //        otInfo << "SwigWrap::GetPasswordCallback: FYI, the
-        // internal 'C'-based password callback was requested by OT (to pass to
-        // OpenSSL), "
-        //                      "but the callback hasn't been set yet.
-        // (Returning nullptr CALLBACK to OpenSSL!! Thus causing it to instead
-        // ask
-        // for the passphrase on the CONSOLE, "
-        //                      "since no Java password dialog was apparently
-        // available.)\n");
+        otInfo << "SwigWrap::GetPasswordCallback: FYI, the internal 'C'-based "
+                  "password callback was requested by OT (to pass to OpenSSL), "
+                  "but the callback hasn't been set yet. (Returning nullptr "
+                  "CALLBACK to "
+                  "OpenSSL!! Thus causing it to instead ask for the passphrase "
+                  "on the "
+                  "CONSOLE, since no Java password dialog was apparently "
+                  "available.)";
 
-        //        return static_cast<OT_OPENSSL_CALLBACK *>(nullptr);
-
-        // We have our own "console" password-gathering function, which allows
-        // us to use our master key.
-        // Since the souped-up cb uses it, I'm just returning that here as a
-        // default, for now.
-        SwigWrap::SetPasswordCallback(&souped_up_pass_cb);
-        return s_pwCallback;
+        return static_cast<OT_OPENSSL_CALLBACK*>(nullptr);
     }
 #endif
 }
@@ -588,11 +583,12 @@ bool SwigWrap::SetPasswordCaller(OTCaller& theCaller)
               "OT 'C'-based password callback is triggered by openssl.)\n";
 
     if (!theCaller.isCallbackSet()) {
-        otErr << szFunc << ": ERROR: OTCaller::setCallback() "
-                           "MUST be called first, with an OTCallback-extended "
-                           "object passed to it,\n"
-                           "BEFORE calling this function with that OTCaller. "
-                           "(Returning false.)\n";
+        otErr << szFunc
+              << ": ERROR: OTCaller::setCallback() "
+                 "MUST be called first, with an OTCallback-extended "
+                 "object passed to it,\n"
+                 "BEFORE calling this function with that OTCaller. "
+                 "(Returning false.)\n";
         return false;
     }
 
@@ -622,9 +618,10 @@ OTCaller* SwigWrap::GetPasswordCaller()
 {
     const char* szFunc = "SwigWrap::GetPasswordCaller";
 
-    otLog4 << szFunc << ": FYI, this was just called by souped_up_pass_cb "
-                        "(which must have just been called by OpenSSL.) "
-                        "Returning s_pCaller == "
+    otLog4 << szFunc
+           << ": FYI, this was just called by souped_up_pass_cb "
+              "(which must have just been called by OpenSSL.) "
+              "Returning s_pCaller == "
            << ((nullptr == s_pCaller) ? "nullptr" : "VALID POINTER")
            << " (Hopefully NOT nullptr, so the "
               "custom password dialog can be triggered.)\n";

--- a/src/core/crypto/OTSymmetricKey.cpp
+++ b/src/core/crypto/OTSymmetricKey.cpp
@@ -120,16 +120,18 @@ bool OTSymmetricKey::ChangePassphrase(
     // OTEnvelope.
     //
     if (!dataIV.Randomize(CryptoConfig::SymmetricIvSize())) {
-        otErr << __FUNCTION__ << ": Failed generating iv for changing "
-                                 "passphrase on a symmetric key. (Returning "
-                                 "false.)\n";
+        otErr << __FUNCTION__
+              << ": Failed generating iv for changing "
+                 "passphrase on a symmetric key. (Returning "
+                 "false.)\n";
         return false;
     }
 
     if (!dataSalt.Randomize(CryptoConfig::SymmetricSaltSize())) {
-        otErr << __FUNCTION__ << ": Failed generating random salt for changing "
-                                 "passphrase on a symmetric key. (Returning "
-                                 "false.)\n";
+        otErr << __FUNCTION__
+              << ": Failed generating random salt for changing "
+                 "passphrase on a symmetric key. (Returning "
+                 "false.)\n";
         return false;
     }
 
@@ -206,8 +208,9 @@ bool OTSymmetricKey::GenerateKey(
            << ": GENERATING keys and passwords...\n";
 
     if (!m_dataIV.Randomize(CryptoConfig::SymmetricIvSize())) {
-        otErr << __FUNCTION__ << ": Failed generating iv for encrypting a "
-                                 "symmetric key. (Returning false.)\n";
+        otErr << __FUNCTION__
+              << ": Failed generating iv for encrypting a "
+                 "symmetric key. (Returning false.)\n";
         return false;
     }
 
@@ -294,8 +297,9 @@ bool OTSymmetricKey::GenerateHashCheck(const OTPassword& thePassphrase)
     OT_ASSERT(m_uIterationCount > 1000);
 
     if (!m_bIsGenerated) {
-        otErr << __FUNCTION__ << ": No Key Generated, run GenerateKey(), and "
-                                 "this function will not be needed!";
+        otErr << __FUNCTION__
+              << ": No Key Generated, run GenerateKey(), and "
+                 "this function will not be needed!";
         OT_FAIL;
     }
 
@@ -377,15 +381,17 @@ OTPassword* OTSymmetricKey::CalculateDerivedKeyFromPassphrase(
 
     if (bCheckForHashCheck) {
         if (!HasHashCheck()) {
-            otErr << __FUNCTION__ << ": Unable to calculate derived key, as "
-                                     "hash check is missing!";
+            otErr << __FUNCTION__
+                  << ": Unable to calculate derived key, as "
+                     "hash check is missing!";
             OT_FAIL;
         }
         OT_ASSERT(!tmpDataHashCheck.IsEmpty());
     } else {
         if (!HasHashCheck()) {
-            otOut << __FUNCTION__ << ": Warning!! No hash check, ignoring... "
-                                     "(since bCheckForHashCheck was set false)";
+            otOut << __FUNCTION__
+                  << ": Warning!! No hash check, ignoring... "
+                     "(since bCheckForHashCheck was set false)";
             OT_ASSERT(tmpDataHashCheck.IsEmpty());
         }
     }
@@ -540,9 +546,10 @@ OTPassword* OTSymmetricKey::GetPassphraseFromUser(
     if ((nCallback > 0) &&  // Success retrieving the passphrase from the user.
         pPassUserInput->SetSize(uCallback)) {
         //      otOut << "%s: Retrieved passphrase (blocksize %d, actual size
-        // %d) from user: %s\n", __FUNCTION__,
-        //                     pPassUserInput->getBlockSize(), nCallback,
-        // pPassUserInput->getPassword());
+        //      %d) from "
+        //               "user: %s\n", __FUNCTION__,
+        //               pPassUserInput->getBlockSize(), nCallback,
+        //               pPassUserInput->getPassword());
         return pPassUserInput;  // Caller MUST delete!
     } else {
         delete pPassUserInput;
@@ -608,16 +615,18 @@ bool OTSymmetricKey::Encrypt(
     const OTPassword* pAlreadyHavePW)
 {
     if (!strKey.Exists() || !strPlaintext.Exists()) {
-        otWarn << __FUNCTION__ << ": Nonexistent: either the key or the "
-                                  "plaintext. Please supply. (Failure.)\n";
+        otWarn << __FUNCTION__
+               << ": Nonexistent: either the key or the "
+                  "plaintext. Please supply. (Failure.)\n";
         return false;
     }
 
     OTSymmetricKey theKey;
 
     if (!theKey.SerializeFrom(strKey)) {
-        otWarn << __FUNCTION__ << ": Failed trying to load symmetric key from "
-                                  "string. (Returning false.)\n";
+        otWarn << __FUNCTION__
+               << ": Failed trying to load symmetric key from "
+                  "string. (Returning false.)\n";
         return false;
     }
 
@@ -722,8 +731,9 @@ bool OTSymmetricKey::Decrypt(
     OTSymmetricKey theKey;
 
     if (!theKey.SerializeFrom(strKey)) {
-        otWarn << __FUNCTION__ << ": Failed trying to load symmetric key from "
-                                  "string. (Returning false.)\n";
+        otWarn << __FUNCTION__
+               << ": Failed trying to load symmetric key from "
+                  "string. (Returning false.)\n";
         return false;
     }
 
@@ -809,11 +819,10 @@ bool OTSymmetricKey::SerializeFrom(const String& strInput, bool bEscaped)
 {
     OTASCIIArmor ascInput;
 
-    if (strInput.Exists() &&
-        ascInput.LoadFromString(
-            const_cast<String&>(strInput),
-            bEscaped,
-            "-----BEGIN OT ARMORED SYMMETRIC KEY")) {
+    if (strInput.Exists() && ascInput.LoadFromString(
+                                 const_cast<String&>(strInput),
+                                 bEscaped,
+                                 "-----BEGIN OT ARMORED SYMMETRIC KEY")) {
         return SerializeFrom(ascInput);
     }
 
@@ -862,8 +871,9 @@ bool OTSymmetricKey::SerializeTo(Data& theOutput) const
            << "   key_size_bits: "
            << static_cast<int32_t>(ntohs(n_key_size_bits))
            << "   iteration_count: "
-           << static_cast<int64_t>(ntohl(n_iteration_count)) << "   \n  "
-                                                                "salt_size: "
+           << static_cast<int64_t>(ntohl(n_iteration_count))
+           << "   \n  "
+              "salt_size: "
            << static_cast<int64_t>(ntohl(n_salt_size))
            << "   iv_size: " << static_cast<int64_t>(ntohl(n_iv_size))
            << "   enc_key_size: " << static_cast<int64_t>(ntohl(n_enc_key_size))

--- a/src/core/crypto/SymmetricKey.cpp
+++ b/src/core/crypto/SymmetricKey.cpp
@@ -562,7 +562,7 @@ bool SymmetricKey::GetPassword(
         const auto length = souped_up_pass_cb(
             static_cast<char*>(master->getMemoryWritable()),
             master->getBlockSize(),
-            false,
+            0,
             reinterpret_cast<void*>(const_cast<OTPasswordData*>(&keyPassword)));
         bool result = false;
 


### PR DESCRIPTION
Fixed core/crypto/SymmetricKey not to pass a bool where an integer is expected.
Added ASSERT to api/crypto/Crypto.cpp for nonsensical situation.
Fixed api/crypto/Util.cpp to call the right function instead of calling itself recursively with the wrong arguments.
Fixed SwigWrap::GetPasswordCallback to actually return NULL when no callback is set.
Updated CachedKey to handle new case where GetPasswordCallback can return NULL.
Initialized 2 boolean output variables in src/core/crypto/OpenSSL.cpp to false. (Unlikely to change anything)
Also set a pointer to null in that file after it's deleted. Also added an assert in that file.

Signed-off-by: FellowTraveler <F3llowTraveler@gmail.com>