### PR TITLE
network::asio::HTTPS: add ssl cipher initialization workaround

### DIFF
--- a/src/core/Data.cpp
+++ b/src/core/Data.cpp
@@ -84,7 +84,7 @@ auto operator<=>(const Data& lhs, const Data& rhs) noexcept
 auto to_hex(const std::byte* in, std::size_t size) noexcept
     -> UnallocatedCString
 {
-    if (nullptr == in) { return {}; }
+    if ((nullptr == in) || (0_uz == size)) { return {}; }
 
     auto out = std::stringstream{};
 
@@ -101,7 +101,7 @@ auto to_hex(
     std::size_t size,
     alloc::Default alloc) noexcept -> CString
 {
-    if (nullptr == in) { return CString{alloc}; }
+    if ((nullptr == in) || (0_uz == size)) { return CString{alloc}; }
 
     auto out = std::stringstream{};  // TODO c++20 use allocator
 

--- a/src/network/blockchain/AddressPrivate.cpp
+++ b/src/network/blockchain/AddressPrivate.cpp
@@ -409,7 +409,9 @@ private:
         output.set_protocol(static_cast<std::uint8_t>(protocol));
         output.set_network(static_cast<std::uint8_t>(network));
         output.set_chain(static_cast<std::uint32_t>(chain));
-        output.set_address(bytes.data(), bytes.size());
+
+        if (valid(bytes)) { output.set_address(bytes.data(), bytes.size()); }
+
         output.set_port(port);
         output.set_time(Clock::to_time_t(lastConnected));
 
@@ -418,7 +420,8 @@ private:
         }
 
         output.set_subtype(static_cast<std::uint8_t>(subtype));
-        output.set_key(key.data(), key.size());
+
+        if (valid(key)) { output.set_key(key.data(), key.size()); }
 
         return output;
     }

--- a/src/network/blockchain/bitcoin/message/Common.cpp
+++ b/src/network/blockchain/bitcoin/message/Common.cpp
@@ -371,6 +371,7 @@ auto Bip155::ToAddress(
         try {
             auto addr = addr_.Bytes();
             auto key = std::array<char, 32_uz>{};
+            const auto keyView = ReadView{key.data(), key.size()};
             auto subtype = std::uint8_t{};
             deserialize(
                 addr, preallocated(key.size(), key.data()), key.size(), "key");
@@ -381,7 +382,7 @@ auto Bip155::ToAddress(
                 bitcoin,
                 type,
                 GetNetwork(subtype, addr.size()),
-                ReadView{key.data(), key.size()},
+                keyView,
                 addr,
                 port_.value(),
                 chain,

--- a/src/util/storage/tree/Root.cpp
+++ b/src/util/storage/tree/Root.cpp
@@ -41,9 +41,9 @@ Root::Root(
     std::atomic<Bucket>& bucket)
     : Node(crypto, factory, storage, hash, OT_PRETTY_CLASS(), current_version_)
     , current_bucket_(bucket)
-    , sequence_()
+    , sequence_(0)
     , gc_params_()
-    , tree_root_()
+    , tree_root_(NullHash{})
     , tree_lock_()
     , tree_()
 {
@@ -58,8 +58,8 @@ auto Root::blank() noexcept -> void
 {
     Node::blank();
     current_bucket_.store(Bucket::left);
-    sequence_.store(0);
-    tree_root_ = NullHash{};
+    gc_params_.last_ = Clock::now();
+    gc_params_.from_ = next(current_bucket_.load());
 }
 
 auto Root::CheckSequence(


### PR DESCRIPTION
Initializing a boost::asio::ssl::context for the first time will randomly result in a "context: library has no ciphers (SSL routines)" exception, but only for OpenSSL 3 or higher.