### PR TITLE
Use the correct unicode escape sequence for narrow non-breaking space.

### DIFF
--- a/src/display/Scale_imp.hpp
+++ b/src/display/Scale_imp.hpp
@@ -89,7 +89,7 @@ struct Scale::Imp {
 
             if (formatDecimals) {
                 if (0u == (counter % 4u)) {
-                    static constexpr auto narrowNonBreakingSpace = u8"\u2009";
+                    static constexpr auto narrowNonBreakingSpace = u8"\u202F";
                     output << narrowNonBreakingSpace;
                     ++counter;
                 }

--- a/tests/blockchain/activity/Test_UI.cpp
+++ b/tests/blockchain/activity/Test_UI.cpp
@@ -740,7 +740,7 @@ TEST_F(Test_BlockchainActivity, receive_assigned_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_6_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"Free Ross");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Incoming Bitcoin transaction: Free Ross");
@@ -757,7 +757,7 @@ TEST_F(Test_BlockchainActivity, receive_assigned_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_5_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Incoming Bitcoin transaction");
@@ -827,7 +827,7 @@ TEST_F(Test_BlockchainActivity, receive_assigned_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), 1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Incoming Bitcoin transaction: Free Ross");
         EXPECT_EQ(memo.toString(), u8"Free Ross");
 
@@ -872,7 +872,7 @@ TEST_F(Test_BlockchainActivity, receive_assigned_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), 1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Incoming Bitcoin transaction");
         EXPECT_EQ(memo.toString(), u8"");
 
@@ -931,7 +931,7 @@ TEST_F(Test_BlockchainActivity, receive_assigned_activity_thread_1)
     ASSERT_TRUE(row->Valid());
     EXPECT_EQ(row->Amount(), 1380959);
     EXPECT_FALSE(row->Deposit());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_FALSE(row->Loading());
     EXPECT_TRUE(row->MarkRead());
     EXPECT_EQ(row->Memo(), u8"");
@@ -952,7 +952,7 @@ TEST_F(Test_BlockchainActivity, receive_assigned_activity_thread_2)
     ASSERT_TRUE(row->Valid());
     EXPECT_EQ(row->Amount(), 1380959);
     EXPECT_FALSE(row->Deposit());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_FALSE(row->Loading());
     EXPECT_TRUE(row->MarkRead());
     EXPECT_EQ(row->Memo(), u8"Free Ross");
@@ -1054,7 +1054,7 @@ TEST_F(Test_BlockchainActivity, send_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_7_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"-0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"-0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Outgoing Bitcoin transaction");
@@ -1071,7 +1071,7 @@ TEST_F(Test_BlockchainActivity, send_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_6_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"Free Ross");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Incoming Bitcoin transaction: Free Ross");
@@ -1088,7 +1088,7 @@ TEST_F(Test_BlockchainActivity, send_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_5_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Incoming Bitcoin transaction");
@@ -1158,7 +1158,7 @@ TEST_F(Test_BlockchainActivity, send_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), -1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"-0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"-0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Outgoing Bitcoin transaction");
         EXPECT_EQ(memo.toString(), u8"");
 
@@ -1203,7 +1203,7 @@ TEST_F(Test_BlockchainActivity, send_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), 1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Incoming Bitcoin transaction: Free Ross");
         EXPECT_EQ(memo.toString(), u8"Free Ross");
 
@@ -1248,7 +1248,7 @@ TEST_F(Test_BlockchainActivity, send_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), 1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Incoming Bitcoin transaction");
         EXPECT_EQ(memo.toString(), u8"");
 
@@ -1312,7 +1312,7 @@ TEST_F(Test_BlockchainActivity, send_activity_thread_3)
     ASSERT_TRUE(row->Valid());
     EXPECT_EQ(row->Amount(), -1380959);
     EXPECT_FALSE(row->Deposit());
-    EXPECT_EQ(row->DisplayAmount(), u8"-0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"-0.013\u202F809\u202F59 ₿");
     EXPECT_FALSE(row->Loading());
     EXPECT_TRUE(row->MarkRead());
     EXPECT_EQ(row->Memo(), u8"");
@@ -1381,7 +1381,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity)
     auto contacts = row->Contacts();
 
     EXPECT_EQ(contacts.size(), 0);
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Incoming Bitcoin transaction");
@@ -1398,7 +1398,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_7_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"-0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"-0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Outgoing Bitcoin transaction");
@@ -1415,7 +1415,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_6_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"Free Ross");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Incoming Bitcoin transaction: Free Ross");
@@ -1432,7 +1432,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity)
 
     ASSERT_EQ(contacts.size(), 1);
     EXPECT_EQ(contacts.at(0), contact_5_id().str());
-    EXPECT_EQ(row->DisplayAmount(), u8"0.013 809 59 ₿");
+    EXPECT_EQ(row->DisplayAmount(), u8"0.013\u202F809\u202F59 ₿");
     EXPECT_EQ(row->Memo(), u8"");
     EXPECT_EQ(row->Workflow(), u8"");
     EXPECT_EQ(row->Text(), u8"Incoming Bitcoin transaction");
@@ -1501,7 +1501,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), 1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Incoming Bitcoin transaction");
         EXPECT_EQ(memo.toString(), u8"");
 
@@ -1546,7 +1546,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), -1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"-0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"-0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Outgoing Bitcoin transaction");
         EXPECT_EQ(memo.toString(), u8"");
 
@@ -1591,7 +1591,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), 1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Incoming Bitcoin transaction: Free Ross");
         EXPECT_EQ(memo.toString(), u8"Free Ross");
 
@@ -1636,7 +1636,7 @@ TEST_F(Test_BlockchainActivity, receive_unassigned_account_activity_qt)
         EXPECT_EQ(polarity.toInt(), 1);
         EXPECT_EQ(workflow.toString(), u8"");
         EXPECT_EQ(type.toInt(), static_cast<int>(ot::StorageBox::BLOCKCHAIN));
-        EXPECT_EQ(amount.toString(), u8"0.013 809 59 ₿");
+        EXPECT_EQ(amount.toString(), u8"0.013\u202F809\u202F59 ₿");
         EXPECT_EQ(text.toString(), u8"Incoming Bitcoin transaction");
         EXPECT_EQ(memo.toString(), u8"");
 

--- a/tests/blockchain/regtest/Test_payment_code.cpp
+++ b/tests/blockchain/regtest/Test_payment_code.cpp
@@ -676,7 +676,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_first_spend_unconfirmed)
 
     ASSERT_EQ(deposit.size(), 1);
     EXPECT_EQ(deposit.at(0), test_chain_);
-    EXPECT_EQ(widget.DisplayBalance(), u8"89.999 996 84 units");
+    EXPECT_EQ(widget.DisplayBalance(), u8"89.999\u202F996\u202F84 units");
     EXPECT_EQ(widget.DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(widget.Name(), expected_account_name_);
     EXPECT_EQ(widget.NotaryID(), expected_notary_.str());
@@ -708,7 +708,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_first_spend_unconfirmed)
         }
     }
 
-    EXPECT_EQ(row->DisplayAmount(), u8"-10.000 003 16 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-10.000\u202F003\u202F16 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(
@@ -1133,7 +1133,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_first_spend_confirmed)
 
     ASSERT_EQ(deposit.size(), 1);
     EXPECT_EQ(deposit.at(0), test_chain_);
-    EXPECT_EQ(widget.DisplayBalance(), u8"89.999 996 84 units");
+    EXPECT_EQ(widget.DisplayBalance(), u8"89.999\u202F996\u202F84 units");
     EXPECT_EQ(widget.DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(widget.Name(), expected_account_name_);
     EXPECT_EQ(widget.NotaryID(), expected_notary_.str());
@@ -1165,7 +1165,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_first_spend_confirmed)
         }
     }
 
-    EXPECT_EQ(row->DisplayAmount(), u8"-10.000 003 16 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-10.000\u202F003\u202F16 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(
@@ -1809,7 +1809,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_second_spend_unconfirmed)
 
     ASSERT_EQ(deposit.size(), 1);
     EXPECT_EQ(deposit.at(0), test_chain_);
-    EXPECT_EQ(widget.DisplayBalance(), u8"74.999 994 48 units");
+    EXPECT_EQ(widget.DisplayBalance(), u8"74.999\u202F994\u202F48 units");
     EXPECT_EQ(widget.DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(widget.Name(), expected_account_name_);
     EXPECT_EQ(widget.NotaryID(), expected_notary_.str());
@@ -1841,7 +1841,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_second_spend_unconfirmed)
         }
     }
 
-    EXPECT_EQ(row->DisplayAmount(), u8"-15.000 002 36 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-15.000\u202F002\u202F36 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(
@@ -1873,7 +1873,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_second_spend_unconfirmed)
         }
     }
 
-    EXPECT_EQ(row->DisplayAmount(), u8"-10.000 003 16 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-10.000\u202F003\u202F16 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(
@@ -2488,7 +2488,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_after_otx)
 
     ASSERT_EQ(deposit.size(), 1);
     EXPECT_EQ(deposit.at(0), test_chain_);
-    EXPECT_EQ(widget.DisplayBalance(), u8"74.999 994 48 units");
+    EXPECT_EQ(widget.DisplayBalance(), u8"74.999\u202F994\u202F48 units");
     EXPECT_EQ(widget.DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(widget.Name(), expected_account_name_);
     EXPECT_EQ(widget.NotaryID(), expected_notary_.str());
@@ -2520,7 +2520,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_after_otx)
         }
     }
 
-    EXPECT_EQ(row->DisplayAmount(), u8"-15.000 002 36 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-15.000\u202F002\u202F36 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(row->Text(), "Outgoing Unit Test Simulation transaction to Bob");
@@ -2549,7 +2549,7 @@ TEST_F(Regtest_payment_code, alice_account_activity_after_otx)
         }
     }
 
-    EXPECT_EQ(row->DisplayAmount(), u8"-10.000 003 16 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-10.000\u202F003\u202F16 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(row->Text(), "Outgoing Unit Test Simulation transaction to Bob");

--- a/tests/blockchain/regtest/Test_send_hd.cpp
+++ b/tests/blockchain/regtest/Test_send_hd.cpp
@@ -467,7 +467,7 @@ TEST_F(Regtest_fixture_hd, account_list_after_receive)
     EXPECT_EQ(row->AccountID(), expected_account_.str());
     EXPECT_EQ(row->Balance(), 10000004950);
     EXPECT_EQ(row->ContractID(), expected_unit_.str());
-    EXPECT_EQ(row->DisplayBalance(), u8"100.000 049 5 units");
+    EXPECT_EQ(row->DisplayBalance(), u8"100.000\u202F049\u202F5 units");
     EXPECT_EQ(row->DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(row->Name(), expected_account_name_);
     EXPECT_EQ(row->NotaryID(), expected_notary_.str());
@@ -495,7 +495,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_receive)
 
     ASSERT_EQ(deposit.size(), 1);
     EXPECT_EQ(deposit.at(0), test_chain_);
-    EXPECT_EQ(widget.DisplayBalance(), u8"100.000 049 5 units");
+    EXPECT_EQ(widget.DisplayBalance(), u8"100.000\u202F049\u202F5 units");
     EXPECT_EQ(widget.DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(widget.Name(), expected_account_name_);
     EXPECT_EQ(widget.NotaryID(), expected_notary_.str());
@@ -513,7 +513,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_receive)
     ASSERT_TRUE(row->Valid());
     EXPECT_EQ(row->Amount(), 10000004950);
     EXPECT_EQ(row->Contacts().size(), 0);
-    EXPECT_EQ(row->DisplayAmount(), u8"100.000 049 5 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"100.000\u202F049\u202F5 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(row->Text(), "Incoming Unit Test Simulation transaction");
@@ -775,7 +775,7 @@ TEST_F(Regtest_fixture_hd, account_list_after_spend)
     EXPECT_EQ(row->AccountID(), expected_account_.str());
     EXPECT_EQ(row->Balance(), 8600002652);
     EXPECT_EQ(row->ContractID(), expected_unit_.str());
-    EXPECT_EQ(row->DisplayBalance(), u8"86.000 026 52 units");
+    EXPECT_EQ(row->DisplayBalance(), u8"86.000\u202F026\u202F52 units");
     EXPECT_EQ(row->DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(row->Name(), expected_account_name_);
     EXPECT_EQ(row->NotaryID(), expected_notary_.str());
@@ -803,7 +803,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_unconfirmed_spend)
 
     ASSERT_EQ(deposit.size(), 1);
     EXPECT_EQ(deposit.at(0), test_chain_);
-    EXPECT_EQ(widget.DisplayBalance(), u8"86.000 026 52 units");
+    EXPECT_EQ(widget.DisplayBalance(), u8"86.000\u202F026\u202F52 units");
     EXPECT_EQ(widget.DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(widget.Name(), expected_account_name_);
     EXPECT_EQ(widget.NotaryID(), expected_notary_.str());
@@ -821,7 +821,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_unconfirmed_spend)
     ASSERT_TRUE(row->Valid());
     EXPECT_EQ(row->Amount(), -1400002298);
     EXPECT_EQ(row->Contacts().size(), 0);
-    EXPECT_EQ(row->DisplayAmount(), u8"-14.000 022 98 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-14.000\u202F022\u202F98 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(row->Text(), "Outgoing Unit Test Simulation transaction");
@@ -835,7 +835,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_unconfirmed_spend)
 
     EXPECT_EQ(row->Amount(), 10000004950);
     EXPECT_EQ(row->Contacts().size(), 0);
-    EXPECT_EQ(row->DisplayAmount(), u8"100.000 049 5 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"100.000\u202F049\u202F5 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(row->Text(), "Incoming Unit Test Simulation transaction");
@@ -991,7 +991,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_confirmed_spend)
 
     ASSERT_EQ(deposit.size(), 1);
     EXPECT_EQ(deposit.at(0), test_chain_);
-    EXPECT_EQ(widget.DisplayBalance(), u8"86.000 026 52 units");
+    EXPECT_EQ(widget.DisplayBalance(), u8"86.000\u202F026\u202F52 units");
     EXPECT_EQ(widget.DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(widget.Name(), expected_account_name_);
     EXPECT_EQ(widget.NotaryID(), expected_notary_.str());
@@ -1009,7 +1009,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_confirmed_spend)
     ASSERT_TRUE(row->Valid());
     EXPECT_EQ(row->Amount(), -1400002298);
     EXPECT_EQ(row->Contacts().size(), 0);
-    EXPECT_EQ(row->DisplayAmount(), u8"-14.000 022 98 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"-14.000\u202F022\u202F98 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(row->Text(), "Outgoing Unit Test Simulation transaction");
@@ -1023,7 +1023,7 @@ TEST_F(Regtest_fixture_hd, account_activity_after_confirmed_spend)
 
     EXPECT_EQ(row->Amount(), 10000004950);
     EXPECT_EQ(row->Contacts().size(), 0);
-    EXPECT_EQ(row->DisplayAmount(), u8"100.000 049 5 units");
+    EXPECT_EQ(row->DisplayAmount(), u8"100.000\u202F049\u202F5 units");
     EXPECT_EQ(row->Memo(), "");
     EXPECT_EQ(row->Workflow(), "");
     EXPECT_EQ(row->Text(), "Incoming Unit Test Simulation transaction");
@@ -1167,7 +1167,7 @@ TEST_F(Regtest_fixture_hd, account_list_after_confirmed_spend)
     EXPECT_EQ(row->AccountID(), expected_account_.str());
     EXPECT_EQ(row->Balance(), 8600002652);
     EXPECT_EQ(row->ContractID(), expected_unit_.str());
-    EXPECT_EQ(row->DisplayBalance(), u8"86.000 026 52 units");
+    EXPECT_EQ(row->DisplayBalance(), u8"86.000\u202F026\u202F52 units");
     EXPECT_EQ(row->DisplayUnit(), expected_display_unit_);
     EXPECT_EQ(row->Name(), expected_account_name_);
     EXPECT_EQ(row->NotaryID(), expected_notary_.str());

--- a/tests/core/Test_DisplayScale.cpp
+++ b/tests/core/Test_DisplayScale.cpp
@@ -69,7 +69,7 @@ TEST(DisplayScale, usd)
 
     EXPECT_EQ(usd.Format(amount2, 0), std::string{u8"$14,000,000.88"});
     EXPECT_EQ(usd.Format(amount2, 1), std::string{u8"1,400,000,088 ¢"});
-    EXPECT_EQ(usd.Format(amount2, 2), std::string{u8"$14.000 000 88 MM"});
+    EXPECT_EQ(usd.Format(amount2, 2), std::string{u8"$14.000\u202F000\u202F88 MM"});
     EXPECT_EQ(usd.Format(amount2, 2, std::nullopt, 2), std::string{u8"$14 MM"});
     EXPECT_EQ(usd.Format(amount2, 2, 0, 2), std::string{u8"$14 MM"});
     EXPECT_EQ(usd.Format(amount2, 2, 1, 2), std::string{u8"$14.0 MM"});
@@ -159,12 +159,12 @@ TEST(DisplayScale, btc)
     EXPECT_EQ(btc.Format(amount1, 2), std::string{u8"1,000,000 μBTC"});
     EXPECT_EQ(btc.Import(btc.Format(amount1, 2), 2), amount1);
 
-    EXPECT_EQ(btc.Format(amount2, 0), std::string{u8"0.000 000 01 ₿"});
-    EXPECT_EQ(btc.Format(amount2, 1), std::string{u8"0.000 01 mBTC"});
+    EXPECT_EQ(btc.Format(amount2, 0), std::string{u8"0.000\u202F000\u202F01 ₿"});
+    EXPECT_EQ(btc.Format(amount2, 1), std::string{u8"0.000\u202F01 mBTC"});
     EXPECT_EQ(btc.Format(amount2, 2), std::string{u8"0.01 μBTC"});
 
     EXPECT_EQ(
-        btc.Format(amount3, 0), std::string{u8"20,999,999.999 999 99 ₿"});
+        btc.Format(amount3, 0), std::string{u8"20,999,999.999\u202F999\u202F99 ₿"});
     EXPECT_EQ(btc.Import(btc.Format(amount3, 0), 0), amount3);
 }
 
@@ -238,9 +238,9 @@ TEST(DisplayScale, pkt)
     EXPECT_EQ(pkt.Format(amount1, 4), std::string{u8"1,073,741,824 pack"});
     EXPECT_EQ(pkt.Import(pkt.Format(amount1, 4), 4), amount1);
 
-    EXPECT_EQ(pkt.Format(amount2, 0), std::string{u8"0.000 000 000 93 PKT"});
-    EXPECT_EQ(pkt.Format(amount2, 1), std::string{u8"0.000 000 93 mPKT"});
-    EXPECT_EQ(pkt.Format(amount2, 2), std::string{u8"0.000 93 μPKT"});
+    EXPECT_EQ(pkt.Format(amount2, 0), std::string{u8"0.000\u202F000\u202F000\u202F93 PKT"});
+    EXPECT_EQ(pkt.Format(amount2, 1), std::string{u8"0.000\u202F000\u202F93 mPKT"});
+    EXPECT_EQ(pkt.Format(amount2, 2), std::string{u8"0.000\u202F93 μPKT"});
     EXPECT_EQ(pkt.Format(amount2, 3), std::string{u8"0.93 nPKT"});
     EXPECT_EQ(pkt.Format(amount2, 4), std::string{u8"1 pack"});
 }

--- a/vcpkg/vcpkg.txt
+++ b/vcpkg/vcpkg.txt
@@ -1,4 +1,5 @@
 boost-asio
+boost-beast
 boost-bind
 boost-circular-buffer
 boost-container


### PR DESCRIPTION
Update unit tests to use unicode escape sequences.
Add boost beast to the vcpkg response file.