### PR TITLE
switch to Open-Transactions fork of frozen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,7 +53,7 @@
 	shallow = true
 [submodule "deps/frozen"]
 	path = deps/frozen
-	url = https://github.com/serge-sans-paille/frozen
+	url = https://github.com/Open-Transactions/frozen
 	shallow = true
 [submodule "deps/vcpkg-overlay"]
 	path = deps/vcpkg-overlay

--- a/src/blockchain/bitcoin/p2p/Bitcoin.cpp
+++ b/src/blockchain/bitcoin/p2p/Bitcoin.cpp
@@ -53,7 +53,7 @@ static constexpr auto bip155_to_opentxs_ = [] {
     });
 }();
 static constexpr auto opentxs_to_bip155_ =
-    invert_frozen_map(bip155_to_opentxs_);
+    frozen::invert_unordered_map(bip155_to_opentxs_);
 
 const CommandMap command_map_{
     {Command::addr, "addr"},

--- a/src/util/Container.hpp
+++ b/src/util/Container.hpp
@@ -5,9 +5,6 @@
 
 #pragma once
 
-#include <frozen/bits/algorithms.h>
-#include <frozen/bits/basic_types.h>
-#include <frozen/unordered_map.h>
 #include <robin_hood.h>
 
 #include "opentxs/util/Container.hpp"
@@ -98,28 +95,5 @@ auto reverse_map(const robin_hood::unordered_flat_map<Key, Value>& map) noexcept
         Value,
         robin_hood::unordered_flat_map<Value, Key>,
         robin_hood::unordered_flat_map<Key, Value>>(map);
-}
-
-template <
-    typename Key,
-    typename Value,
-    std::size_t N,
-    typename Hash = frozen::anna<Value>,
-    typename KeyEqual = std::equal_to<Value>>
-constexpr auto invert_frozen_map(
-    const frozen::unordered_map<Key, Value, N>& in) noexcept
-{
-    return frozen::make_unordered_map<Value, Key, N, Hash, KeyEqual>([&in] {
-        auto items = std::array<std::pair<Value, Key>, N>{};
-        auto o = items.begin();
-        auto i = in.cbegin();
-
-        for (auto end = in.end(); i != end; ++i, ++o) {
-            o->first = i->second;
-            o->second = i->first;
-        }
-
-        return items;
-    }());
 }
 }  // namespace opentxs


### PR DESCRIPTION
Our version includes the frozen::invert_unordered_map function which per serge-sans-paille/frozen#146 is not suitable for inclusion in the upstream project