### PR TITLE
Bug-295 - tests for gtest/gmock env

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,11 +14,11 @@ jobs:
           - compiler: gcc-10
             platform: ubuntu-20.04
             command: /usr/bin/build-opentxs-gcc
-            docker: 5
+            docker: 8
           - compiler: clang-10
             platform: ubuntu-20.04
             command: /usr/bin/build-opentxs-clang
-            docker: 6
+            docker: 8
     runs-on:  ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2.3.4

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ function(
       opentxs::libopentxs
       Boost::program_options
       opentxs-test-helpers
+      GTest::gmock
   )
 
   target_include_directories(
@@ -151,3 +152,4 @@ add_subdirectory(otx)
 add_subdirectory(paymentcode)
 add_subdirectory(rpc)
 add_subdirectory(ui)
+add_subdirectory(dummy)

--- a/tests/dummy/CMakeLists.txt
+++ b/tests/dummy/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2010-2022 The Open-Transactions developers
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+add_opentx_test(unittest-opentxs-testframework-simpleTest Test_SimpleTest.cpp)
+add_opentx_test(unittest-opentxs-testframework-fixtureTest Test_FixtureTest.cpp)
+add_opentx_test(
+  unittest-opentxs-testframework-parametrizedTest Test_ParametrizedTest.cpp
+)
+add_opentx_test(unittest-opentxs-testframework-strictMock Test_StrictMock.cpp)
+add_opentx_test(unittest-opentxs-testframework-niceMock Test_NiceMock.cpp)
+add_opentx_test(unittest-opentxs-testframework-naggyMock Test_NaggyMock.cpp)

--- a/tests/dummy/Interfaces/DummyInterface.hpp
+++ b/tests/dummy/Interfaces/DummyInterface.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+namespace opentxs::dummyinterface
+{
+class Interface {
+public:
+    virtual bool someFunction(const int &input) = 0;
+    virtual bool someConstFunction(const int& input) = 0;
+    virtual bool someFunctionWithNoExcept(const int &input) noexcept= 0;
+    virtual bool someConstFunctionWithNoExcept(const int &input) const noexcept = 0;
+
+    virtual ~Interface() = default;
+
+protected:
+    Interface() = default;
+
+private:
+    Interface(const Interface &) = delete;
+    Interface(Interface&&) = delete;
+    Interface& operator=(const Interface&) = delete;
+    Interface& operator=(const Interface&&) = delete;
+};
+}

--- a/tests/dummy/Mocks/DummyInterfaceMock.hpp
+++ b/tests/dummy/Mocks/DummyInterfaceMock.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include "dummy/Interfaces/DummyInterface.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Weffc++"
+
+namespace opentxs::dummyinterface
+{
+namespace mock
+{
+class Interface : public ::opentxs::dummyinterface::Interface
+{
+public:
+    Interface()
+        : ::opentxs::dummyinterface::Interface()
+    {
+    }
+    MOCK_METHOD(bool, someFunction, (const int& input), (override));
+    MOCK_METHOD(bool, someConstFunction, (const int& input), (override));
+    MOCK_METHOD(
+        bool,
+        someFunctionWithNoExcept,
+        (const int& input),
+        (noexcept, override));
+    MOCK_METHOD(
+        bool,
+        someConstFunctionWithNoExcept,
+        (const int& input),
+        (const, noexcept, override));
+};
+
+}       // namespace mock {
+}       // namespace opentxs::dummyinterface
+
+#pragma GCC diagnostic pop

--- a/tests/dummy/Test_FixtureTest.cpp
+++ b/tests/dummy/Test_FixtureTest.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+// fixture at global namespace
+class FixtureClassAtGlobalNameSpace : public ::testing::Test
+{
+private:
+    bool mBool;
+
+public:
+    FixtureClassAtGlobalNameSpace()
+        : mBool(false)
+    {
+    }
+    virtual ~FixtureClassAtGlobalNameSpace() override = default;
+
+    virtual bool getBool() const { return mBool; }
+
+    void SetUp() override { mBool = true; }
+
+    void TearDown() override { mBool = false; }
+};
+
+TEST_F(FixtureClassAtGlobalNameSpace, simpleFixture)
+{
+    EXPECT_TRUE(getBool());
+}
+
+// fixture at unnamed namespace
+namespace {
+
+class FixtureClassAtUnnamedNamespace : public ::testing::Test
+{
+private:
+    bool mBool;
+
+public:
+    FixtureClassAtUnnamedNamespace()
+        : mBool(false)
+    {
+    }
+    virtual ~FixtureClassAtUnnamedNamespace() override = default;
+
+    virtual bool getBool() const { return mBool; }
+
+    void SetUp() override { mBool = true; }
+
+    void TearDown() override { mBool = false; }
+};
+
+TEST_F(FixtureClassAtUnnamedNamespace, simpleFixture)
+{
+    EXPECT_TRUE(getBool());
+}
+}
+
+// fixture at named namespace
+namespace ottest {
+namespace DummyTest {
+
+class FixtureClassInsideNamedNamespace : public ::testing::Test
+{
+private:
+    bool mBool;
+
+public:
+    FixtureClassInsideNamedNamespace()
+        : mBool(false)
+    {
+    }
+    virtual ~FixtureClassInsideNamedNamespace() override = default;
+
+    virtual bool getBool() const { return mBool; }
+
+    void SetUp() override { mBool = true; }
+
+    void TearDown() override { mBool = false; }
+};
+
+TEST_F(FixtureClassInsideNamedNamespace, simpleFixture)
+{
+    EXPECT_TRUE(this->getBool());
+}
+}   // DummyTest
+}   // ottest

--- a/tests/dummy/Test_NaggyMock.cpp
+++ b/tests/dummy/Test_NaggyMock.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "dummy/Mocks/DummyInterfaceMock.hpp"
+
+namespace
+{
+
+TEST(NaggyMock, constructor)
+{
+    ::opentxs::dummyinterface::mock::Interface naggyMock;
+}
+
+TEST(NaggyMock, naggyMockOnFunction)
+{
+    ::opentxs::dummyinterface::mock::Interface naggyMock;
+    ON_CALL(naggyMock, someFunction(0)).WillByDefault(::testing::Return(false));
+    ON_CALL(naggyMock, someFunction(1)).WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(naggyMock, someFunction(0)).Times(1);
+    EXPECT_CALL(naggyMock, someFunction(1)).Times(1);
+
+    EXPECT_TRUE(naggyMock.someFunction(1));
+    EXPECT_FALSE(naggyMock.someFunction(0));
+
+    // uninteresting call
+    ON_CALL(naggyMock, someConstFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(naggyMock.someConstFunction(2));
+}
+
+TEST(NaggyMock, naggyMockOnConstFunction)
+{
+    ::opentxs::dummyinterface::mock::Interface naggyMock;
+    ON_CALL(naggyMock, someConstFunction(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(naggyMock, someConstFunction(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(naggyMock, someConstFunction(0)).Times(1);
+    EXPECT_CALL(naggyMock, someConstFunction(1)).Times(1);
+
+    EXPECT_TRUE(naggyMock.someConstFunction(1));
+    EXPECT_FALSE(naggyMock.someConstFunction(0));
+
+    // uninteresting call
+    ON_CALL(naggyMock, someFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(naggyMock.someFunction(2));
+}
+
+TEST(NaggyMock, naggyMockOnNoExceptFunction)
+{
+    ::opentxs::dummyinterface::mock::Interface naggyMock;
+    ON_CALL(naggyMock, someFunctionWithNoExcept(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(naggyMock, someFunctionWithNoExcept(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(naggyMock, someFunctionWithNoExcept(0)).Times(1);
+    EXPECT_CALL(naggyMock, someFunctionWithNoExcept(1)).Times(1);
+
+    EXPECT_TRUE(naggyMock.someFunctionWithNoExcept(1));
+    EXPECT_FALSE(naggyMock.someFunctionWithNoExcept(0));
+
+    // uninteresting call
+    ON_CALL(naggyMock, someFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(naggyMock.someFunction(2));
+}
+
+TEST(NaggyMock, naggyMockOnNoExceptConstFunction)
+{
+    ::opentxs::dummyinterface::mock::Interface naggyMock;
+    ON_CALL(naggyMock, someConstFunctionWithNoExcept(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(naggyMock, someConstFunctionWithNoExcept(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(naggyMock, someConstFunctionWithNoExcept(0)).Times(1);
+    EXPECT_CALL(naggyMock, someConstFunctionWithNoExcept(1)).Times(1);
+
+    EXPECT_TRUE(naggyMock.someConstFunctionWithNoExcept(1));
+    EXPECT_FALSE(naggyMock.someConstFunctionWithNoExcept(0));
+
+    // uninteresting call
+    ON_CALL(naggyMock, someFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(naggyMock.someFunction(2));
+}
+
+}      // namespace {

--- a/tests/dummy/Test_NiceMock.cpp
+++ b/tests/dummy/Test_NiceMock.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "dummy/Mocks/DummyInterfaceMock.hpp"
+
+namespace
+{
+
+TEST(NiceMock, constructor)
+{
+    ::testing::NiceMock<::opentxs::dummyinterface::mock::Interface>
+        mockInstance;
+}
+
+TEST(NiceMock, niceMockOnFunction)
+{
+    ::testing::NiceMock<::opentxs::dummyinterface::mock::Interface> niceMock;
+    ON_CALL(niceMock, someFunction(0)).WillByDefault(::testing::Return(false));
+    ON_CALL(niceMock, someFunction(1)).WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(niceMock, someFunction(0)).Times(1);
+    EXPECT_CALL(niceMock, someFunction(1)).Times(1);
+
+    EXPECT_TRUE(niceMock.someFunction(1));
+    EXPECT_FALSE(niceMock.someFunction(0));
+
+    // uninteresting call
+    ON_CALL(niceMock, someConstFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(niceMock.someConstFunction(2));
+}
+
+TEST(NiceMock, niceMockOnConstFunction)
+{
+    ::testing::NiceMock<::opentxs::dummyinterface::mock::Interface> niceMock;
+    ON_CALL(niceMock, someConstFunction(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(niceMock, someConstFunction(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(niceMock, someConstFunction(0)).Times(1);
+    EXPECT_CALL(niceMock, someConstFunction(1)).Times(1);
+
+    EXPECT_TRUE(niceMock.someConstFunction(1));
+    EXPECT_FALSE(niceMock.someConstFunction(0));
+
+    // uninteresting call
+    ON_CALL(niceMock, someFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(niceMock.someFunction(2));
+}
+
+TEST(NiceMock, niceMockOnNoExceptFunction)
+{
+    ::testing::NiceMock<::opentxs::dummyinterface::mock::Interface> niceMock;
+    ON_CALL(niceMock, someFunctionWithNoExcept(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(niceMock, someFunctionWithNoExcept(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(niceMock, someFunctionWithNoExcept(0)).Times(1);
+    EXPECT_CALL(niceMock, someFunctionWithNoExcept(1)).Times(1);
+
+    EXPECT_TRUE(niceMock.someFunctionWithNoExcept(1));
+    EXPECT_FALSE(niceMock.someFunctionWithNoExcept(0));
+
+    // uninteresting call
+    ON_CALL(niceMock, someFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(niceMock.someFunction(2));
+}
+
+TEST(NiceMock, niceMockOnNoExceptConstFunction)
+{
+    ::testing::NiceMock<::opentxs::dummyinterface::mock::Interface> niceMock;
+    ON_CALL(niceMock, someConstFunctionWithNoExcept(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(niceMock, someConstFunctionWithNoExcept(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(niceMock, someConstFunctionWithNoExcept(0)).Times(1);
+    EXPECT_CALL(niceMock, someConstFunctionWithNoExcept(1)).Times(1);
+
+    EXPECT_TRUE(niceMock.someConstFunctionWithNoExcept(1));
+    EXPECT_FALSE(niceMock.someConstFunctionWithNoExcept(0));
+
+    // uninteresting call
+    ON_CALL(niceMock, someFunction(::testing::_))
+        .WillByDefault(::testing::Return(true));
+    EXPECT_TRUE(niceMock.someFunction(2));
+}
+
+}      // namespace {

--- a/tests/dummy/Test_ParametrizedTest.cpp
+++ b/tests/dummy/Test_ParametrizedTest.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+// parametrized test at global namespace
+struct ParametrizedTestAtGlobalNamespaceStruct {
+    ::std::string mName;
+    bool mExpectedValue;
+
+    friend ::std::ostream &operator << (::std::ostream &os, const ParametrizedTestAtGlobalNamespaceStruct&obj)
+    {
+        return os
+               << "Test name: '" << obj.mName << "'";
+    }
+};
+
+class ParametrizedTestAtGlobalNamespaceClass
+    : public ::testing::TestWithParam<ParametrizedTestAtGlobalNamespaceStruct>
+{
+private:
+    bool mBool;
+
+public:
+    ParametrizedTestAtGlobalNamespaceClass()
+        : mBool(false)
+    {
+    }
+
+    bool getBool() const { return mBool; }
+
+    void SetUp() override { mBool = GetParam().mExpectedValue; }
+
+    void TearDown() override { mBool = false; }
+};
+
+ParametrizedTestAtGlobalNamespaceStruct
+    ParametrizedClassAtGlobalNamespace_TestVector[] =
+        {
+            {"YES", true},
+            {"NO", false},
+};
+
+INSTANTIATE_TEST_CASE_P(
+    ParametrizedTestAtGlobalNamespace,
+    ParametrizedTestAtGlobalNamespaceClass,
+    ::testing::ValuesIn(ParametrizedClassAtGlobalNamespace_TestVector)
+);
+
+TEST_P(ParametrizedTestAtGlobalNamespaceClass, simpleParametrizedTest)
+{
+    EXPECT_EQ(getBool(), GetParam().mExpectedValue);
+}
+
+// parametrized test at unnamed namespace
+namespace
+{
+struct ParametrizedTestAtUnnamedNamespaceStruct {
+    ::std::string mName;
+    bool mExpectedValue;
+
+    friend ::std::ostream& operator<<(
+        ::std::ostream& os,
+        const ParametrizedTestAtUnnamedNamespaceStruct& obj)
+    {
+        return os << "Test name: '" << obj.mName << "'";
+    }
+};
+
+class ParametrizedTestAtUnnamedNamespaceClass
+    : public ::testing::TestWithParam<ParametrizedTestAtUnnamedNamespaceStruct>
+{
+private:
+    bool mBool;
+
+public:
+    ParametrizedTestAtUnnamedNamespaceClass()
+        : mBool(false)
+    {
+    }
+
+    bool getBool() const { return mBool; }
+
+    void SetUp() override { mBool = GetParam().mExpectedValue; }
+
+    void TearDown() override { mBool = false; }
+};
+
+ParametrizedTestAtUnnamedNamespaceStruct
+    ParametrizedClassAtUnnamedNamespace_TestVector[] = {
+        {"YES", true},
+        {"NO", false},
+};
+
+INSTANTIATE_TEST_CASE_P(
+    ParametrizedTestAtUnnamedNamespace,
+    ParametrizedTestAtUnnamedNamespaceClass,
+    ::testing::ValuesIn(ParametrizedClassAtUnnamedNamespace_TestVector));
+
+TEST_P(ParametrizedTestAtUnnamedNamespaceClass, simpleParametrizedTest)
+{
+    EXPECT_EQ(getBool(), GetParam().mExpectedValue);
+}
+}       // namespace
+
+// parametrized test at named namespace
+namespace ottest
+{
+namespace DummyTest
+{
+
+struct ParametrizedTestAtNamedNamespaceStruct {
+    ::std::string mName;
+    bool mExpectedValue;
+
+    friend ::std::ostream& operator<<(
+        ::std::ostream& os,
+        const ParametrizedTestAtNamedNamespaceStruct& obj)
+    {
+        return os << "Test name: '" << obj.mName << "'";
+    }
+};
+
+class ParametrizedTestAtNamedNamespaceClass
+    : public ::testing::TestWithParam<ParametrizedTestAtNamedNamespaceStruct>
+{
+private:
+    bool mBool;
+
+public:
+    ParametrizedTestAtNamedNamespaceClass()
+        : mBool(false)
+    {
+    }
+
+    bool getBool() const { return mBool; }
+
+    void SetUp() override { mBool = GetParam().mExpectedValue; }
+
+    void TearDown() override { mBool = false; }
+};
+
+ParametrizedTestAtNamedNamespaceStruct
+    ParametrizedClassAtNamedNamespace_TestVector[] = {
+        {"YES", true},
+        {"NO", false},
+};
+
+INSTANTIATE_TEST_CASE_P(
+    ParametrizedTestAtNamedNamespace,
+    ParametrizedTestAtNamedNamespaceClass,
+    ::testing::ValuesIn(ParametrizedClassAtNamedNamespace_TestVector));
+
+TEST_P(ParametrizedTestAtNamedNamespaceClass, simpleParametrizedTest)
+{
+    EXPECT_EQ(getBool(), GetParam().mExpectedValue);
+}
+
+}  // namespace  DummyTest
+}       // namespace ottest {

--- a/tests/dummy/Test_SimpleTest.cpp
+++ b/tests/dummy/Test_SimpleTest.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+// test at global namespace
+TEST(SimpleTestAtGlobalNamespace, simpleTest)
+{
+    ASSERT_TRUE(true);
+}
+
+// test at unnamed namespace
+namespace {
+TEST(SimpleTestAtUnNamedNamespace, simpletest)
+{
+    ASSERT_TRUE(true);
+}
+
+// test at named namespace
+namespace DummyTest {
+TEST(SimpleTestAtNamedNamespace, simpleTest)
+{
+    ASSERT_TRUE(true);
+}
+}       // namespace DummyTest {
+
+}

--- a/tests/dummy/Test_StrictMock.cpp
+++ b/tests/dummy/Test_StrictMock.cpp
@@ -1,0 +1,86 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "dummy/Mocks/DummyInterfaceMock.hpp"
+
+namespace
+{
+
+TEST(StrictMock, constructor)
+{
+    ::testing::StrictMock<::opentxs::dummyinterface::mock::Interface>
+        strictMock;
+}
+
+TEST(StrictMock, strictMockOnFunction)
+{
+    ::testing::StrictMock<::opentxs::dummyinterface::mock::Interface>
+        strictMock;
+    ON_CALL(strictMock, someFunction(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(strictMock, someFunction(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(strictMock, someFunction(0)).Times(1);
+    EXPECT_CALL(strictMock, someFunction(1)).Times(1);
+
+    EXPECT_TRUE(strictMock.someFunction(1));
+    EXPECT_FALSE(strictMock.someFunction(0));
+}
+
+TEST(StrictMock, strictMockOnConstFunction)
+{
+    ::testing::StrictMock<::opentxs::dummyinterface::mock::Interface>
+        strictMock;
+    ON_CALL(strictMock, someConstFunction(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(strictMock, someConstFunction(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(strictMock, someConstFunction(0)).Times(1);
+    EXPECT_CALL(strictMock, someConstFunction(1)).Times(1);
+
+    EXPECT_TRUE(strictMock.someConstFunction(1));
+    EXPECT_FALSE(strictMock.someConstFunction(0));
+}
+
+TEST(StrictMock, strictMockOnNoExceptFunction)
+{
+    ::testing::StrictMock<::opentxs::dummyinterface::mock::Interface>
+        strictMock;
+    ON_CALL(strictMock, someFunctionWithNoExcept(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(strictMock, someFunctionWithNoExcept(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(strictMock, someFunctionWithNoExcept(0)).Times(1);
+    EXPECT_CALL(strictMock, someFunctionWithNoExcept(1)).Times(1);
+
+    EXPECT_TRUE(strictMock.someFunctionWithNoExcept(1));
+    EXPECT_FALSE(strictMock.someFunctionWithNoExcept(0));
+}
+
+TEST(StrictMock, strictMockOnNoExceptConstFunction)
+{
+    ::testing::StrictMock<::opentxs::dummyinterface::mock::Interface>
+        strictMock;
+    ON_CALL(strictMock, someConstFunctionWithNoExcept(0))
+        .WillByDefault(::testing::Return(false));
+    ON_CALL(strictMock, someConstFunctionWithNoExcept(1))
+        .WillByDefault(::testing::Return(true));
+
+    EXPECT_CALL(strictMock, someConstFunctionWithNoExcept(0)).Times(1);
+    EXPECT_CALL(strictMock, someConstFunctionWithNoExcept(1)).Times(1);
+
+    EXPECT_TRUE(strictMock.someConstFunctionWithNoExcept(1));
+    EXPECT_FALSE(strictMock.someConstFunctionWithNoExcept(0));
+}
+
+}     // namespace {
+
+
+

--- a/vcpkg/vcpkg-nonwindows.txt
+++ b/vcpkg/vcpkg-nonwindows.txt
@@ -20,6 +20,7 @@ boost-type-index
 fontconfig
 gettext
 gtest
+gmock
 libsodium
 lmdb
 openssl


### PR DESCRIPTION
These are tests, that checks does gtest/gmock basic features works. When we will use a new kind of gmock/gtest feature, we should add a test that verifies if it works at all enviroments.