### PR TITLE
ensure network::blockchain::OTDHT connects to network::otdht::Peer

### DIFF
--- a/src/api/session/Endpoints.cpp
+++ b/src/api/session/Endpoints.cpp
@@ -114,7 +114,10 @@ Endpoints::Endpoints(const int instance) noexcept
 
         return out;
     }())
-    , otdht_node_(build_inproc_path("internal/otdht/node", version_1_))
+    , otdht_node_router_(
+          build_inproc_path("internal/otdht/node/router", version_1_))
+    , otdht_node_publish_(
+          build_inproc_path("internal/otdht/node/publish", version_1_))
     , otdht_wallet_(build_inproc_path("internal/otdht/wallet", version_1_))
     , pair_event_(build_inproc_path("pairevent", version_1_))
     , peer_reply_update_(build_inproc_path("peerreplyupdate", version_1_))
@@ -330,9 +333,14 @@ auto Endpoints::OTDHTBlockchain(
     return otdht_blockchain_.at(chain);
 }
 
-auto Endpoints::OTDHTNode() const noexcept -> std::string_view
+auto Endpoints::OTDHTNodePublish() const noexcept -> std::string_view
 {
-    return otdht_node_;
+    return otdht_node_publish_;
+}
+
+auto Endpoints::OTDHTNodeRouter() const noexcept -> std::string_view
+{
+    return otdht_node_router_;
 }
 
 auto Endpoints::OTDHTWallet() const noexcept -> std::string_view

--- a/src/api/session/Endpoints.hpp
+++ b/src/api/session/Endpoints.hpp
@@ -83,7 +83,8 @@ public:
     auto NymDownload() const noexcept -> std::string_view final;
     auto OTDHTBlockchain(opentxs::blockchain::Type chain) const noexcept
         -> std::string_view final;
-    auto OTDHTNode() const noexcept -> std::string_view final;
+    auto OTDHTNodePublish() const noexcept -> std::string_view final;
+    auto OTDHTNodeRouter() const noexcept -> std::string_view final;
     auto OTDHTWallet() const noexcept -> std::string_view final;
     auto PairEvent() const noexcept -> std::string_view final;
     auto PeerReplyUpdate() const noexcept -> std::string_view final;
@@ -150,7 +151,8 @@ private:
     const CString nym_created_;
     const CString nym_download_;
     const BlockchainMap otdht_blockchain_;
-    const CString otdht_node_;
+    const CString otdht_node_router_;
+    const CString otdht_node_publish_;
     const CString otdht_wallet_;
     const CString pair_event_;
     const CString peer_reply_update_;

--- a/src/internal/api/session/Endpoints.hpp
+++ b/src/internal/api/session/Endpoints.hpp
@@ -26,7 +26,8 @@ public:
     auto Internal() const noexcept -> const Endpoints& final { return *this; }
     virtual auto OTDHTBlockchain(opentxs::blockchain::Type chain) const noexcept
         -> std::string_view = 0;
-    virtual auto OTDHTNode() const noexcept -> std::string_view = 0;
+    virtual auto OTDHTNodePublish() const noexcept -> std::string_view = 0;
+    virtual auto OTDHTNodeRouter() const noexcept -> std::string_view = 0;
     virtual auto OTDHTWallet() const noexcept -> std::string_view = 0;
     virtual auto ProcessPushNotification() const noexcept
         -> std::string_view = 0;

--- a/src/internal/network/blockchain/Types.hpp
+++ b/src/internal/network/blockchain/Types.hpp
@@ -57,6 +57,7 @@ enum class DHTJob : OTZMQWorkType {
     response = value(WorkType::P2PResponse),
     push_tx = value(WorkType::P2PPushTransaction),
     job_processed = OT_ZMQ_INTERNAL_SIGNAL + 0,
+    peer_list = OT_ZMQ_OTDHT_PEER_LIST,
     registration = OT_ZMQ_REGISTER_SIGNAL,
     init = OT_ZMQ_INIT_SIGNAL,
     cfilter = OT_ZMQ_NEW_FILTER_SIGNAL,

--- a/src/internal/network/otdht/Peer.hpp
+++ b/src/internal/network/otdht/Peer.hpp
@@ -10,6 +10,8 @@
 #include <string_view>
 
 #include "internal/network/otdht/Node.hpp"
+#include "opentxs/util/Allocator.hpp"
+#include "opentxs/util/Container.hpp"
 
 // NOLINTBEGIN(modernize-concat-nested-namespaces)
 namespace opentxs  // NOLINT
@@ -31,9 +33,14 @@ class Peer
 public:
     class Actor;
 
+    static auto NextID(alloc::Default alloc) noexcept -> CString;
+
+    auto Init() noexcept -> void;
+
     Peer(
         std::shared_ptr<const api::Session> api,
         boost::shared_ptr<Node::Shared> shared,
+        std::string_view routingID,
         std::string_view toRemote,
         std::string_view fromNode) noexcept;
     Peer() = delete;
@@ -43,5 +50,8 @@ public:
     auto operator=(Peer&&) -> Peer& = delete;
 
     ~Peer();
+
+private:
+    boost::shared_ptr<Actor> actor_;
 };
 }  // namespace opentxs::network::otdht

--- a/src/internal/network/otdht/Types.hpp
+++ b/src/internal/network/otdht/Types.hpp
@@ -40,6 +40,7 @@ enum class NodeJob : OTZMQWorkType {
     chain_state = value(WorkType::BlockchainStateChange),
     new_cfilter = value(WorkType::BlockchainNewFilter),
     new_peer = value(WorkType::SyncServerUpdated),
+    registration = OT_ZMQ_REGISTER_SIGNAL,
     init = OT_ZMQ_INIT_SIGNAL,
     statemachine = OT_ZMQ_STATE_MACHINE_SIGNAL,
 };

--- a/src/network/blockchain/otdht/OTDHT.cpp
+++ b/src/network/blockchain/otdht/OTDHT.cpp
@@ -41,6 +41,7 @@ auto print(DHTJob job) noexcept -> std::string_view
             {Job::response, "response"sv},
             {Job::push_tx, "push_tx"sv},
             {Job::job_processed, "job_processed"sv},
+            {Job::peer_list, "peer_list"sv},
             {Job::registration, "registration"sv},
             {Job::init, "init"sv},
             {Job::cfilter, "cfilter"sv},

--- a/src/network/otdht/node/Actor.hpp
+++ b/src/network/otdht/node/Actor.hpp
@@ -42,6 +42,17 @@ namespace block
 class Position;
 }  // namespace block
 }  // namespace blockchain
+
+namespace network
+{
+namespace zeromq
+{
+namespace socket
+{
+class Raw;
+}  // namespace socket
+}  // namespace zeromq
+}  // namespace network
 // }  // namespace v1
 }  // namespace opentxs
 // NOLINTEND(modernize-concat-nested-namespaces)
@@ -72,27 +83,37 @@ public:
 private:
     friend opentxs::Actor<Node::Actor, NodeJob>;
 
-    using PeerData = std::pair<CString, zeromq::socket::Raw>;
+    using PeerData = std::tuple<CString, CString, zeromq::socket::Raw>;
     using Peers = Map<CString, PeerData>;
 
     std::shared_ptr<const api::Session> api_p_;
     boost::shared_ptr<Shared> shared_p_;
     const api::Session& api_;
     Shared::Guarded& data_;
+    zeromq::socket::Raw& publish_;
+    zeromq::socket::Raw& router_;
     Peers peers_;
+
+    auto get_peers() const noexcept -> Set<CString>;
+    auto get_peers(Message& out) const noexcept -> void;
 
     auto do_shutdown() noexcept -> void;
     auto do_startup() noexcept -> bool;
     auto load_peers() noexcept -> void;
     auto load_positions() noexcept -> void;
     auto pipeline(const Work work, Message&& msg) noexcept -> void;
+    auto pipeline_other(const Work work, Message&& msg) noexcept -> void;
+    auto pipeline_router(const Work work, Message&& msg) noexcept -> void;
     auto process_cfilter(
         opentxs::blockchain::Type chain,
         opentxs::blockchain::block::Position&& tip) noexcept -> void;
     auto process_chain_state(Message&& msg) noexcept -> void;
     auto process_new_cfilter(Message&& msg) noexcept -> void;
     auto process_new_peer(Message&& msg) noexcept -> void;
+    auto process_registration(Message&& msg) noexcept -> void;
     auto process_peer(std::string_view endpoint) noexcept -> void;
+    auto publish_peers() noexcept -> void;
+    auto send_to_peers(Message&& msg) noexcept -> void;
     auto work() noexcept -> bool;
 };
 }  // namespace opentxs::network::otdht

--- a/src/network/otdht/node/Node.cpp
+++ b/src/network/otdht/node/Node.cpp
@@ -40,6 +40,7 @@ auto print(NodeJob job) noexcept -> std::string_view
             {Job::chain_state, "chain_state"sv},
             {Job::new_cfilter, "new_cfilter"sv},
             {Job::new_peer, "new_peer"sv},
+            {Job::registration, "registration"sv},
             {Job::init, "init"sv},
             {Job::statemachine, "statemachine"sv},
         };

--- a/src/network/otdht/peer/Actor.cpp
+++ b/src/network/otdht/peer/Actor.cpp
@@ -10,9 +10,7 @@
 #include "network/otdht/peer/Actor.hpp"  // IWYU pragma: associated
 
 #include <algorithm>
-#include <atomic>
 #include <chrono>
-#include <cstddef>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
@@ -64,6 +62,7 @@ using namespace std::literals;
 Peer::Actor::Actor(
     std::shared_ptr<const api::Session> api,
     boost::shared_ptr<Node::Shared> shared,
+    std::string_view routingID,
     std::string_view toRemote,
     std::string_view fromNode,
     zeromq::BatchID batchID,
@@ -146,7 +145,7 @@ Peer::Actor::Actor(
 
         return socket;
     }())
-    , routing_id_(next_id(alloc))
+    , routing_id_(routingID, alloc)
     , blockchain_([&] {
         auto out = BlockchainSockets{alloc};
         auto index = 1_uz;
@@ -267,15 +266,6 @@ auto Peer::Actor::forward_to_chain(
         blockchain_.at(chain).SendDeferred(
             std::move(msg), __FILE__, __LINE__, true);
     }
-}
-
-auto Peer::Actor::next_id(allocator_type alloc) noexcept -> CString
-{
-    static auto counter = std::atomic<std::size_t>{};
-    auto out = CString{"OTDHT peer #", alloc};
-    out.append(std::to_string(++counter));
-
-    return out;
 }
 
 auto Peer::Actor::ping() noexcept -> void

--- a/src/network/otdht/peer/Actor.hpp
+++ b/src/network/otdht/peer/Actor.hpp
@@ -67,6 +67,7 @@ public:
     Actor(
         std::shared_ptr<const api::Session> api,
         boost::shared_ptr<Node::Shared> shared,
+        std::string_view routingID,
         std::string_view toRemote,
         std::string_view fromNode,
         zeromq::BatchID batchID,
@@ -103,7 +104,6 @@ private:
     Timer ping_timer_;
     Timer registration_timer_;
 
-    static auto next_id(allocator_type alloc) noexcept -> CString;
     static auto strip_header(Message&& in) noexcept -> Message;
 
     auto check_ping() noexcept -> void;

--- a/src/util/Work.cpp
+++ b/src/util/Work.cpp
@@ -101,6 +101,7 @@ auto print(OTZMQWorkType in) noexcept -> std::string_view
             {value(WorkType::OTXResponse), "WorkType::OTXResponse"sv},
             {value(WorkType::OTXPush), "WorkType::OTXPush"sv},
             {value(WorkType::OTXLegacyXML), "WorkType::OTXLegacyXML"sv},
+            {OT_ZMQ_OTDHT_PEER_LIST, "OT_ZMQ_OTDHT_PEER_LIST"sv},
             {OT_ZMQ_HEADER_ORACLE_JOB_READY,
              "OT_ZMQ_HEADER_ORACLE_JOB_READY"sv},
             {OT_ZMQ_REORG_SIGNAL, "OT_ZMQ_REORG_SIGNAL"sv},

--- a/src/util/Work.hpp
+++ b/src/util/Work.hpp
@@ -63,6 +63,7 @@ constexpr auto OT_ZMQ_BLOCKCHAIN_WALLET_PREPARE_REORG =         OTZMQWorkType{OT
 constexpr auto OT_ZMQ_NEW_BLOCK_HEADER_SIGNAL =                 OTZMQWorkType{OT_ZMQ_HIGHEST_SIGNAL - 43};
 constexpr auto OT_ZMQ_REORG_SIGNAL =                            OTZMQWorkType{OT_ZMQ_HIGHEST_SIGNAL - 44};
 constexpr auto OT_ZMQ_HEADER_ORACLE_JOB_READY =                 OTZMQWorkType{OT_ZMQ_HIGHEST_SIGNAL - 45};
+constexpr auto OT_ZMQ_OTDHT_PEER_LIST =                         OTZMQWorkType{OT_ZMQ_HIGHEST_SIGNAL - 46};
 // clang-format on
 
 template <typename Enum>


### PR DESCRIPTION
startup order between these objects is not defined so explicit registration messages and retries are necessary to avoid race conditions