### PR TITLE
Revert "Prefer std::variant to union."

### DIFF
--- a/src/otx/client/StateMachine.cpp
+++ b/src/otx/client/StateMachine.cpp
@@ -965,7 +965,8 @@ bool StateMachine::run_task(
 template <typename T>
 bool StateMachine::run_task(std::function<bool(const TaskID, const T&)> func)
 {
-    auto& param = param_.emplace<T>(make_blank<T>::value());
+    auto& param = get_param<T>();
+    new (&param) T(make_blank<T>::value());
 
     while (get_task<T>().Pop(task_id_, param)) {
         LogInsane(OT_METHOD)(__FUNCTION__)(": ")(--task_count_).Flush();
@@ -974,6 +975,8 @@ bool StateMachine::run_task(std::function<bool(const TaskID, const T&)> func)
 
         func(task_id_, param);
     }
+
+    param.~T();
 
     return true;
 }

--- a/src/otx/client/StateMachine.hpp
+++ b/src/otx/client/StateMachine.hpp
@@ -18,7 +18,6 @@
 #include <functional>
 #include <future>
 #include <tuple>
-#include <variant>
 
 namespace std
 {
@@ -93,36 +92,37 @@ public:
     using TaskID = api::client::OTX::TaskID;
     using Thread = std::function<void()>;
 
-    using Params = std::variant<
-        std::monostate,
-        CheckNymTask,
-        DepositPaymentTask,
-        DownloadContractTask,
+    union Params {
+        CheckNymTask check_nym_;
+        DepositPaymentTask deposit_payment_;
+        DownloadContractTask download_contract_;
 #if OT_CASH
-        DownloadMintTask,
+        DownloadMintTask download_mint_;
 #endif
-        DownloadNymboxTask,
-        DownloadUnitDefinitionTask,
-        GetTransactionNumbersTask,
-        IssueUnitDefinitionTask,
-        MessageTask,
+        DownloadNymboxTask download_nymbox_;
+        DownloadUnitDefinitionTask download_unit_definition_;
+        GetTransactionNumbersTask get_transaction_numbers_;
+        IssueUnitDefinitionTask issue_unit_definition_;
+        MessageTask send_message_;
 #if OT_CASH
-        PayCashTask,
+        PayCashTask send_cash_;
 #endif
-        PaymentTask,
-        PeerReplyTask,
-        PeerRequestTask,
-        ProcessInboxTask,
-        PublishServerContractTask,
-        RegisterAccountTask,
-        RegisterNymTask,
-        SendChequeTask,
-        SendTransferTask
+        PaymentTask send_payment_;
+        PeerReplyTask peer_reply_;
+        PeerRequestTask peer_request_;
+        ProcessInboxTask process_inbox_;
+        PublishServerContractTask publish_server_contract_;
+        RegisterAccountTask register_account_;
+        RegisterNymTask register_nym_;
+        SendChequeTask send_cheque_;
+        SendTransferTask send_transfer_;
 #if OT_CASH
-        ,
-        WithdrawCashTask
+        WithdrawCashTask withdraw_cash_;
 #endif
-        >;
+
+        Params() { memset(static_cast<void*>(this), 0, sizeof(Params)); }
+        ~Params() {}
+    };
 
     otx::client::implementation::PaymentTasks payment_tasks_;
 

--- a/src/otx/client/StateMachine.tpp
+++ b/src/otx/client/StateMachine.tpp
@@ -10,6 +10,113 @@
 namespace opentxs::otx::client::implementation
 {
 template <>
+CheckNymTask& StateMachine::get_param()
+{
+    return param_.check_nym_;
+}
+template <>
+DepositPaymentTask& StateMachine::get_param()
+{
+    return param_.deposit_payment_;
+}
+template <>
+DownloadContractTask& StateMachine::get_param()
+{
+    return param_.download_contract_;
+}
+#if OT_CASH
+template <>
+DownloadMintTask& StateMachine::get_param()
+{
+    return param_.download_mint_;
+}
+#endif
+template <>
+DownloadNymboxTask& StateMachine::get_param()
+{
+    return param_.download_nymbox_;
+}
+template <>
+DownloadUnitDefinitionTask& StateMachine::get_param()
+{
+    return param_.download_unit_definition_;
+}
+template <>
+GetTransactionNumbersTask& StateMachine::get_param()
+{
+    return param_.get_transaction_numbers_;
+}
+template <>
+IssueUnitDefinitionTask& StateMachine::get_param()
+{
+    return param_.issue_unit_definition_;
+}
+template <>
+MessageTask& StateMachine::get_param()
+{
+    return param_.send_message_;
+}
+#if OT_CASH
+template <>
+PayCashTask& StateMachine::get_param()
+{
+    return param_.send_cash_;
+}
+#endif
+template <>
+PaymentTask& StateMachine::get_param()
+{
+    return param_.send_payment_;
+}
+template <>
+PeerReplyTask& StateMachine::get_param()
+{
+    return param_.peer_reply_;
+}
+template <>
+PeerRequestTask& StateMachine::get_param()
+{
+    return param_.peer_request_;
+}
+template <>
+ProcessInboxTask& StateMachine::get_param()
+{
+    return param_.process_inbox_;
+}
+template <>
+PublishServerContractTask& StateMachine::get_param()
+{
+    return param_.publish_server_contract_;
+}
+template <>
+RegisterAccountTask& StateMachine::get_param()
+{
+    return param_.register_account_;
+}
+template <>
+RegisterNymTask& StateMachine::get_param()
+{
+    return param_.register_nym_;
+}
+template <>
+SendChequeTask& StateMachine::get_param()
+{
+    return param_.send_cheque_;
+}
+template <>
+SendTransferTask& StateMachine::get_param()
+{
+    return param_.send_transfer_;
+}
+#if OT_CASH
+template <>
+WithdrawCashTask& StateMachine::get_param()
+{
+    return param_.withdraw_cash_;
+}
+#endif
+
+template <>
 const UniqueQueue<CheckNymTask>& StateMachine::get_task() const
 {
     return check_nym_;


### PR DESCRIPTION
Reverts Open-Transactions/opentxs#1392 due to std::variant gcc/clang incompatibility:

https://bugzilla.redhat.com/show_bug.cgi?id=1719103