### PR TITLE
Patch around unused variable errors.

### DIFF
--- a/src/client/OTClient.cpp
+++ b/src/client/OTClient.cpp
@@ -947,7 +947,10 @@ bool OTClient::harvest_unused(ServerContext& context)
 
     // Loop through workflows to determine which issued numbers should not be
     // harvested
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
     for (const auto& [id, alias] : workflows) {
+#pragma GCC diagnostic pop
         const auto workflowID = Identifier::Factory(id);
         const auto workflow = workflow_.LoadWorkflow(nymID, workflowID);
 
@@ -998,9 +1001,11 @@ bool OTClient::harvest_unused(ServerContext& context)
         switch (workflow->type()) {
             case proto::PAYMENTWORKFLOWTYPE_OUTGOINGCHEQUE:
             case proto::PAYMENTWORKFLOWTYPE_OUTGOINGINVOICE: {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
                 auto [state, cheque] =
                     api::client::Workflow::InstantiateCheque(api_, *workflow);
-
+#pragma GCC diagnostic pop
                 if (false == bool(cheque)) {
                     otErr << OT_METHOD << __FUNCTION__
                           << ": Failed to load cheque" << std::endl;

--- a/src/contact/ContactSection.cpp
+++ b/src/contact/ContactSection.cpp
@@ -83,8 +83,11 @@ ContactSection ContactSection::operator+(const ContactSection& rhs) const
 
             OT_ASSERT(group);
         } else {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
             [[maybe_unused]] const auto [it, inserted] =
                 map.emplace(rhsID, rhsGroup);
+#pragma GCC diagnostic pop
 
             OT_ASSERT(inserted);
         }

--- a/src/storage/tree/Bip47Channels.cpp
+++ b/src/storage/tree/Bip47Channels.cpp
@@ -340,7 +340,11 @@ proto::StorageBip47Contexts Bip47Channels::serialize() const
         }
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
     for (const auto& [id, data] : channel_data_) {
+#pragma GCC diagnostic pop
+
         const auto& [local, chain, contact, remote] = data;
         auto& index = *serialized.add_index();
         index.set_version(CHANNEL_INDEX_VERSION);


### PR DESCRIPTION
Building with gcc-8 causes unused variable warnings, which are fatal because of -Werror.