### PR TITLE
Revert badly-designed "fix" for new clang warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if(ANDROID)
 endif()
 
 if(CMAKE_COMPILER_IS_CLANGXX)
-  set(PEDANTIC_CXX_FLAGS "${PEDANTIC_CXX_FLAGS} -Wno-unused-parameter -Wno-old-style-cast")
+  set(PEDANTIC_CXX_FLAGS "${PEDANTIC_CXX_FLAGS} -Wno-unused-parameter -Wno-old-style-cast -Wno-null-dereference")
 endif()
 
 message(STATUS "C++ Compiler ID: ${CMAKE_CXX_COMPILER_ID}")

--- a/src/ui/ContactSectionBlank.hpp
+++ b/src/ui/ContactSectionBlank.hpp
@@ -53,24 +53,12 @@ public:
     std::string Name(const std::string& lang) const override { return {}; }
     const opentxs::ui::ContactSubsection& First() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-      // then returns it as a reference. Undefined behavior; clang wouldn't
-      // even compile on my Mac.
         return *static_cast<const opentxs::ui::ContactSubsection*>(nullptr);
-#endif
     }
     bool Last() const override { return true; }
     const opentxs::ui::ContactSubsection& Next() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-      // then returns it as a reference. Undefined behavior; clang wouldn't
-      // even compile on my Mac.
         return *static_cast<const opentxs::ui::ContactSubsection*>(nullptr);
-#endif
     }
     proto::ContactSectionName Type() const override { return {}; }
     bool Valid() const override { return false; }

--- a/src/ui/ContactSubsectionBlank.hpp
+++ b/src/ui/ContactSubsectionBlank.hpp
@@ -53,24 +53,12 @@ public:
     std::string Name(const std::string& lang) const override { return {}; }
     const opentxs::ui::ContactItem& First() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-      // then returns it as a reference. Undefined behavior; clang wouldn't
-      // even compile on my Mac.
         return *static_cast<const opentxs::ui::ContactItem*>(nullptr);
-#endif
     }
     bool Last() const override { return true; }
     const opentxs::ui::ContactItem& Next() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-        // then returns it as a reference. Undefined behavior; clang wouldn't
-        // even compile on my Mac.
         return *static_cast<const opentxs::ui::ContactItem*>(nullptr);
-#endif
     }
     proto::ContactItemType Type() const override { return {}; }
     bool Valid() const override { return false; }

--- a/src/ui/ProfileSectionBlank.hpp
+++ b/src/ui/ProfileSectionBlank.hpp
@@ -61,26 +61,14 @@ public:
     bool Delete(const int, const std::string&) const override { return false; }
     const opentxs::ui::ProfileSubsection& First() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-      // then returns it as a reference. Undefined behavior; clang wouldn't
-      // even compile on my Mac.
         return *static_cast<const opentxs::ui::ProfileSubsection*>(nullptr);
-#endif
     }
     ItemTypeList Items(const std::string&) const override { return {}; }
     bool Last() const override { return true; }
     std::string Name(const std::string& lang) const override { return {}; }
     const opentxs::ui::ProfileSubsection& Next() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-      // then returns it as a reference. Undefined behavior; clang wouldn't
-      // even compile on my Mac.
         return *static_cast<const opentxs::ui::ProfileSubsection*>(nullptr);
-#endif
     }
     bool SetActive(const int, const std::string&, const bool) const override
     {

--- a/src/ui/ProfileSubsectionBlank.hpp
+++ b/src/ui/ProfileSubsectionBlank.hpp
@@ -57,25 +57,13 @@ public:
     bool Delete(const std::string& claimID) const override { return false; }
     const opentxs::ui::ProfileItem& First() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-      // then returns it as a reference. Undefined behavior; clang wouldn't
-      // even compile on my Mac.
         return *static_cast<const opentxs::ui::ProfileItem*>(nullptr);
-#endif
     }
     bool Last() const override { return true; }
     std::string Name(const std::string& lang) const override { return {}; }
     const opentxs::ui::ProfileItem& Next() const override
     {
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-        OT_FAIL;
-#else // Notice the below line deliberately dereferences a null pointer,
-      // then returns it as a reference. Undefined behavior; clang wouldn't
-      // even compile on my Mac.
         return *static_cast<const opentxs::ui::ProfileItem*>(nullptr);
-#endif
     }
     proto::ContactItemType Type() const override { return {}; }
     bool SetActive(const std::string&, const bool) const override


### PR DESCRIPTION
The previous commit added a workaround for a new clang warning that only suppressed the warning for Mac users, not for clang builds on any other platform.

This commit disables the new warning for clang on all platforms and removes the erroneous ifdef statements.