### PR TITLE
add vcpkg.json to allows automatic building of dependencies

### DIFF
--- a/.github/workflows/vcpkg.yml
+++ b/.github/workflows/vcpkg.yml
@@ -78,5 +78,5 @@ jobs:
     - name: 'Compile'
       run: |
         cd '${{ github.workspace }}'
-        cmake -S '${{ github.workspace }}' --preset '${{ matrix.preset }}' -DVCPKG_INSTALLED_DIR='${{ env.VCPKG_INSTALLED_DIR }}' -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DOT_STATIC_DEPENDENCIES='${{ matrix.static_deps }}'
+        cmake -S '${{ github.workspace }}' --preset '${{ matrix.preset }}' -DVCPKG_INSTALLED_DIR='${{ env.VCPKG_INSTALLED_DIR }}' -DVCPKG_TARGET_TRIPLET='${{ matrix.triplet }}' -DOT_STATIC_DEPENDENCIES='${{ matrix.static_deps }}' -DVCPKG_MANIFEST_MODE=OFF
         cmake --build --preset '${{ matrix.preset }}' -- -k 0

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,64 @@
+{
+    "$schema":
+        "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+    "name": "opentxs",
+    "version": "1",
+    "dependencies": [
+        {
+            "name": "boost-asio",
+            "features": [
+                "ssl"
+            ]
+        },
+        "boost-beast",
+        "boost-bind",
+        "boost-circular-buffer",
+        "boost-container",
+        "boost-core",
+        "boost-dynamic-bitset",
+        "boost-endian",
+        "boost-exception",
+        "boost-interprocess",
+        "boost-iostreams",
+        "boost-json",
+        "boost-lexical-cast",
+        "boost-multiprecision",
+        "boost-program-options",
+        "boost-stacktrace",
+        "boost-system",
+        "boost-thread",
+        "boost-type-index",
+        "gtest",
+        "libsodium",
+        "lmdb",
+        "openssl",
+        "protobuf",
+        "pthread",
+        "qtbase",
+        "qtdeclarative",
+        "qtsvg",
+        "sqlite3",
+        "tbb",
+        {
+            "name": "zeromq",
+            "features": [
+                "sodium"
+            ]
+        }
+    ],
+    "builtin-baseline": "a7b6122f6b6504d16d96117336a0562693579933",
+    "overrides": [
+        {
+            "name": "openssl",
+            "version-string": "1.1.1n"
+        }
+    ],
+    "vcpkg-configuration": {
+        "overlay-ports": [
+            "./deps/vcpkg-overlay/ports"
+        ],
+        "overlay-triplets": [
+            "./deps/vcpkg-overlay/triplets"
+        ]
+    }
+}


### PR DESCRIPTION
For best results use the deps/vcpkg submodule as VCPKG_ROOT, however you must first navigate into that directory and run "git fetch --unshallow" to ensure all history is available.