### PR TITLE
Use unicode escape sequence for specifying the space character for formatting amounts.

### DIFF
--- a/src/blockchain/node/BlockOracle.hpp
+++ b/src/blockchain/node/BlockOracle.hpp
@@ -165,10 +165,9 @@ private:
             Mem(const std::size_t limit) noexcept;
 
         private:
-            using Completed =
-                std::deque<std::pair<block::pHash, BitcoinBlockFuture>>;
-            using Index = boost::container::
-                flat_map<ReadView, Completed::const_reverse_iterator>;
+            using CachedBlock = std::pair<block::pHash, BitcoinBlockFuture>;
+            using Completed = std::deque<CachedBlock>;
+            using Index = boost::container::flat_map<ReadView, const CachedBlock*>;
 
             const std::size_t limit_;
             Completed queue_;

--- a/src/blockchain/node/blockoracle/Cache.cpp
+++ b/src/blockchain/node/blockoracle/Cache.cpp
@@ -109,7 +109,7 @@ auto BlockOracle::Cache::ReceiveBlock(BitcoinBlock_p in) const noexcept -> void
     auto& [time, promise, future, queued] = pending->second;
     promise.set_value(std::move(in));
     LogVerbose(OT_METHOD)(__FUNCTION__)(": Cached block ")(id.asHex()).Flush();
-    mem_.push(std::move(id), std::move(future));
+    mem_.push(id, std::move(future));
     pending_.erase(pending);
     publish(pending_.size());
 }

--- a/src/blockchain/node/blockoracle/Mem.cpp
+++ b/src/blockchain/node/blockoracle/Mem.cpp
@@ -51,8 +51,11 @@ auto BlockOracle::Cache::Mem::push(
 {
     if (0 == id->size()) { return; }
 
-    const auto& item = queue_.emplace_back(std::move(id), std::move(future));
-    index_[item.first->Bytes()] = queue_.crbegin();
+    auto i = queue_.emplace(queue_.end(), std::move(id), std::move(future));
+    const auto& item = *i;
+    const auto [j, added] = index_.try_emplace(item.first->Bytes(), &item);
+
+    OT_ASSERT(added);
 
     while (queue_.size() > limit_) {
         const auto& item = queue_.front();

--- a/src/display/Scale_imp.hpp
+++ b/src/display/Scale_imp.hpp
@@ -89,8 +89,8 @@ struct Scale::Imp {
 
             if (formatDecimals) {
                 if (0u == (counter % 4u)) {
-                    static constexpr auto thinSpace = u8" ";
-                    output << thinSpace;
+                    static constexpr auto narrowNonBreakingSpace = u8"\u2009";
+                    output << narrowNonBreakingSpace;
                     ++counter;
                 }
 


### PR DESCRIPTION
Fixed an abort on Windows caused by iterator implementation differences.