### PR TITLE
lucre/bank.h has missing variables; turn off "warnings" for it

### DIFF
--- a/include/opentxs/cash/DigitalCash.hpp
+++ b/include/opentxs/cash/DigitalCash.hpp
@@ -22,7 +22,10 @@
 
 #if OT_CASH_USING_LUCRE
 // IWYU pragma: begin_exports
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #include <lucre/bank.h>
+#pragma GCC diagnostic pop
 // IWYU pragma: end_exports
 #endif
 


### PR DESCRIPTION
Because we're building with -Werror, other people's warnings are our "blows up the build." This uses a pragma to disable this "warning".