### PR TITLE
Improve cmake logic related to OPENTXS_BUILD_TESTS and OPENTXS_HIDDEN_SYMBOLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,18 +406,6 @@ if(OT_IWYU)
   otcommon_make_iwyu_target()
 endif()
 
-if(OPENTXS_BUILD_TESTS
-   AND NOT
-       (CMAKE_BUILD_TYPE
-        STREQUAL
-        "Debug"
-        OR CMAKE_BUILD_TYPE
-           STREQUAL
-           "RelWithDebInfo")
-)
-  message(FATAL_ERROR "opentxs unit tests require CMAKE_BUILD_TYPE=Debug")
-endif()
-
 if(OT_WITH_BLOCKCHAIN)
   if("${CMAKE_SIZEOF_VOID_P}"
      EQUAL
@@ -527,18 +515,8 @@ endif()
 # -----------------------------------------------------------------------------
 # Source Definitions
 
-if(CMAKE_BUILD_TYPE
-   STREQUAL
-   "Debug"
-)
+if(OPENTXS_BUILD_TESTS)
   set(OPENTXS_HIDDEN_SYMBOLS OFF)
-
-  if(WIN32 AND BUILD_SHARED_LIBS)
-    message(
-      FATAL_ERROR
-        "Building as a shared library in debug mode is impossible on windows due to linker limitations"
-    )
-  endif()
 else()
   set(OPENTXS_HIDDEN_SYMBOLS ON)
 endif()
@@ -550,6 +528,13 @@ if(OPENTXS_HIDDEN_SYMBOLS)
 else()
   set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+  if(WIN32 AND BUILD_SHARED_LIBS)
+    message(
+      FATAL_ERROR
+        "Building as a shared library without hidden symbols is impossible on windows due to linker limitations"
+    )
+  endif()
 endif()
 
 # Storage backends


### PR DESCRIPTION
* Until all tests are refactored to only access private symbols via fixtures in the ottest target it is impossible to compile the unit tests with OPENTXS_HIDDEN_SYMBOLS=ON

* Windows PE format limitations mean it is impossible to build a DLL with OPENTXS_HIDDEN_SYMBOLS=OFF

Previously these limitations were expressed in terms CMAKE_BUILD_TYPE but now they have been disentangled. It is valid to compile the unit tests with CMAKE_BUILD_TYPE=Release, as long as you aren't building a DLL on Windows and it's valid to build a DLL on Windows with MAKE_BUILD_TYPE=Debug as long as the unit tests are disabled.