### PR TITLE
Add support for Ethereum hash types

### DIFF
--- a/.format-exclude
+++ b/.format-exclude
@@ -5,6 +5,7 @@ deps/bech32
 deps/cs_libguarded
 deps/frozen
 deps/irrxml
+deps/keccack
 deps/lucre
 deps/opentxs-cmake
 deps/packetcrypt/packetcrypt_rs

--- a/.gitmodules
+++ b/.gitmodules
@@ -62,3 +62,7 @@
 	path = tests/ottest/data/blockchain/cashtoken
 	url = https://github.com/bitjson/cashtokens
 	shallow = true
+[submodule "keccack-tiny"]
+	path = deps/keccack
+	url = https://github.com/Open-Transactions/keccak-tiny
+	shallow = true

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -82,6 +82,30 @@ endif()
 libopentxs_add_sources($<TARGET_OBJECTS:opentxs-external-hashes>)
 
 add_library(
+  opentxs-keccak OBJECT "keccack/keccak-tiny.c" "keccack/keccak-tiny.h"
+)
+libopentxs_configure_c_target(opentxs-keccak)
+set_target_properties(
+  opentxs-keccak
+  PROPERTIES
+    C_STANDARD 11
+    C_INCLUDE_WHAT_YOU_USE ""
+    CXX_INCLUDE_WHAT_YOU_USE ""
+)
+
+if(NOT MSVC)
+  target_compile_options(
+    opentxs-keccak
+    PRIVATE
+      -Wno-declaration-after-statement
+      -Wno-extra-semi-stmt
+      -Wno-reserved-macro-identifier
+  )
+endif()
+
+libopentxs_add_sources($<TARGET_OBJECTS:opentxs-keccak>)
+
+add_library(
   opentxs-bech32 OBJECT
   "bech32/ref/c++/bech32.cpp"
   "bech32/ref/c++/bech32.h"

--- a/generated/license/CMakeLists.txt
+++ b/generated/license/CMakeLists.txt
@@ -78,6 +78,7 @@ include(otcommon-file-to-hex)
 otcommon_file_to_hex(
   "${CMAKE_CURRENT_SOURCE_DIR}/apache-2.0.txt" "APACHE_2_0_HEX"
 )
+otcommon_file_to_hex("${CMAKE_CURRENT_SOURCE_DIR}/cc0.txt" "CC0_HEX")
 otcommon_file_to_hex("${CMAKE_CURRENT_SOURCE_DIR}/lgpl-2.1.txt" "LGPL_2_1_HEX")
 otcommon_file_to_hex("${opentxs_SOURCE_DIR}/MPL-2.0" "MPL_2_0_HEX")
 otcommon_file_to_hex("${opentxs_SOURCE_DIR}/deps/argon2/LICENSE" "ARGON_HEX")
@@ -106,19 +107,28 @@ configure_file(
   "${opentxs_BINARY_DIR}/src/util/license/apache.cpp"
   @ONLY
 )
+
 configure_file(
   "base58.cpp.in"
   "${opentxs_BINARY_DIR}/src/util/license/base58.cpp"
   @ONLY
 )
+
 configure_file(
   "base64.cpp.in"
   "${opentxs_BINARY_DIR}/src/util/license/base64.cpp"
   @ONLY
 )
+
 configure_file(
   "bech32.cpp.in"
   "${opentxs_BINARY_DIR}/src/util/license/bech32.cpp"
+  @ONLY
+)
+
+configure_file(
+  "cc0.cpp.in"
+  "${opentxs_BINARY_DIR}/src/util/license/cc0.cpp"
   @ONLY
 )
 
@@ -207,6 +217,7 @@ configure_file(
   "${opentxs_BINARY_DIR}/src/util/license/mpl.cpp"
   @ONLY
 )
+
 configure_file(
   "opentxs.cpp.in"
   "${opentxs_BINARY_DIR}/src/util/license/opentxs.cpp"

--- a/generated/license/cc0.cpp.in
+++ b/generated/license/cc0.cpp.in
@@ -1,0 +1,18 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "util/license/License.hpp"  // IWYU pragma: associated
+
+namespace opentxs
+{
+auto text_cc0() noexcept -> std::string_view
+{
+    static constexpr unsigned char bytes[] = {
+@CC0_HEX@
+    };
+
+    return {reinterpret_cast<const char*>(bytes), sizeof(bytes)};
+}
+}  // namespace opentxs

--- a/generated/license/cc0.txt
+++ b/generated/license/cc0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/generated/protobuf/Enums.proto
+++ b/generated/protobuf/Enums.proto
@@ -103,6 +103,8 @@ enum HashType {
     HASHTYPE_BITCOIN = 11;
     HASHTYPE_SIPHASH24 = 12;
     HASHTYPE_X11 = 13;
+    HASHTYPE_KECCAK256 = 14;
+    HASHTYPE_ETHEREUM = 15;
 }
 
 enum NymMode {

--- a/include/opentxs/crypto/HashType.hpp
+++ b/include/opentxs/crypto/HashType.hpp
@@ -27,11 +27,12 @@ enum class HashType : std::uint8_t {
     Bitcoin = 11,
     SipHash24 = 12,
     X11 = 13,
+    Keccak256 = 14,
+    Ethereum = 15,
 };
 
 constexpr auto value(const HashType in) noexcept
 {
     return static_cast<std::uint8_t>(in);
 }
-
 }  // namespace opentxs::crypto

--- a/src/api/crypto/Hash.hpp
+++ b/src/api/crypto/Hash.hpp
@@ -102,6 +102,10 @@ private:
 
     auto bitcoin_hash_160(const ReadView data, Writer&& destination)
         const noexcept -> bool;
+    auto ethereum_hash_160(const ReadView data, Writer&& destination)
+        const noexcept -> bool;
+    auto keccack_256(const ReadView data, Writer&& destination) const noexcept
+        -> bool;
     auto sha_256_double(const ReadView data, Writer&& destination)
         const noexcept -> bool;
     auto sha_256_double_checksum(const ReadView data, Writer&& destination)

--- a/src/crypto/asymmetric/base/Imp.cpp
+++ b/src/crypto/asymmetric/base/Imp.cpp
@@ -603,6 +603,8 @@ auto Key::hashtype_map() noexcept -> const HashTypeMap&
         {Bitcoin, HASHTYPE_BITCOIN},
         {SipHash24, HASHTYPE_SIPHASH24},
         {X11, HASHTYPE_X11},
+        {Keccak256, HASHTYPE_KECCAK256},
+        {Ethereum, HASHTYPE_ETHEREUM},
     };
 
     return map;

--- a/src/crypto/asymmetric/base/Imp.hpp
+++ b/src/crypto/asymmetric/base/Imp.hpp
@@ -244,7 +244,7 @@ protected:
         allocator_type alloc) noexcept;
 
 private:
-    static constexpr auto HashTypeMapSize = std::size_t{14};
+    static constexpr auto HashTypeMapSize = std::size_t{16};
     using HashTypeMap = frozen::
         unordered_map<crypto::HashType, proto::HashType, HashTypeMapSize>;
     using HashTypeReverseMap = frozen::

--- a/src/crypto/library/HashingProvider.cpp
+++ b/src/crypto/library/HashingProvider.cpp
@@ -28,6 +28,10 @@ auto HashingProvider::StringToHashType(const String& inputString) noexcept
         return crypto::HashType::Blake2b256;
     } else if (inputString.Compare("BLAKE2B512")) {
         return crypto::HashType::Blake2b512;
+    } else if (inputString.Compare("X11")) {
+        return crypto::HashType::X11;
+    } else if (inputString.Compare("KECCAK256")) {
+        return crypto::HashType::Keccak256;
     }
 
     return crypto::HashType::Error;
@@ -61,6 +65,9 @@ auto HashingProvider::HashTypeToString(const crypto::HashType hashType) noexcept
         case X11: {
             hashTypeString = String::Factory("X11");
         } break;
+        case Keccak256: {
+            hashTypeString = String::Factory("KECCAK256");
+        } break;
         case Error:
         case Ripemd160:
         case Sha1:
@@ -68,6 +75,7 @@ auto HashingProvider::HashTypeToString(const crypto::HashType hashType) noexcept
         case Sha256DC:
         case Bitcoin:
         case SipHash24:
+        case Ethereum:
         default: {
             hashTypeString = String::Factory("ERROR");
         }
@@ -117,6 +125,12 @@ auto HashingProvider::HashSize(const crypto::HashType hashType) noexcept
         }
         case X11: {
             return 32;
+        }
+        case Keccak256: {
+            return 32;
+        }
+        case Ethereum: {
+            return 20;
         }
         case Error:
         case None:

--- a/src/crypto/library/openssl/OpenSSL.cpp
+++ b/src/crypto/library/openssl/OpenSSL.cpp
@@ -289,6 +289,8 @@ auto OpenSSL::HashTypeToOpenSSLTypeStage2(
         case Sha256DC:
         case SipHash24:
         case X11:
+        case Keccak256:
+        case Ethereum:
         default: {
             return nullptr;
         }

--- a/src/serialization/protobuf/verify/signature/Signature_3.cpp
+++ b/src/serialization/protobuf/verify/signature/Signature_3.cpp
@@ -61,7 +61,7 @@ auto CheckProto_3(
 
     CHECK_EXISTS(hashtype);
 
-    if (input.hashtype() > proto::HASHTYPE_X11) {
+    if (input.hashtype() > proto::HASHTYPE_ETHEREUM) {
         FAIL_2("invalid hash type", input.hashtype());
     }
 

--- a/src/util/license/CMakeLists.txt
+++ b/src/util/license/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
     "${CMAKE_CURRENT_BINARY_DIR}/base58.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/base64.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/bech32.cpp"
+    "${CMAKE_CURRENT_BINARY_DIR}/cc0.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/chai.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/dash.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/frozen.cpp"
@@ -30,4 +31,5 @@ target_sources(
     "${CMAKE_CURRENT_BINARY_DIR}/tbb.cpp"
     "License.cpp"
     "License.hpp"
+    "keccak-tiny.cpp"
 )

--- a/src/util/license/License.hpp
+++ b/src/util/license/License.hpp
@@ -20,6 +20,7 @@ auto license_chaiscript(LicenseMap& out) noexcept -> void;
 auto license_dash(LicenseMap& out) noexcept -> void;
 auto license_frozen(LicenseMap& out) noexcept -> void;
 auto license_irrxml(LicenseMap& out) noexcept -> void;
+auto license_keccak_tiny(LicenseMap& out) noexcept -> void;
 auto license_libguarded(LicenseMap& out) noexcept -> void;
 auto license_lucre(LicenseMap& out) noexcept -> void;
 auto license_matterfi(LicenseMap& out) noexcept -> void;
@@ -31,6 +32,7 @@ auto license_secp256k1(LicenseMap& out) noexcept -> void;
 auto license_simpleini(LicenseMap& out) noexcept -> void;
 auto license_tbb(LicenseMap& out) noexcept -> void;
 auto text_apache_v2() noexcept -> std::string_view;
+auto text_cc0() noexcept -> std::string_view;
 auto text_lgpl_v2_1() noexcept -> std::string_view;
 auto text_mpl_v2() noexcept -> std::string_view;
 }  // namespace opentxs

--- a/src/util/license/keccak-tiny.cpp
+++ b/src/util/license/keccak-tiny.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2010-2022 The Open-Transactions developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "util/license/License.hpp"  // IWYU pragma: associated
+
+#include "opentxs/util/Container.hpp"
+
+namespace opentxs
+{
+auto license_keccak_tiny(LicenseMap& out) noexcept -> void
+{
+    using namespace std::literals;
+    static constexpr auto header =
+        "A single-file implementation of SHA-3 and SHAKE.\n\nImplementor: David Leon Gil\nLicense: CC0, attribution kindly requested. Blame taken too, but not liability.\n"sv;
+
+    out.emplace(
+        "libkeccak-tiny",
+        UnallocatedCString{header} + UnallocatedCString{text_cc0()});
+}
+}  // namespace opentxs

--- a/tests/ottest/data/crypto/Hashes.cpp
+++ b/tests/ottest/data/crypto/Hashes.cpp
@@ -5,6 +5,8 @@
 
 #include "ottest/data/crypto/Hashes.hpp"  // IWYU pragma: associated
 
+#include <initializer_list>
+
 #include "opentxs/util/Container.hpp"
 
 namespace ottest
@@ -141,6 +143,78 @@ auto Argon2id() noexcept -> std::span<const ArgonVector>
             "diffsaltdiffsalt"sv,
             "c22e7f0935f83ed7a0163bfd4f09a2014b94c9aa19dc681e7e781170dcfd1659"sv,
         },
+    };
+
+    return data;
+}
+
+auto EthHashes() noexcept -> std::span<const EthereumVector>
+{
+    // Generated using https://www.rfctools.com/ethereum-address-test-tool/
+    static constexpr auto data = std::initializer_list<EthereumVector>{
+        {
+            "1247328147577841EDAB7CE43A31D49C722152C28229D84C28722594D16B8A29"sv,
+            "1be26e236e77da12843aa641c806be6cde6977dec790c86bfe84ec3fa4535826f6288d62fd77fdd61061052f82959211059547bfdb44cab932f682aff4a89918"sv,
+            "997d2b9fb17bed5422bcd616e14a6a8bf2f28a1a8fda205232084c74faa19531"sv,
+            "e14a6a8bf2f28a1a8fda205232084c74faa19531"sv,
+            "7b8f26e84c37225b697d9719545e03e7546ecf69cce647b9c1d0ea68810d8721"sv,
+            "e14A6a8Bf2f28a1A8FdA205232084c74faa19531"sv,
+        },
+        {
+            "E9613EB5DE38D4B8763813913C8493E20D9BB725744A89132B777897AD2E6110"sv,
+            "ec55462bb46842e5c9aa3bc49f15bcb714a128d8dbffffc4a60106e385bc3bc466ccaa3b0a767afe2c66a66221449cc7e7482944e13a17a755a4dde0801e03fc"sv,
+            "697c4ee0537b3f74290fb32faa9c7e21d31712cc8a23314ce550052c96b62eea"sv,
+            "aa9c7e21d31712cc8a23314ce550052c96b62eea"sv,
+            "a87372e8d9b4304edcb623931884843ac28cc9c941f0a5c357d18a87bd2a0d47"sv,
+            "AA9c7e21D31712cC8A23314ce550052C96B62EEA"sv,
+        },
+        {
+            "622CCEC9DC0E38CCEC65099CEE973BD0DB209263C39DCEA31410B0E9952D0A1E"sv,
+            "3493c1baea56ea6979ae0ba3eebff66e72433016872b49895dcb6b3ca192a2019315c8f42d8f6108b2166bc1cac5cc7a02cd54d5dfe6409d1c0735b93fa86f0d"sv,
+            "da3b5b385dba4ad8a06bdf25191fd4aa32edd0a6a199079b3c32c979dbc72980"sv,
+            "191fd4aa32edd0a6a199079b3c32c979dbc72980"sv,
+            "140b32f3ab1a9f3ecc8b75e4738201f6042e1a73a25219fd243367e058cefe16"sv,
+            "191Fd4Aa32eDD0a6A199079b3c32c979dbc72980"sv,
+        },
+        {
+            "DD665AE694722A3813C42155B888DD367047EA121138542D94EDD00293CC3271"sv,
+            "d307e35ef9ef4c5efd66d9039f399994b2c909ac9cf026934d678019d7db2d9ecd1c163dfad20504d790ddad3ec7c19031169e9e4d40d89cf540d92d1320d7bc"sv,
+            "fdcc5b29a0408b069d4ccdde10330c7f31d50ef2193802d8664f7285527a260f"sv,
+            "10330c7f31d50ef2193802d8664f7285527a260f"sv,
+            "bb1b734623b9e391cc5f4759a0d84a3c04f671616721cf356c7d0fce75ed18da"sv,
+            "10330c7f31D50eF2193802d8664F7285527a260f"sv,
+        },
+        {
+            "BC149CAA45A9E84A2E29AD9010092C3082620ACA378282B8E741B68D5CCEC017"sv,
+            "714fe34e719331594d980385a62b8b509d3112e1090184c9b02d5158b832284335c53001b70bc51abfb17e467316b196cd5f261ed5595c8afb486a442f8ffa74"sv,
+            "b96d34881ada92c2edd09df2b4bb730813fe4a3be56c6665f836a73cefba6eba"sv,
+            "b4bb730813fe4a3be56c6665f836a73cefba6eba"sv,
+            "74d9c07348b3b8f8a6150ce8e2a37655c20e4a6ebff73da8e375f28febb5afb1"sv,
+            "b4BB730813Fe4A3BE56c6665F836a73cEfbA6EbA"sv,
+        },
+    };
+
+    return data;
+}
+
+auto Keccak256() noexcept -> std::span<const KeccakVector>
+{
+    // https://github.com/mighty-gerbils/gerbil-crypto/blob/master/t/keccak-test.ss
+    static constexpr auto data = std::initializer_list<KeccakVector>{
+        {""sv,
+         "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"sv},
+        {"arsttsra"sv,
+         "b1f354b28ff28452d6b9d61f41061bbe82beb1fc98f33364a8058d1a5d164d05"sv},
+        {"arst"sv,
+         "c3305bc9de1244e48050962ced50b75934c37006e99e8b7a62213e945c3dfcd7"sv},
+        {"abc"sv,
+         "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"sv},
+        {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"sv,
+         "45d3b367a6904e6e8d502ee04999a7c27647f91fa845d456525fd352ae3d7371"sv},
+        {"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"sv,
+         "f519747ed599024f3882238e5ab43960132572b7345fbeb9a90769dafd21ad67"sv},
+        {"this is a test"sv,
+         "9fd09c38c2a5ae0a0bcd617872b735e37909ccc05c956460be7d3d03d881a0dc"sv},
     };
 
     return data;

--- a/tests/ottest/data/crypto/Hashes.hpp
+++ b/tests/ottest/data/crypto/Hashes.hpp
@@ -24,11 +24,25 @@ struct OPENTXS_EXPORT ArgonVector {
     std::string_view expected_{};
 };
 
+struct OPENTXS_EXPORT EthereumVector {
+    std::string_view secret_{};
+    std::string_view uncompressed_public_{};
+    std::string_view pubkey_hash_{};
+    std::string_view last_20_{};
+    std::string_view checksum_{};
+    std::string_view address_{};
+};
+
 struct OPENTXS_EXPORT HMACVector {
     std::string_view key_{};
     std::string_view data_{};
     std::string_view sha256_{};
     std::string_view sha512_{};
+};
+
+struct OPENTXS_EXPORT KeccakVector {
+    std::string_view input_{};
+    std::string_view expected_{};
 };
 
 struct OPENTXS_EXPORT MurmurVector {
@@ -69,6 +83,8 @@ struct OPENTXS_EXPORT X11Vector {
 
 OPENTXS_EXPORT auto Argon2i() noexcept -> std::span<const ArgonVector>;
 OPENTXS_EXPORT auto Argon2id() noexcept -> std::span<const ArgonVector>;
+OPENTXS_EXPORT auto EthHashes() noexcept -> std::span<const EthereumVector>;
+OPENTXS_EXPORT auto Keccak256() noexcept -> std::span<const KeccakVector>;
 OPENTXS_EXPORT auto Murmur() noexcept -> std::span<const MurmurVector>;
 OPENTXS_EXPORT auto NistBasic() noexcept -> std::span<const NistHashVector>;
 OPENTXS_EXPORT auto NistMillion() noexcept -> const NistHashVector&;


### PR DESCRIPTION
Keccak-256 was added to OpenSSL in 2021, however it won't appear in an official release until version 3.2.0.

Until then we will use another library but someday we will just be able to use OpenSSL.