### PR TITLE
Transport Notary + towards a Clang Fix

### DIFF
--- a/include/opentxs/api/Api.hpp
+++ b/include/opentxs/api/Api.hpp
@@ -41,6 +41,8 @@
 
 #include "opentxs/Forward.hpp"
 
+//#include "opentxs/Types.hpp"
+
 #include <string>
 
 namespace opentxs

--- a/include/opentxs/api/client/Pair.hpp
+++ b/include/opentxs/api/client/Pair.hpp
@@ -43,6 +43,7 @@
 
 #include <cstdint>
 #include <set>
+#include <map>
 #include <string>
 
 namespace opentxs
@@ -55,6 +56,15 @@ namespace client
 class Pair
 {
 public:
+    static Pair * Factory(
+        const Flag& running,
+        const opentxs::api::client::Sync& sync,
+        const opentxs::api::client::ServerAction& action,
+        const opentxs::api::client::Wallet& wallet,
+        const opentxs::OT_API& otapi,
+        const opentxs::OTAPI_Exec& exec,
+        const opentxs::network::zeromq::Context& context);
+
     virtual bool AddIssuer(
         const Identifier& localNymID,
         const Identifier& issuerNymID,

--- a/include/opentxs/api/client/Sync.hpp
+++ b/include/opentxs/api/client/Sync.hpp
@@ -45,6 +45,8 @@
 
 #include <cstdint>
 #include <tuple>
+#include <memory>
+#include <set>
 
 #define DEFAULT_PROCESS_INBOX_ITEMS 5
 
@@ -57,6 +59,18 @@ namespace client
 class Sync
 {
 public:
+    EXPORT static Sync * Factory(const Flag& running,
+                                 const OT_API& otapi,
+                                 const opentxs::OTAPI_Exec& exec,
+                                 const opentxs::api::ContactManager& contacts,
+                                 const opentxs::api::Settings& config,
+                                 const opentxs::api::Api& api,
+                                 const opentxs::api::client::Wallet& wallet,
+                                 const opentxs::api::client::Workflow& workflow,
+                                 const opentxs::api::crypto::Encode& encoding,
+                                 const opentxs::network::zeromq::Context& zmq,
+                                 const ContextLockCallback& lockCallback);
+
     EXPORT virtual bool AcceptIncoming(
         const Identifier& nymID,
         const Identifier& accountID,

--- a/include/opentxs/cash/Purse.hpp
+++ b/include/opentxs/cash/Purse.hpp
@@ -237,5 +237,8 @@ public:
     EXPORT void ReleaseTokens();
 };
 }  // namespace opentxs
+
+extern template class std::shared_ptr<const opentxs::Purse>;
+
 #endif  // OT_CASH
 #endif  // OPENTXS_CASH_PURSE_HPP

--- a/include/opentxs/client/OTRecord.hpp
+++ b/include/opentxs/client/OTRecord.hpp
@@ -67,11 +67,12 @@ private:
     std::string m_strThreadItemId;  // Will eventually replace Box Index.
     time64_t m_ValidFrom{0};
     time64_t m_ValidTo{0};
-    const std::string& m_str_notary_id;
-    const std::string& m_str_instrument_definition_id;
-    const std::string& m_str_currency_tla;
-    const std::string& m_str_nym_id;
-    const std::string& m_str_account_id;
+    const std::string m_str_msg_notary_id; // Notary where msg was transmitted
+    const std::string m_str_pmnt_notary_id; // Notary the instrument is drawn on
+    const std::string m_str_unit_type_id;
+    const std::string m_str_currency_tla;
+    const std::string m_str_nym_id;
+    const std::string m_str_account_id;
     std::string m_str_other_nym_id;
     std::string m_str_other_account_id;
     std::string m_str_name;
@@ -111,9 +112,9 @@ private:
     // or payment inbox, or record box. (If outpayment, contains
     // transaction number on outgoing instrument.)
     //
-    std::int64_t m_lTransactionNum{0};
-    std::int64_t m_lTransNumForDisplay{0};
-    std::int64_t m_lClosingNum{0};  // Only used for finalReceipts.
+    TransactionNumber m_lTransactionNum{0};
+    TransactionNumber m_lTransNumForDisplay{0};
+    TransactionNumber m_lClosingNum{0};  // Only used for finalReceipts.
 
     bool m_bIsPending{false};
     bool m_bIsOutgoing{false};
@@ -147,7 +148,7 @@ private:
         const std::string& ACCOUNT_ID,
         const std::string& INDICES) const;
     bool discard_incoming_payments(
-        const std::string& NOTARY_ID,
+        const std::string& TRANSPORT_NOTARY_ID,
         const std::string& NYM_ID,
         const std::string& INDICES) const;
 
@@ -172,8 +173,8 @@ public:
     EXPORT void SetSuccess(const bool bIsSuccess);
     EXPORT bool HasSuccess(bool& bIsSuccess) const;
 
-    EXPORT void SetClosingNum(const std::int64_t lClosingNum);
-    EXPORT bool GetClosingNum(std::int64_t& lClosingNum) const;
+    EXPORT void SetClosingNum(const TransactionNumber lClosingNum);
+    EXPORT bool GetClosingNum(TransactionNumber& lClosingNum) const;
 
     EXPORT void SetSpecialMail(bool bIsSpecial = true);
     EXPORT bool IsSpecialMail() const;
@@ -257,20 +258,21 @@ public:
     EXPORT const std::string& GetMsgTypeDisplay() const;  // Used by "special
                                                           // mail."
     EXPORT void SetMsgTypeDisplay(const std::string& str_type);
-    EXPORT std::int64_t GetTransactionNum() const;  // Trans Num of receipt in
+    EXPORT TransactionNumber GetTransactionNum() const;  // Trans Num of receipt in
                                                     // the
                                                     // box. (Unless outpayment,
                                                     // contains number for
                                                     // instrument.)
-    EXPORT void SetTransactionNum(int64_t lTransNum);
-    EXPORT std::int64_t GetTransNumForDisplay() const;  // Trans Num of the
+    EXPORT void SetTransactionNum(TransactionNumber lTransNum);
+    EXPORT TransactionNumber GetTransNumForDisplay() const;  // Trans Num of the
                                                         // cheque
     // inside the receipt in the
     // box.
-    EXPORT void SetTransNumForDisplay(std::int64_t lTransNum);
+    EXPORT void SetTransNumForDisplay(TransactionNumber lTransNum);
     EXPORT OTRecordType GetRecordType() const;
-    EXPORT const std::string& GetNotaryID() const;
-    EXPORT const std::string& GetInstrumentDefinitionID() const;
+    EXPORT const std::string& GetMsgNotaryID() const;
+    EXPORT const std::string& GetPmntNotaryID() const;
+    EXPORT const std::string& GetUnitTypeID() const;
     EXPORT const std::string& GetCurrencyTLA() const;  // BTC, USD, etc.
     EXPORT const std::string& GetNymID() const;
     EXPORT const std::string& GetAccountID() const;
@@ -310,8 +312,8 @@ public:
     EXPORT time64_t GetPaymentPlanStartDate() const;
     EXPORT time64_t GetTimeBetweenPayments() const;
 
-    EXPORT int64_t GetInitialPaymentAmount() const;
-    EXPORT int64_t GetPaymentPlanAmount() const;
+    EXPORT Amount GetInitialPaymentAmount() const;
+    EXPORT Amount GetPaymentPlanAmount() const;
 
     EXPORT int32_t GetMaximumNoPayments() const;
     EXPORT bool FormatAmount(std::string& str_output) const;
@@ -330,8 +332,9 @@ public:
     bool operator<(const OTRecord& rhs);
     OTRecord(
         OTRecordList& backlink,
-        const std::string& str_notary_id,
-        const std::string& str_instrument_definition_id,
+        const std::string& str_msg_notary_id,
+        const std::string& str_pmnt_notary_id,
+        const std::string& str_unit_type_id,
         const std::string& str_currency_tla,
         const std::string& str_nym_id,
         const std::string& str_account_id,

--- a/include/opentxs/client/OTRecordList.hpp
+++ b/include/opentxs/client/OTRecordList.hpp
@@ -93,10 +93,11 @@ public:
     EXPORT virtual void notifyOfSuccessfulNotarization(
         const std::string& str_acct_id,
         const std::string p_nym_id,
-        const std::string p_notary_id,
+        const std::string p_msg_notary_id,
+        const std::string p_pmnt_notary_id,
         const std::string p_txn_contents,
-        std::int64_t lTransactionNum,
-        std::int64_t lTransNumForDisplay) const;
+        TransactionNumber lTransactionNum,
+        TransactionNumber lTransNumForDisplay) const;
 };
 
 /*
@@ -203,6 +204,7 @@ public:
     EXPORT ~OTRecordList();
 
     EXPORT static bool accept_from_paymentbox(
+        const std::string& transport_notary,
         const std::string& myacct,
         const std::string& indices,
         const std::string& paymentType,
@@ -270,7 +272,7 @@ public:
     EXPORT static bool checkServer(const char* name, std::string& server);
 
     EXPORT static std::int32_t discard_incoming_payments(
-        const std::string& server,
+        const std::string& transportNotaryId,
         const std::string& mynym,
         const std::string& indices);
 
@@ -323,10 +325,11 @@ public:
     EXPORT void notifyOfSuccessfulNotarization(
         const std::string& str_acct_id,
         const std::string p_nym_id,
-        const std::string p_notary_id,
+        const std::string p_msg_notary_id,
+        const std::string p_pmnt_notary_id,
         const std::string p_txn_contents,
-        std::int64_t lTransactionNum,
-        std::int64_t lTransNumForDisplay) const;
+        TransactionNumber lTransactionNum,
+        TransactionNumber lTransNumForDisplay) const;
     /** Populates m_contents from OT API. Calls ClearContents(). */
     EXPORT bool Populate();
     /** Clears m_contents (NOT nyms, accounts, servers, or instrument

--- a/include/opentxs/core/Identifier.hpp
+++ b/include/opentxs/core/Identifier.hpp
@@ -47,6 +47,8 @@
 
 #include <iosfwd>
 #include <string>
+#include <set>
+#include <map>
 
 /** An Identifier is basically a 256 bit hash value. This class makes it easy to
  * convert IDs back and forth to strings. */
@@ -135,4 +137,11 @@ private:
         const proto::HDPath& path);
 };
 }  // namespace opentxs
+
+
+extern template class std::set<opentxs::OTIdentifier>;
+extern template class std::map<opentxs::OTIdentifier,
+                               std::set<opentxs::OTIdentifier>>;
+
+
 #endif  // OPENTXS_CORE_OTIDENTIFIER_HPP

--- a/include/opentxs/ext/OTPayment.hpp
+++ b/include/opentxs/ext/OTPayment.hpp
@@ -46,6 +46,8 @@
 #include "opentxs/core/String.hpp"
 #include "opentxs/Types.hpp"
 
+#include <memory>
+
 namespace opentxs
 {
 /*
@@ -281,4 +283,7 @@ private:
     using ot_super = Contract;
 };
 }  // namespace opentxs
+
+extern template class std::shared_ptr<const opentxs::OTPayment>;
+
 #endif  // OPENTXS_EXT_OTPAYMENT_HPP

--- a/src/api/Api.cpp
+++ b/src/api/Api.cpp
@@ -38,22 +38,32 @@
 
 #include "opentxs/stdafx.hpp"
 
+#include "opentxs/core/Identifier.hpp"
+
+#include "opentxs/api/client/Pair.hpp"
+#include "opentxs/api/client/Sync.hpp"
 #include "opentxs/api/crypto/Crypto.hpp"
 #include "opentxs/api/network/ZMQ.hpp"
+#include "opentxs/api/Api.hpp"
 #include "opentxs/api/Activity.hpp"
 #include "opentxs/api/ContactManager.hpp"
 #include "opentxs/api/Settings.hpp"
+//#if OT_CASH
+//#include "opentxs/cash/Purse.hpp"
+//#endif //OT_CASH
 #include "opentxs/client/OT_API.hpp"
 #include "opentxs/client/OTAPI_Exec.hpp"
 #include "opentxs/core/crypto/OTCachedKey.hpp"
-#include "opentxs/core/Identifier.hpp"
+//#include "opentxs/core/Identifier.hpp"
 #include "opentxs/core/Log.hpp"
+//#include "opentxs/ext/OTPayment.hpp"
 
 #include "client/Cash.hpp"
-#include "client/Pair.hpp"
 #include "client/ServerAction.hpp"
-#include "client/Sync.hpp"
 #include "client/Workflow.hpp"
+
+#include <set>
+#include <map>
 
 #include "Api.hpp"
 
@@ -160,7 +170,7 @@ void Api::Init()
 
     OT_ASSERT(cash_);
 
-    sync_.reset(new api::client::implementation::Sync(
+    sync_.reset(api::client::Sync::Factory(
         running_,
         *ot_api_,
         *otapi_exec_,
@@ -175,7 +185,7 @@ void Api::Init()
 
     OT_ASSERT(sync_);
 
-    pair_.reset(new api::client::implementation::Pair(
+    pair_.reset(api::client::Pair::Factory(
         running_,
         *sync_,
         *server_action_,

--- a/src/api/client/Pair.cpp
+++ b/src/api/client/Pair.cpp
@@ -38,10 +38,13 @@
 
 #include "opentxs/stdafx.hpp"
 
+#include "opentxs/core/Identifier.hpp"
+#include "opentxs/api/client/Pair.hpp"
+#include "opentxs/api/client/Sync.hpp"
 #include "opentxs/api/client/Issuer.hpp"
 #include "opentxs/api/client/ServerAction.hpp"
-#include "opentxs/api/client/Sync.hpp"
 #include "opentxs/api/client/Wallet.hpp"
+#include "opentxs/api/Api.hpp"
 #include "opentxs/client/OT_API.hpp"
 #include "opentxs/client/OTAPI_Exec.hpp"
 #include "opentxs/client/ServerAction.hpp"
@@ -50,13 +53,15 @@
 #include "opentxs/contact/ContactItem.hpp"
 #include "opentxs/contact/ContactSection.hpp"
 #include "opentxs/core/contract/peer/PeerRequest.hpp"
-#include "opentxs/core/Identifier.hpp"
 #include "opentxs/core/Log.hpp"
 #include "opentxs/core/Message.hpp"
 #include "opentxs/core/Nym.hpp"
 #include "opentxs/network/zeromq/Context.hpp"
 #include "opentxs/network/zeromq/PublishSocket.hpp"
 #include "opentxs/Proto.hpp"
+
+#include <set>
+#include <map>
 
 #include "Pair.hpp"
 
@@ -73,6 +78,31 @@
     }
 
 #define OT_METHOD "opentxs::api::client::implementation::Pair::"
+
+
+namespace opentxs::api::client
+{
+Pair * Pair::Factory(
+    const Flag& running,
+    const opentxs::api::client::Sync& sync,
+    const opentxs::api::client::ServerAction& action,
+    const opentxs::api::client::Wallet& wallet,
+    const opentxs::OT_API& otapi,
+    const opentxs::OTAPI_Exec& exec,
+    const opentxs::network::zeromq::Context& context)
+{
+    return new api::client::implementation::Pair(
+        running,
+        sync,
+        action,
+        wallet,
+        otapi,
+        exec,
+        context);
+}
+} // namespace opentxs::api::client
+
+
 
 namespace opentxs::api::client::implementation
 {

--- a/src/api/client/Pair.hpp
+++ b/src/api/client/Pair.hpp
@@ -41,6 +41,8 @@
 
 #include "opentxs/Internal.hpp"
 
+#include "opentxs/core/Identifier.hpp"
+
 #include "opentxs/api/client/Pair.hpp"
 #include "opentxs/core/Flag.hpp"
 #include "opentxs/core/Lockable.hpp"
@@ -70,6 +72,8 @@ public:
     void Update() const override;
 
     ~Pair();
+
+    friend class opentxs::api::client::Pair;
 
 private:
     class Cleanup

--- a/src/api/client/Sync.cpp
+++ b/src/api/client/Sync.cpp
@@ -38,7 +38,10 @@
 
 #include "opentxs/stdafx.hpp"
 
+#include "opentxs/core/Identifier.hpp"
+
 #include "opentxs/api/client/Pair.hpp"
+#include "opentxs/api/client/Sync.hpp"
 #include "opentxs/api/client/ServerAction.hpp"
 #include "opentxs/api/client/Wallet.hpp"
 #include "opentxs/api/client/Workflow.hpp"
@@ -60,7 +63,6 @@
 #include "opentxs/core/crypto/OTPassword.hpp"
 #include "opentxs/core/Account.hpp"
 #include "opentxs/core/Cheque.hpp"
-#include "opentxs/core/Identifier.hpp"
 #include "opentxs/core/Ledger.hpp"
 #include "opentxs/core/Log.hpp"
 #include "opentxs/core/Message.hpp"
@@ -132,6 +134,37 @@
 #define PROCESS_INBOX_RETRIES 3
 
 #define OT_METHOD "opentxs::api::client::implementation::Sync::"
+
+namespace opentxs::api::client
+{
+Sync * Sync::Factory(
+    const Flag& running,
+    const OT_API& otapi,
+    const opentxs::OTAPI_Exec& exec,
+    const opentxs::api::ContactManager& contacts,
+    const opentxs::api::Settings& config,
+    const opentxs::api::Api& api,
+    const opentxs::api::client::Wallet& wallet,
+    const opentxs::api::client::Workflow& workflow,
+    const opentxs::api::crypto::Encode& encoding,
+    const opentxs::network::zeromq::Context& zmq,
+    const ContextLockCallback& lockCallback)
+{
+    return new api::client::implementation::Sync(
+        running,
+        otapi,
+        exec,
+        contacts,
+        config,
+        api,
+        wallet,
+        workflow,
+        encoding,
+        zmq,
+        lockCallback);
+}
+} // namespace opentxs::api::client
+
 
 namespace opentxs::api::client::implementation
 {

--- a/src/api/client/Sync.hpp
+++ b/src/api/client/Sync.hpp
@@ -41,10 +41,16 @@
 
 #include "opentxs/Internal.hpp"
 
+#include "opentxs/core/Identifier.hpp"
+
 #include "opentxs/api/client/Sync.hpp"
+#if OT_CASH
+#include "opentxs/cash/Purse.hpp"
+#endif //OT_CASH
 #include "opentxs/core/Lockable.hpp"
 #include "opentxs/core/Flag.hpp"
 #include "opentxs/core/UniqueQueue.hpp"
+#include "opentxs/ext/OTPayment.hpp"
 
 #include <atomic>
 #include <memory>

--- a/src/api/crypto/Encode.cpp
+++ b/src/api/crypto/Encode.cpp
@@ -38,8 +38,6 @@
 
 #include "opentxs/stdafx.hpp"
 
-#include "Encode.hpp"
-
 #include "opentxs/core/crypto/CryptoEncoding.hpp"
 #include "opentxs/core/crypto/OTPassword.hpp"
 #if OT_CRYPTO_USING_TREZOR
@@ -51,6 +49,8 @@
 
 #include <iostream>
 #include <regex>
+
+#include "Encode.hpp"
 
 namespace opentxs::api::crypto::implementation
 {

--- a/src/cash/Purse.cpp
+++ b/src/cash/Purse.cpp
@@ -66,10 +66,13 @@
 #include <stdint.h>
 #include <list>
 #include <map>
-#include <memory>
 #include <ostream>
 #include <string>
 #include <utility>
+
+#if OT_CASH
+template class std::shared_ptr<const opentxs::Purse>;
+#endif //OT_CASH
 
 namespace opentxs
 {

--- a/src/client/OTRecord.cpp
+++ b/src/client/OTRecord.cpp
@@ -68,29 +68,29 @@ namespace opentxs
 bool OTRecord::FormatAmount(std::string& str_output) const
 {
     if (m_str_amount.empty() ||
-        m_str_instrument_definition_id.empty())  // Need these to do the
+        m_str_unit_type_id.empty())  // Need these to do the
                                                  // formatting.
     {
 //      otOut << __FUNCTION__ << ": Unable to format amount. Type: " <<
 //      m_str_type << " Amount: "
 //            << m_str_amount << "  Asset: " <<
-//            m_str_instrument_definition_id << "";
+//            m_str_unit_type_id << "";
         return false;
     }
     str_output = OT::App().API().Exec().FormatAmount(
-        m_str_instrument_definition_id,
+        m_str_unit_type_id,
         OT::App().API().Exec().StringToLong(m_str_amount));
     return (!str_output.empty());
 }
 
 bool OTRecord::FormatAmountWithoutSymbol(std::string& str_output)
 {
-    if (m_str_amount.empty() || m_str_instrument_definition_id.empty()) {
+    if (m_str_amount.empty() || m_str_unit_type_id.empty()) {
         return false;
     }
 
     str_output = OT::App().API().Exec().FormatAmountWithoutSymbol(
-        m_str_instrument_definition_id,
+        m_str_unit_type_id,
         OT::App().API().Exec().StringToLong(m_str_amount));
     return (!str_output.empty());
 }
@@ -101,17 +101,17 @@ bool OTRecord::FormatAmountLocale(
     const std::string& str_decimal) const
 {
     if (m_str_amount.empty() ||
-        m_str_instrument_definition_id.empty())  // Need these to do the
+        m_str_unit_type_id.empty())  // Need these to do the
                                                  // formatting.
     {
 //      otOut << __FUNCTION__ << ": Unable to format amount. Type: " <<
 //      m_str_type << " Amount: "
 //            << m_str_amount << "  Asset: " <<
-//            m_str_instrument_definition_id << "";
+//            m_str_unit_type_id << "";
         return false;
     }
     str_output = OT::App().API().Exec().FormatAmountLocale(
-        m_str_instrument_definition_id,
+        m_str_unit_type_id,
         OT::App().API().Exec().StringToLong(m_str_amount),
         str_thousands,
         str_decimal);
@@ -123,12 +123,12 @@ bool OTRecord::FormatAmountWithoutSymbolLocale(
     const std::string& str_thousands,
     const std::string& str_decimal)
 {
-    if (m_str_amount.empty() || m_str_instrument_definition_id.empty()) {
+    if (m_str_amount.empty() || m_str_unit_type_id.empty()) {
         return false;
     }
 
     str_output = OT::App().API().Exec().FormatAmountWithoutSymbolLocale(
-        m_str_instrument_definition_id,
+        m_str_unit_type_id,
         OT::App().API().Exec().StringToLong(m_str_amount),
         str_thousands,
         str_decimal);
@@ -303,7 +303,7 @@ bool OTRecord::FormatDescription(std::string& str_output) const
                     str_instrument_type = "final receipt (finished)";
                 }
             } else if (0 == GetInstrumentType().compare("marketReceipt")) {
-                const int64_t lAmount =
+                const Amount lAmount =
                     OT::App().API().Exec().StringToLong(m_str_amount);
 
                 // I *think* successful trades have a negative amount -- we'll
@@ -315,7 +315,7 @@ bool OTRecord::FormatDescription(std::string& str_output) const
                     str_instrument_type = "market trade (receipt)";
                 }
             } else if (0 == GetInstrumentType().compare("chequeReceipt")) {
-                const int64_t lAmount =
+                const Amount lAmount =
                     OT::App().API().Exec().StringToLong(m_str_amount);
 
                 // I paid OUT when this chequeReceipt came through. It must be a
@@ -334,7 +334,7 @@ bool OTRecord::FormatDescription(std::string& str_output) const
             } else if (0 == GetInstrumentType().compare("voucherReceipt")) {
                 str_instrument_type = "payment";
             } else if (0 == GetInstrumentType().compare("paymentReceipt")) {
-                const int64_t lAmount =
+                const Amount lAmount =
                     OT::App().API().Exec().StringToLong(m_str_amount);
 
                 if (!IsCanceled() && (lAmount > 0)) strKind.Set("received ");
@@ -407,7 +407,7 @@ bool OTRecord::FormatDescription(std::string& str_output) const
                     str_instrument_type = "final receipt";
                 }
             } else if (0 == GetInstrumentType().compare("marketReceipt")) {
-                const int64_t lAmount =
+                const Amount lAmount =
                     OT::App().API().Exec().StringToLong(m_str_amount);
 
                 // I *think* marketReceipts have negative value. We'll just test
@@ -417,7 +417,7 @@ bool OTRecord::FormatDescription(std::string& str_output) const
                 else
                     str_instrument_type = "market trade (receipt)";
             } else if (0 == GetInstrumentType().compare("chequeReceipt")) {
-                const int64_t lAmount =
+                const Amount lAmount =
                     OT::App().API().Exec().StringToLong(m_str_amount);
 
                 // I paid OUT when this chequeReceipt came through. It must be a
@@ -444,7 +444,7 @@ bool OTRecord::FormatDescription(std::string& str_output) const
                 else
                     str_instrument_type = "payment (receipt)";
             } else if (0 == GetInstrumentType().compare("paymentReceipt")) {
-                const int64_t lAmount =
+                const Amount lAmount =
                     OT::App().API().Exec().StringToLong(m_str_amount);
 
                 if (!IsCanceled() && (lAmount > 0)) strKind.Set("received ");
@@ -517,7 +517,7 @@ time64_t OTRecord::GetInitialPaymentDate() const
     return OT_TIME_ZERO;
 }
 
-int64_t OTRecord::GetInitialPaymentAmount() const
+Amount OTRecord::GetInitialPaymentAmount() const
 {
     if (!IsPaymentPlan()) return 0;
 
@@ -553,7 +553,7 @@ time64_t OTRecord::GetTimeBetweenPayments() const
     return OT_TIME_ZERO;
 }
 
-int64_t OTRecord::GetPaymentPlanAmount() const
+Amount OTRecord::GetPaymentPlanAmount() const
 {
     if (!IsPaymentPlan()) return 0;
 
@@ -585,12 +585,12 @@ void OTRecord::SetFinalReceipt(bool bValue /*=true*/)
     m_bIsFinalReceipt = bValue;
 }
 
-void OTRecord::SetClosingNum(const int64_t lClosingNum)
+void OTRecord::SetClosingNum(const TransactionNumber lClosingNum)
 {
     m_lClosingNum = lClosingNum;
 }
 
-bool OTRecord::GetClosingNum(int64_t& lClosingNum) const
+bool OTRecord::GetClosingNum(TransactionNumber& lClosingNum) const
 {
     if (!m_bIsFinalReceipt) return false;
 
@@ -725,26 +725,46 @@ bool OTRecord::DiscardOutgoingCash() const
 //
 bool OTRecord::DeleteRecord() const
 {
-    if (!CanDeleteRecord()) return false;
-    if (!m_bIsSpecialMail &&
-        (m_str_notary_id.empty() || m_str_nym_id.empty())) {
-        otErr << __FUNCTION__ << ": Error: missing server id ("
-              << m_str_notary_id << ") or nym id (" << m_str_nym_id << ")\n";
+    if (!CanDeleteRecord())
         return false;
-    }
+    // ----------------------------------------------
     std::string str_using_account;
+    bool bUsingAccountOrNym{false};
 
     if ((OTRecord::Transfer == GetRecordType()) ||
-        (OTRecord::Receipt == GetRecordType())) {
+        (OTRecord::Receipt == GetRecordType()))
+    {
         if (m_str_account_id.empty()) {
             otErr << __FUNCTION__
-                  << ": Error: missing account id for transfer or receipt.\n";
+            << ": Error: missing account id for transfer or receipt.\n";
             return false;
         }
-
-        str_using_account = m_str_account_id;
-    } else
-        str_using_account = m_str_nym_id;  // For instruments.
+        bUsingAccountOrNym = true;
+        str_using_account = m_str_account_id; // For receipts in asset acct box.
+    } else {
+        bUsingAccountOrNym = false;
+        str_using_account = m_str_nym_id;  // For instruments in payment box.
+    }
+    // ----------------------------------------------
+    if (!m_bIsSpecialMail)
+    {
+        if (m_str_nym_id.empty()) {
+            otErr << __FUNCTION__ << ": Error: missing nym id ("
+                  << m_str_nym_id << ")\n";
+            return false;
+        }
+        if (bUsingAccountOrNym && m_str_pmnt_notary_id.empty()) {
+            otErr << __FUNCTION__ << ": Error: missing pmnt notary id ("
+                  << m_str_pmnt_notary_id << ")\n";
+            return false;
+        }
+        if (!bUsingAccountOrNym && m_str_msg_notary_id.empty()) {
+            otErr << __FUNCTION__ << ": Error: missing msg notary id ("
+                  << m_str_msg_notary_id << ")\n";
+            return false;
+        }
+    }
+    // ----------------------------------------------
     switch (GetRecordType()) {
         // Delete from in-mail or out-mail.
         //
@@ -807,23 +827,44 @@ bool OTRecord::DeleteRecord() const
     if (0 == m_lTransactionNum) {
         otErr << __FUNCTION__
               << ": Error: Transaction number is 0, in recordbox for "
-                 "server id ("
-              << m_str_notary_id << "), nym id (" << m_str_nym_id
+                 "msg notary id ("
+              << m_str_msg_notary_id << "), pmnt notary id ("
+              << m_str_pmnt_notary_id << "), nym id (" << m_str_nym_id
               << "), acct id (" << str_using_account << ")\n";
         return false;
     }
-    const Identifier theNotaryID(m_str_notary_id), theNymID(m_str_nym_id),
-        theAcctID(str_using_account);  // this last one sometimes contains NymID
-                                       // (see above.)
+
+    const Identifier theNotaryID(bUsingAccountOrNym
+                                 ? m_str_pmnt_notary_id
+                                 : m_str_msg_notary_id);
+
+    const Identifier theNymID(m_str_nym_id),
+                     theAcctID(str_using_account);  // this one sometimes
+                                                    // contains NymID.
+
+    // Sometimes this is an asset account record box for the payment notary.
+    // Sometimes this is a Nym's payments record box for the transport notary.
+    //
+    // In the first case, it's a transfer or receipt that was in your asset
+    // account inbox and is now in the corresponding record box. That's the
+    // account on the notary where the payment actually happened.
+    //
+    // In the second case, it's a cheque that someone sent you, which was in
+    // your payments inbox (on the server where you receive MESSAGES, NOT on
+    // the server where that cheque was drawn!) Now since you already deposited
+    // it or whatever, it's now in the record box that corresponds to that
+    // payments inbox on your transport notary.
+    //
+    // So in some cases, we want to use your payment notary, and in other cases,
+    // we want to use your transport notary.
 
     Ledger* pRecordbox =
-        OT::App().API().OTAPI().LoadRecordBox(theNotaryID, theNymID, theAcctID);
+        OT::App().API().OTAPI().LoadRecordBox(theNotaryID, theNymID,
+                                              theAcctID);
     std::unique_ptr<Ledger> theRecordBoxAngel(pRecordbox);
-    if (nullptr == pRecordbox) {
-        otErr << __FUNCTION__ << ": Failed loading record box for server ID ("
-              << m_str_notary_id
-              << ") nymID "
-                 "("
+    if (!pRecordbox) {
+        otErr << __FUNCTION__ << ": Failed loading record box for msg notary ID"
+              " (" << m_str_msg_notary_id << ") nymID ("
               << m_str_nym_id << ") accountID (" << str_using_account << ")\n";
         return false;
     }
@@ -836,14 +877,15 @@ bool OTRecord::DeleteRecord() const
               << m_lTransactionNum
               << " in recordbox "
                  "for server id ("
-              << m_str_notary_id << "), nym id (" << m_str_nym_id
+              << theNotaryID.str() << "), nym id (" << m_str_nym_id
               << "), acct id (" << str_using_account << ")\n";
         return false;
     }
     // Accept it.
     //
     return SwigWrap::ClearRecord(
-        m_str_notary_id,
+        //m_str_msg_notary_id,
+        theNotaryID.str(),
         m_str_nym_id,
         str_using_account,
         nIndex,
@@ -884,12 +926,12 @@ bool OTRecord::accept_inbox_items(
 }
 
 bool OTRecord::discard_incoming_payments(
-    const std::string& notaryID,
-    const std::string& nymID,
+    const std::string& TRANSPORT_NOTARY_ID,
+    const std::string& NYM_ID,
     const std::string& INDICES) const
 {
-    return 1 == OTRecordList::discard_incoming_payments(notaryID,
-                                                        nymID,
+    return 1 == OTRecordList::discard_incoming_payments(TRANSPORT_NOTARY_ID,
+                                                        NYM_ID,
                                                         INDICES);
 }
 
@@ -920,10 +962,10 @@ bool OTRecord::AcceptIncomingTransferOrReceipt() const
         //
         case OTRecord::Transfer:
         case OTRecord::Receipt: {
-            if (m_str_notary_id.empty() || m_str_nym_id.empty() ||
+            if (m_str_pmnt_notary_id.empty() || m_str_nym_id.empty() ||
                 m_str_account_id.empty()) {
-                otErr << __FUNCTION__ << ": Error: missing server id ("
-                      << m_str_notary_id << ") or nym id (" << m_str_nym_id
+                otErr << __FUNCTION__ << ": Error: missing pmnt notary id ("
+                      << m_str_pmnt_notary_id << ") or nym id (" << m_str_nym_id
                       << ") or "
                          "acct id ("
                       << m_str_account_id << ")\n";
@@ -932,23 +974,23 @@ bool OTRecord::AcceptIncomingTransferOrReceipt() const
             if (0 == m_lTransactionNum) {
                 otErr << __FUNCTION__
                       << ": Error: Transaction number is 0, in asset "
-                         "account inbox for server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                         "account inbox for pmnt notary id ("
+                      << m_str_pmnt_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
-            const Identifier theNotaryID(m_str_notary_id),
+            const Identifier thePmntNotaryID(m_str_pmnt_notary_id),
                 theNymID(m_str_nym_id), theAcctID(m_str_account_id);
 
             // Open the Nym's asset account inbox.
             Ledger* pInbox = OT::App().API().OTAPI().LoadInbox(
-                theNotaryID, theNymID, theAcctID);
+                thePmntNotaryID, theNymID, theAcctID);
             std::unique_ptr<Ledger> theInboxAngel(pInbox);
-            if (nullptr == pInbox) {
+            if (!pInbox) {
                 otErr << __FUNCTION__
                       << ": Error: Unable to load asset account inbox for "
-                         "server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                         "pmnt notary id ("
+                      << m_str_pmnt_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
@@ -960,9 +1002,9 @@ bool OTRecord::AcceptIncomingTransferOrReceipt() const
             if ((-1) == nIndex) {
                 otErr << __FUNCTION__ << ": Error: Unable to find transaction "
                       << m_lTransactionNum
-                      << " in payment inbox "
-                         "for server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                      << " in asset account inbox "
+                         "for pmnt notary id ("
+                      << m_str_pmnt_notary_id << "), nym id (" << m_str_nym_id
                       << "), acct id (" << m_str_account_id << ")\n";
                 return false;
             }
@@ -992,32 +1034,33 @@ bool OTRecord::AcceptIncomingInstrument(const std::string& str_into_acct) const
         // Accept from Nym's payments inbox.
         //
         case OTRecord::Instrument: {
-            if (m_str_notary_id.empty() || m_str_nym_id.empty()) {
-                otErr << __FUNCTION__ << ": Error: missing server id ("
-                      << m_str_notary_id << ") or nym id (" << m_str_nym_id
+            if (m_str_msg_notary_id.empty() || m_str_nym_id.empty()) {
+                otErr << __FUNCTION__ << ": Error: missing msg notary id ("
+                      << m_str_msg_notary_id << ") or nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
             if (0 == m_lTransactionNum) {
                 otErr << __FUNCTION__
                       << ": Error: Transaction number is 0, in payment "
-                         "inbox for server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                         "inbox for msg notary id ("
+                      << m_str_msg_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
-            const Identifier theNotaryID(m_str_notary_id),
+            const Identifier theMsgNotaryID(m_str_msg_notary_id),
                 theNymID(m_str_nym_id);
 
             // Open the Nym's payments inbox.
             Ledger* pInbox =
-                OT::App().API().OTAPI().LoadPaymentInbox(theNotaryID, theNymID);
+                OT::App().API().OTAPI().LoadPaymentInbox(theMsgNotaryID,
+                                                         theNymID);
             std::unique_ptr<Ledger> theInboxAngel(pInbox);
-            if (nullptr == pInbox) {
+            if (!pInbox) {
                 otErr << __FUNCTION__
-                      << ": Error: Unable to load payment inbox for server "
+                      << ": Error: Unable to load payment inbox for msg notary "
                          "id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                      << m_str_msg_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
@@ -1029,8 +1072,8 @@ bool OTRecord::AcceptIncomingInstrument(const std::string& str_into_acct) const
                 otErr << __FUNCTION__ << ": Error: Unable to find transaction "
                       << m_lTransactionNum
                       << " in "
-                         "payment inbox for server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                         "payment inbox for transport notary id ("
+                      << m_str_msg_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
@@ -1067,6 +1110,7 @@ bool OTRecord::AcceptIncomingInstrument(const std::string& str_into_acct) const
 
             std::string str_server_response;
             if (!OTRecordList::accept_from_paymentbox(
+                    m_str_msg_notary_id,
                     str_into_acct,
                     str_indices,
                     szPaymentType,
@@ -1078,7 +1122,8 @@ bool OTRecord::AcceptIncomingInstrument(const std::string& str_into_acct) const
                 backlink_.notifyOfSuccessfulNotarization(
                     str_into_acct,
                     m_str_nym_id,
-                    m_str_notary_id,
+                    m_str_msg_notary_id,
+                    m_str_pmnt_notary_id,
                     str_server_response,
                     m_lTransactionNum,
                     m_lTransNumForDisplay);
@@ -1101,31 +1146,33 @@ bool OTRecord::DiscardIncoming() const
 
     switch (GetRecordType()) {
         case OTRecord::Instrument: {
-            if (m_str_notary_id.empty() || m_str_nym_id.empty()) {
+            if (m_str_msg_notary_id.empty() || m_str_nym_id.empty()) {
                 otErr << __FUNCTION__ << ": Error: missing server id ("
-                      << m_str_notary_id << ") or nym id (" << m_str_nym_id
+                      << m_str_msg_notary_id << ") or nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
             if (0 == m_lTransactionNum) {
                 otErr << __FUNCTION__
                       << ": Error: Transaction number is 0, in "
-                         "payment inbox for server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                         "payment inbox for transport notary id ("
+                      << m_str_msg_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
-            const Identifier theNotaryID(m_str_notary_id),
+            const Identifier theMsgNotaryID(m_str_msg_notary_id),
                 theNymID(m_str_nym_id);
 
             // Open the Nym's payments inbox.
             Ledger* pInbox =
-                OT::App().API().OTAPI().LoadPaymentInbox(theNotaryID, theNymID);
+                OT::App().API().OTAPI().LoadPaymentInbox(theMsgNotaryID,
+                                                         theNymID);
             std::unique_ptr<Ledger> theInboxAngel(pInbox);
-            if (nullptr == pInbox) {
+            if (!pInbox) {
                 otErr << __FUNCTION__
-                      << ": Error: Unable to load payment inbox for server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                      << ": Error: Unable to load payment inbox for transport "
+                         "notary id ("
+                      << m_str_msg_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
@@ -1137,8 +1184,8 @@ bool OTRecord::DiscardIncoming() const
                 otErr << __FUNCTION__ << ": Error: Unable to find transaction "
                       << m_lTransactionNum
                       << " in "
-                         "payment inbox for server id ("
-                      << m_str_notary_id << "), nym id (" << m_str_nym_id
+                         "payment inbox for transport notary id ("
+                      << m_str_msg_notary_id << "), nym id (" << m_str_nym_id
                       << ")\n";
                 return false;
             }
@@ -1149,7 +1196,7 @@ bool OTRecord::DiscardIncoming() const
             const std::string str_indices(strIndices.Get());
 
             return discard_incoming_payments(
-                m_str_notary_id, m_str_nym_id, str_indices);
+                m_str_msg_notary_id, m_str_nym_id, str_indices);
 
         }  // case: instrument
         break;
@@ -1239,7 +1286,7 @@ bool OTRecord::CancelOutgoing(std::string str_via_acct) const  // This can be
                               << lIndex << "\n";
                         return false;
                     }
-                    int64_t lTransNum = 0;
+                    TransactionNumber lTransNum = 0;
                     thePayment.GetOpeningNum(lTransNum, theNymID);
                     if (0 == lTransNum)  // Found it.
                     {
@@ -1293,7 +1340,7 @@ bool OTRecord::CancelOutgoing(std::string str_via_acct) const  // This can be
                           << "\n";
                     return false;
                 }
-                int64_t lTransNum = 0;
+                TransactionNumber lTransNum = 0;
                 thePayment.GetOpeningNum(lTransNum, theNymID);
                 if (lTransNum == m_lTransactionNum)  // Found it.
                 {
@@ -1314,22 +1361,22 @@ bool OTRecord::CancelOutgoing(std::string str_via_acct) const  // This can be
 
     return true;
 }
-int64_t OTRecord::GetTransactionNum() const
+TransactionNumber OTRecord::GetTransactionNum() const
 {
     return m_lTransactionNum;
 }  // Trans Num of receipt in the box. (Unless outpayment, contains number for
    // instrument.)
-void OTRecord::SetTransactionNum(int64_t lTransNum)
+void OTRecord::SetTransactionNum(TransactionNumber lTransNum)
 {
     m_lTransactionNum = lTransNum;
 }
-int64_t OTRecord::GetTransNumForDisplay() const
+TransactionNumber OTRecord::GetTransNumForDisplay() const
 {
     if (m_lTransNumForDisplay > 0) return m_lTransNumForDisplay;
 
     return m_lTransactionNum;
 }
-void OTRecord::SetTransNumForDisplay(int64_t lTransNum)
+void OTRecord::SetTransNumForDisplay(TransactionNumber lTransNum)
 {
     m_lTransNumForDisplay = lTransNum;
 }
@@ -1344,10 +1391,14 @@ bool OTRecord::HasContents() const { return !m_str_contents.empty(); }
 bool OTRecord::HasMemo() const { return !m_str_memo.empty(); }
 bool OTRecord::IsExpired() const { return m_bIsExpired; }
 bool OTRecord::IsCanceled() const { return m_bIsCanceled; }
-const std::string& OTRecord::GetNotaryID() const { return m_str_notary_id; }
-const std::string& OTRecord::GetInstrumentDefinitionID() const
+const std::string& OTRecord::GetMsgNotaryID()
+    const {return m_str_msg_notary_id;}
+const std::string& OTRecord::GetPmntNotaryID()
+    const {return m_str_pmnt_notary_id;}
+
+const std::string& OTRecord::GetUnitTypeID() const
 {
-    return m_str_instrument_definition_id;
+    return m_str_unit_type_id;
 }
 const std::string& OTRecord::GetCurrencyTLA() const
 {
@@ -1532,7 +1583,8 @@ bool OTRecord::operator<(const OTRecord& rhs)
 }
 OTRecord::OTRecord(
     OTRecordList& backlink,
-    const std::string& str_notary_id,
+    const std::string& str_msg_notary_id,
+    const std::string& str_pmnt_notary_id,
     const std::string& str_instrument_definition_id,
     const std::string& str_currency_tla,
     const std::string& str_nym_id,
@@ -1550,8 +1602,9 @@ OTRecord::OTRecord(
     : backlink_(backlink)
     , m_ValidFrom(OT_TIME_ZERO)
     , m_ValidTo(OT_TIME_ZERO)
-    , m_str_notary_id(str_notary_id)
-    , m_str_instrument_definition_id(str_instrument_definition_id)
+    , m_str_msg_notary_id(str_msg_notary_id)
+    , m_str_pmnt_notary_id(str_pmnt_notary_id)
+    , m_str_unit_type_id(str_instrument_definition_id)
     , m_str_currency_tla(str_currency_tla)
     , m_str_nym_id(str_nym_id)
     , m_str_account_id(str_account_id)

--- a/src/client/OT_API.cpp
+++ b/src/client/OT_API.cpp
@@ -7730,11 +7730,18 @@ bool OT_API::RecordPayment(
     return true;
 }
 
+
+// Notice that since the Nym ID is sometimes also passed as the account ID
+// (in the case of Nym recordbox, versus Account recordbox...) which means
+// sometimes the Notary ID is the notary where a payment instrument was
+// transported, versus being a notary where a payment instrument was deposited.
+// (Often a different notary).
+//
+//
 bool OT_API::ClearRecord(
     const Identifier& NOTARY_ID,
     const Identifier& NYM_ID,
-    const Identifier& ACCOUNT_ID,  // NYM_ID can be passed
-                                   // here as well.
+    const Identifier& ACCOUNT_ID,  // NYM_ID can be passed here as well.
     std::int32_t nIndex,
     bool bClearAll) const  // if true, nIndex is ignored.
 {
@@ -7752,11 +7759,11 @@ bool OT_API::ClearRecord(
     std::unique_ptr<Ledger> pRecordBox(
         LoadRecordBox(NOTARY_ID, NYM_ID, ACCOUNT_ID));
 
-    if (nullptr == pRecordBox) {
+    if (pRecordBox) {
         pRecordBox.reset(Ledger::GenerateLedger(
             NYM_ID, ACCOUNT_ID, NOTARY_ID, Ledger::recordBox, true));
 
-        if (nullptr == pRecordBox) {
+        if (pRecordBox) {
             otErr << OT_METHOD << __FUNCTION__
                   << ": Unable to load or create record box "
                      "(and thus unable to do anything with it.)\n";

--- a/src/client/SwigWrap.cpp
+++ b/src/client/SwigWrap.cpp
@@ -38,8 +38,7 @@
 
 #include "opentxs/stdafx.hpp"
 
-#include "opentxs/client/SwigWrap.hpp"
-
+#include "opentxs/core/Identifier.hpp"
 #include "opentxs/api/client/Issuer.hpp"
 #include "opentxs/api/client/Pair.hpp"
 #include "opentxs/api/client/Sync.hpp"
@@ -63,7 +62,6 @@
 #include "opentxs/core/crypto/OTPasswordData.hpp"
 #include "opentxs/core/util/Assert.hpp"
 #include "opentxs/core/util/Common.hpp"
-#include "opentxs/core/Identifier.hpp"
 #include "opentxs/core/Log.hpp"
 #include "opentxs/core/NumList.hpp"
 #include "opentxs/core/String.hpp"
@@ -73,6 +71,8 @@
 #include "opentxs/OT.hpp"
 #include "opentxs/Proto.hpp"
 #include "opentxs/Types.hpp"
+
+#include "opentxs/client/SwigWrap.hpp"
 
 #include <algorithm>
 #include <chrono>

--- a/src/core/Identifier.cpp
+++ b/src/core/Identifier.cpp
@@ -55,6 +55,12 @@
 #include "opentxs/core/String.hpp"
 #include "opentxs/OT.hpp"
 
+
+template class std::set<opentxs::OTIdentifier>;
+template class std::map<opentxs::OTIdentifier,
+                        std::set<opentxs::OTIdentifier>>;
+
+
 namespace opentxs
 {
 OTIdentifier Identifier::Factory() { return OTIdentifier(new Identifier()); }

--- a/src/ext/OTPayment.cpp
+++ b/src/ext/OTPayment.cpp
@@ -65,10 +65,11 @@
 
 #include <irrxml/irrXML.hpp>
 #include <stdint.h>
-#include <memory>
 #include <ostream>
 #include <string>
 #include <vector>
+
+template class std::shared_ptr<const opentxs::OTPayment>;
 
 #define OT_METHOD "opentxs::OTPayment::"
 


### PR DESCRIPTION
The first commit contains updates needed by Moneychanger in order to differentiate between transport notaries and payment notaries. (To fix a bug where an instrument didn't deposit properly).
The second commit contains my efforts, thus far unsuccessful, to fix the bug where building Opentxs with clang causes _clang itself_ to crash. (Usually when building Pair.cpp).
Moneychanger PR coming shortly once OT is building again.