### PR TITLE
Libsodium::Derive: explicitly specify Argon2 algorithm

### DIFF
--- a/include/opentxs/client/SwigWrap.hpp
+++ b/include/opentxs/client/SwigWrap.hpp
@@ -2836,6 +2836,14 @@ public:
     EXPORT static std::int64_t Message_GetUsageCredits(
         const std::string& THE_MESSAGE);
 
+    EXPORT static int32_t completePeerReply(
+        const std::string& nymID,
+        const std::string& replyOrRequestID);
+
+    EXPORT static int32_t completePeerRequest(
+        const std::string& nymID,
+        const std::string& requestID);
+
     EXPORT static std::string getSentRequests(const std::string& nymID);
 
     EXPORT static std::string getIncomingRequests(const std::string& nymID);

--- a/src/client/SwigWrap.cpp
+++ b/src/client/SwigWrap.cpp
@@ -3077,6 +3077,20 @@ std::string SwigWrap::comma(const std::set<Identifier>& list)
     return output;
 }
 
+std::int32_t SwigWrap::completePeerReply(
+    const std::string& nymID,
+    const std::string& replyID)
+{
+    return OT::App().API().Exec().completePeerReply(nymID, replyID);
+}
+
+std::int32_t SwigWrap::completePeerRequest(
+    const std::string& nymID,
+    const std::string& requestID)
+{
+    return OT::App().API().Exec().completePeerRequest(nymID, requestID);
+}
+
 std::string SwigWrap::getSentRequests(const std::string& nymID)
 {
     return comma(OT::App().API().Exec().getSentRequests(nymID));

--- a/src/core/crypto/Libsodium.cpp
+++ b/src/core/crypto/Libsodium.cpp
@@ -145,7 +145,7 @@ bool Libsodium::Derive(
                  salt,
                  operations,
                  difficulty,
-                 crypto_pwhash_ALG_DEFAULT));
+                 crypto_pwhash_ALG_ARGON2I13));
 }
 
 bool Libsodium::Digest(


### PR DESCRIPTION
Libsodium-1.0.15 changes the value of crypto_pwhash_ALG_DEFAULT from crypto_pwhash_ALG_ARGON2I13 to crypto_pwhash_ALG_ARGON2ID13

Specify the old value to maintain compatibility between opentxs builds that use old and new versions of libsodium